### PR TITLE
🔧 ci: remove PublishTrimmed=false which is invalid for MacCatalyst

### DIFF
--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -36,7 +36,6 @@
 		<!-- We rely on MtouchLink=None to disable ILLink instead -->
 		
 		<!-- Disable ILLink completely to avoid MT2301/NETSDK1144 crash -->
-		<PublishTrimmed>false</PublishTrimmed>
 		<MtouchLink>None</MtouchLink>
 	</PropertyGroup>
 


### PR DESCRIPTION
The error message stated MacCatalyst must use PublishTrimmed=true. Retaining MtouchLink=None to disable the actual linking behavior.

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [ ] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [ ] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [ ] Kein hardcoded Farben (AppThemeBinding verwendet)
- [ ] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
