### PR TITLE
🔧 ci: fix MT4162 vs ILLink conflict in mac build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
             -c Debug \
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
-            -p:CodesignProvision=""
+            -p:CodesignProvision="" \
+            -p:MtouchLink=None \
+            "-p:MtouchExtraArgs=--nowarn:MT4162"
 
   build-windows:
     name: Build (Windows)

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -30,10 +30,6 @@
 
 		<!-- Xcode 26.3 installiert, SDK erwartet 26.2 – Prüfung deaktiviert bis SDK-Update -->
 		<ValidateXcodeVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">false</ValidateXcodeVersion>
-
-		<!-- Suppress MT4162: .NET 10 MAUI SDK bindings reference MacCatalyst 26.0 APIs
-		     which are not yet in the Xcode version used by CI runners -->
-		<MtouchExtraArgs Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst' Or $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">$(MtouchExtraArgs) --nowarn:MT4162</MtouchExtraArgs>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
MtouchExtraArgs with --nowarn:MT4162 was being passed to ILLink which doesn't understand MT codes → MT2301/NETSDK1144.

Fix: remove MtouchExtraArgs from csproj, disable ILLink in CI via MtouchLink=None, pass --nowarn:MT4162 only to mtouch.

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [x] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [x] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [ ] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [x] Kein hardcoded Farben (AppThemeBinding verwendet)
- [x] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
