### PR TITLE
🔧 fix(ci): suppress MT4162 in csproj for .NET 10 MAUI SDK bindings

### DIFF
--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -30,6 +30,10 @@
 
 		<!-- Xcode 26.3 installiert, SDK erwartet 26.2 – Prüfung deaktiviert bis SDK-Update -->
 		<ValidateXcodeVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">false</ValidateXcodeVersion>
+
+		<!-- Suppress MT4162: .NET 10 MAUI SDK bindings reference MacCatalyst 26.0 APIs
+		     which are not yet in the Xcode version used by CI runners -->
+		<MtouchExtraArgs Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">$(MtouchExtraArgs) --nowarn:MT4162</MtouchExtraArgs>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
.NET 10 MAUI generates bindings referencing MacCatalyst 26.0 APIs but CI runners only have Xcode 16 (MacCatalyst 18.5). MT4162 suppressed via MtouchExtraArgs for ios/maccatalyst targets.

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [ ] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [ ] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [ ] Kein hardcoded Farben (AppThemeBinding verwendet)
- [ ] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
