### PR TITLE
🔧 chore(config): add iOS signing config and entitlements for device d…

### DIFF
--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -37,6 +37,11 @@
 		<!-- Debug: Mit Apple Development Zertifikat signieren -->
 		<CodesignKey Condition="'$(Configuration)' == 'Debug' AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">Apple Development</CodesignKey>
 
+		<!-- iOS: Entitlements und Signing -->
+		<CodesignEntitlements Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">Platforms/iOS/Entitlements.plist</CodesignEntitlements>
+		<CodesignKey Condition="'$(Configuration)' == 'Debug' AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">Apple Development</CodesignKey>
+		<CodesignProvision Condition="'$(Configuration)' == 'Debug' AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'ios'">Automatic</CodesignProvision>
+
 		<!-- Suppress MT4162 warning from mtouch (but not via ILLink) -->
 		<!-- Note: passing -nowarn:MT4162 directly to MtouchExtraArgs might be picked up by ILLink and fail -->
 		<!-- We rely on MtouchLink=None to disable ILLink instead -->

--- a/Finanzuebersicht/Platforms/iOS/Entitlements.plist
+++ b/Finanzuebersicht/Platforms/iOS/Entitlements.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+    <dict>
+        <key>get-task-allow</key>
+        <true/>
+    </dict>
+</plist>


### PR DESCRIPTION
…eployment

- Add Platforms/iOS/Entitlements.plist with get-task-allow for debug builds
- Add CodesignKey, CodesignEntitlements, CodesignProvision to csproj for iOS
- Enables deployment to physical iOS devices via Apple Development certificate

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [ ] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [ ] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [ ] Kein hardcoded Farben (AppThemeBinding verwendet)
- [ ] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
