### PR TITLE
🔧 ci: disable ILLink/MtouchLink entirely to fix build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,9 +54,7 @@ jobs:
             -c Debug \
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
-            -p:CodesignProvision="" \
-            -p:MtouchLink=None \
-            "-p:MtouchExtraArgs=--nowarn:MT4162"
+            -p:CodesignProvision=""
 
   build-windows:
     name: Build (Windows)

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -30,6 +30,14 @@
 
 		<!-- Xcode 26.3 installiert, SDK erwartet 26.2 – Prüfung deaktiviert bis SDK-Update -->
 		<ValidateXcodeVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">false</ValidateXcodeVersion>
+
+		<!-- Suppress MT4162 warning from mtouch (but not via ILLink) -->
+		<!-- Note: passing -nowarn:MT4162 directly to MtouchExtraArgs might be picked up by ILLink and fail -->
+		<!-- We rely on MtouchLink=None to disable ILLink instead -->
+		
+		<!-- Disable ILLink completely to avoid MT2301/NETSDK1144 crash -->
+		<PublishTrimmed>false</PublishTrimmed>
+		<MtouchLink>None</MtouchLink>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
Removed MtouchExtraArgs (caused MT2301/Invalid WarnAsError) Added PublishTrimmed=false and MtouchLink=None to csproj Cleaned up ci.yml to use csproj settings

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [ ] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [ ] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [ ] Kein hardcoded Farben (AppThemeBinding verwendet)
- [ ] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
