### PR TITLE
💄 style(ui): replace default .NET icon with custom € app icon

### DIFF
--- a/Finanzuebersicht/Resources/AppIcon/appicon.svg
+++ b/Finanzuebersicht/Resources/AppIcon/appicon.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg">
-    <rect x="0" y="0" width="456" height="456" fill="#512BD4" />
+    <rect x="0" y="0" width="456" height="456" fill="#007AFF" />
 </svg>

--- a/Finanzuebersicht/Resources/AppIcon/appiconfg.svg
+++ b/Finanzuebersicht/Resources/AppIcon/appiconfg.svg
@@ -1,8 +1,19 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
-<svg width="456" height="456" viewBox="0 0 456 456" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xml:space="preserve" xmlns:serif="http://www.serif.com/" style="fill-rule:evenodd;clip-rule:evenodd;stroke-linejoin:round;stroke-miterlimit:2;">
-    <path d="m 105.50037,281.60863 c -2.70293,0 -5.00091,-0.90042 -6.893127,-2.70209 -1.892214,-1.84778 -2.837901,-4.04181 -2.837901,-6.58209 0,-2.58722 0.945687,-4.80389 2.837901,-6.65167 1.892217,-1.84778 4.190197,-2.77167 6.893127,-2.77167 2.74819,0 5.06798,0.92389 6.96019,2.77167 1.93749,1.84778 2.90581,4.06445 2.90581,6.65167 0,2.54028 -0.96832,4.73431 -2.90581,6.58209 -1.89221,1.80167 -4.212,2.70209 -6.96019,2.70209 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 213.56111,280.08446 H 195.99044 L 149.69953,207.0544 c -1.17121,-1.84778 -2.14037,-3.76515 -2.90581,-5.75126 h -0.40578 c 0.36051,2.12528 0.54076,6.67515 0.54076,13.6496 v 65.13172 h -15.54349 v -99.36009 h 18.71925 l 44.7374,71.29798 c 1.89222,2.95695 3.1087,4.98917 3.64945,6.09751 h 0.26996 c -0.45021,-2.6325 -0.67573,-7.09015 -0.67573,-13.37293 v -64.02256 h 15.47557 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="m 289.25134,280.08446 h -54.40052 v -99.36009 h 52.23835 v 13.99669 h -36.15411 v 28.13085 h 33.31621 v 13.9271 h -33.31621 v 29.37835 h 38.31628 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
-    <path d="M 366.56466,194.72106 H 338.7222 v 85.3634 h -16.08423 v -85.3634 h -27.77455 v -13.99669 h 71.70124 z" style="fill:#ffffff;fill-rule:nonzero;stroke-width:0.838376" />
+<?xml version="1.0" encoding="UTF-8"?>
+<svg width="456" height="456" viewBox="0 0 456 456" xmlns="http://www.w3.org/2000/svg">
+  <!-- € C-arc: center (175,230), r=105, opening ~110° on right (±55°) -->
+  <path d="M 235,144 A 105,105 0 1,0 235,316"
+        fill="none" stroke="white" stroke-width="40" stroke-linecap="round"/>
+  <!-- Upper bar: protrudes left, ends before opening -->
+  <line x1="58" y1="206" x2="226" y2="206"
+        stroke="white" stroke-width="36" stroke-linecap="round"/>
+  <!-- Lower bar: slightly shorter -->
+  <line x1="58" y1="254" x2="212" y2="254"
+        stroke="white" stroke-width="36" stroke-linecap="round"/>
+  <!-- Arrow shaft (more gap to the right) -->
+  <line x1="362" y1="322" x2="362" y2="148"
+        stroke="white" stroke-width="34" stroke-linecap="round"/>
+  <!-- Arrow head -->
+  <polyline points="312,204 362,138 412,204"
+            fill="none" stroke="white" stroke-width="34"
+            stroke-linecap="round" stroke-linejoin="round"/>
 </svg>


### PR DESCRIPTION
- appiconfg.svg: white € symbol with upward arrow on blue background
- appicon.svg: background updated from #512BD4 to #007AFF
- € has wider opening (~110°), proper bar proportions, arrow with gap

Affected: appicon.svg, appiconfg.svg

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [x] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [x] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [x] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [x] Kein hardcoded Farben (AppThemeBinding verwendet)
- [x] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
