### PR TITLE
🔧 ci: use MtouchLink=SdkOnly to fix MT0180 SDK mismatch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
             -p:CodesignProvision="" \
-            -p:MtouchLink=None \
+            -p:MtouchLink=SdkOnly \
             -p:EnableILLink=false
 
   build-windows:

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -36,7 +36,7 @@
 		<!-- We rely on MtouchLink=None to disable ILLink instead -->
 		
 		<!-- Disable ILLink completely to avoid MT2301/NETSDK1144 crash -->
-		<MtouchLink>None</MtouchLink>
+		<MtouchLink>SdkOnly</MtouchLink>
 		<UserDialogs>false</UserDialogs>
 		<!-- Ensure UseInterpreter is true if link is None, though usually implied for Debug -->
 		<UseInterpreter Condition="'$(Configuration)' == 'Debug'">true</UseInterpreter>


### PR DESCRIPTION
The .NET 10 MAUI bindings require 'Link Framework SDKs Only' (MtouchLink=SdkOnly) when building with older SDKs on CI to avoid MT0180/MT2301 errors. Verified local build works with this change.

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [ ] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [ ] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [ ] Kein hardcoded Farben (AppThemeBinding verwendet)
- [ ] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
