### PR TITLE
✨ feat(ui): add edit/delete for categories and fix detail layout

### DIFF
--- a/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
@@ -42,12 +42,18 @@ public partial class CategoriesViewModel : ObservableObject
     [RelayCommand]
     private async Task DeleteKategorie(Category kategorie)
     {
+        var confirm = await Shell.Current.DisplayAlert(
+            "Kategorie löschen",
+            $"\"{kategorie.Name}\" wirklich löschen?",
+            "Löschen", "Abbrechen");
+        if (!confirm) return;
+
         await _dataService.DeleteCategoryAsync(kategorie.Id);
         Kategorien.Remove(kategorie);
     }
 
     [RelayCommand]
-    private async Task GoToDetail(Category? kategorie)
+    private async Task GoToDetail(Category? kategorie = null)
     {
         var parameter = new Dictionary<string, object>();
         if (kategorie != null)

--- a/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
@@ -23,6 +23,8 @@ public partial class CategoryDetailViewModel : ObservableObject
     [ObservableProperty]
     private TransactionType typ = TransactionType.Ausgabe;
 
+    public string PageTitle => _existingCategory == null ? "Neue Kategorie" : "Kategorie bearbeiten";
+
     public List<string> VerfuegbareIcons { get; } =
     [
         "🛒", "🚗", "🏠", "🎬", "💊", "💼", "📦",

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -32,6 +32,11 @@
                         </SwipeView.RightItems>
 
                         <Grid ColumnDefinitions="50, *, Auto" Padding="16,12" ColumnSpacing="12">
+                            <Grid.GestureRecognizers>
+                                <TapGestureRecognizer
+                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=GoToDetailCommand}"
+                                    CommandParameter="{Binding .}" />
+                            </Grid.GestureRecognizers>
                             <Border Grid.Column="0" BackgroundColor="{Binding Color}"
                                     StrokeShape="RoundRectangle 12"
                                     Stroke="Transparent"

--- a/Finanzuebersicht/Views/CategoryDetailPage.xaml
+++ b/Finanzuebersicht/Views/CategoryDetailPage.xaml
@@ -4,7 +4,7 @@
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              x:Class="Finanzuebersicht.Views.CategoryDetailPage"
              x:DataType="vm:CategoryDetailViewModel"
-             Title="Kategorie">
+             Title="{Binding PageTitle}">
 
     <ScrollView Padding="16">
         <VerticalStackLayout Spacing="20">
@@ -21,8 +21,7 @@
                 <Label Text="Icon" FontSize="13" TextColor="Gray" />
                 <CollectionView ItemsSource="{Binding VerfuegbareIcons}"
                                 SelectionMode="Single"
-                                SelectedItem="{Binding Icon}"
-                                HeightRequest="120">
+                                SelectedItem="{Binding Icon}">
                     <CollectionView.ItemsLayout>
                         <GridItemsLayout Orientation="Vertical" Span="7"
                                          HorizontalItemSpacing="8" VerticalItemSpacing="8" />
@@ -46,8 +45,7 @@
                 <Label Text="Farbe" FontSize="13" TextColor="Gray" />
                 <CollectionView ItemsSource="{Binding VerfuegbareFarben}"
                                 SelectionMode="Single"
-                                SelectedItem="{Binding Color}"
-                                HeightRequest="60">
+                                SelectedItem="{Binding Color}">
                     <CollectionView.ItemsLayout>
                         <GridItemsLayout Orientation="Vertical" Span="5"
                                          HorizontalItemSpacing="10" VerticalItemSpacing="10" />


### PR DESCRIPTION
- CategoriesPage: tap on item navigates to edit (GoToDetailCommand with category as parameter via TapGestureRecognizer)
- CategoriesViewModel: delete confirmation dialog before deleting
- CategoryDetailViewModel: PageTitle property ('Neue Kategorie' vs 'Kategorie bearbeiten') bound to page Title
- CategoryDetailPage: removed fixed HeightRequest from icon/color CollectionViews so they expand to show all items without scrolling

Affected: CategoriesPage.xaml, CategoriesViewModel.cs,
          CategoryDetailPage.xaml, CategoryDetailViewModel.cs

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [x] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [x] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [ ] Kein hardcoded Farben (AppThemeBinding verwendet)
- [x] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
