### PR TITLE
🔧 ci: force disable ILLink with EnableILLink=false and MtouchLink=None

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,7 +54,9 @@ jobs:
             -c Debug \
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
-            -p:CodesignProvision=""
+            -p:CodesignProvision="" \
+            -p:MtouchLink=None \
+            -p:EnableILLink=false
 
   build-windows:
     name: Build (Windows)

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -37,6 +37,9 @@
 		
 		<!-- Disable ILLink completely to avoid MT2301/NETSDK1144 crash -->
 		<MtouchLink>None</MtouchLink>
+		<UserDialogs>false</UserDialogs>
+		<!-- Ensure UseInterpreter is true if link is None, though usually implied for Debug -->
+		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">true</UseInterpreter>
 	</PropertyGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
NETSDK1144 persists despite MtouchLink=None, indicating ILLink task still runs. Fix: Add EnableILLink=false property to build command and UseInterpreter=true in csproj.

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [ ] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [ ] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [ ] Kein hardcoded Farben (AppThemeBinding verwendet)
- [ ] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
