### PR TITLE
build(windows): Set WindowsPackageType to None

### DIFF
--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -27,6 +27,7 @@
 		<SupportedOSPlatformVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.19041.0</SupportedOSPlatformVersion>
 		<TargetPlatformMinVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">10.0.17763.0</TargetPlatformMinVersion>
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
+		<WindowsPackageType Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'windows'">None</WindowsPackageType>
 
 		<!-- Xcode 26.3 installiert, SDK erwartet 26.2 – Prüfung deaktiviert bis SDK-Update -->
 		<ValidateXcodeVersion Condition="$([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) != 'windows'">false</ValidateXcodeVersion>


### PR DESCRIPTION
Added WindowsPackageType=None for Windows builds to prevent packaging as MSIX or other types. This ensures the app is built as a classic desktop application rather than an installable package.

## Beschreibung

<!-- Was wurde geändert und warum? -->

## Art der Änderung

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] ♻️ Refactoring
- [ ] 💄 UI/Style
- [x] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [x] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [x] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [x] Kein hardcoded Farben (AppThemeBinding verwendet)
- [x] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
