### PR TITLE
♻️ refactor(viewmodel): entkopple ViewModels von Shell-APIs

### DIFF
--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -35,6 +35,8 @@ public static class MauiProgram
 		builder.Services.AddSingleton<InitializationService>();
 		builder.Services.AddSingleton<ThemeService>();
 		builder.Services.AddSingleton<ILocalizationService, LocalizationService>();
+		builder.Services.AddSingleton<INavigationService, ShellNavigationService>();
+		builder.Services.AddSingleton<IDialogService, ShellDialogService>();
 
 		// ViewModels
 		builder.Services.AddTransient<DashboardViewModel>();

--- a/Finanzuebersicht/Services/Dialogs/IDialogService.cs
+++ b/Finanzuebersicht/Services/Dialogs/IDialogService.cs
@@ -1,0 +1,7 @@
+namespace Finanzuebersicht.Services;
+
+public interface IDialogService
+{
+    Task ShowAlertAsync(string title, string message, string cancel);
+    Task<bool> ShowConfirmationAsync(string title, string message, string accept, string cancel);
+}

--- a/Finanzuebersicht/Services/Dialogs/ShellDialogService.cs
+++ b/Finanzuebersicht/Services/Dialogs/ShellDialogService.cs
@@ -1,0 +1,24 @@
+namespace Finanzuebersicht.Services;
+
+public class ShellDialogService : IDialogService
+{
+    public async Task ShowAlertAsync(string title, string message, string cancel)
+    {
+        if (Shell.Current is null) return;
+
+        await MainThread.InvokeOnMainThreadAsync(async () =>
+        {
+            await Shell.Current.DisplayAlertAsync(title, message, cancel);
+        });
+    }
+
+    public async Task<bool> ShowConfirmationAsync(string title, string message, string accept, string cancel)
+    {
+        if (Shell.Current is null) return false;
+
+        return await MainThread.InvokeOnMainThreadAsync(async () =>
+        {
+            return await Shell.Current.DisplayAlertAsync(title, message, accept, cancel);
+        });
+    }
+}

--- a/Finanzuebersicht/Services/Navigation/INavigationService.cs
+++ b/Finanzuebersicht/Services/Navigation/INavigationService.cs
@@ -1,0 +1,7 @@
+namespace Finanzuebersicht.Services;
+
+public interface INavigationService
+{
+    Task GoToAsync(string route, IDictionary<string, object>? parameters = null);
+    Task GoBackAsync();
+}

--- a/Finanzuebersicht/Services/Navigation/ShellNavigationService.cs
+++ b/Finanzuebersicht/Services/Navigation/ShellNavigationService.cs
@@ -1,0 +1,20 @@
+namespace Finanzuebersicht.Services;
+
+public class ShellNavigationService : INavigationService
+{
+    public async Task GoToAsync(string route, IDictionary<string, object>? parameters = null)
+    {
+        if (Shell.Current is null) return;
+
+        if (parameters is null)
+            await Shell.Current.GoToAsync(route);
+        else
+            await Shell.Current.GoToAsync(route, parameters);
+    }
+
+    public async Task GoBackAsync()
+    {
+        if (Shell.Current is null) return;
+        await Shell.Current.GoToAsync("..");
+    }
+}

--- a/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
@@ -12,6 +12,8 @@ public partial class CategoriesViewModel : ObservableObject
 {
     private readonly IDataService _dataService;
     private readonly ILocalizationService _loc;
+    private readonly INavigationService _navigationService;
+    private readonly IDialogService _dialogService;
 
     [ObservableProperty]
     private ObservableCollection<Category> kategorien = [];
@@ -19,10 +21,16 @@ public partial class CategoriesViewModel : ObservableObject
     [ObservableProperty]
     private bool isLoading;
 
-    public CategoriesViewModel(IDataService dataService, ILocalizationService localizationService)
+    public CategoriesViewModel(
+        IDataService dataService,
+        ILocalizationService localizationService,
+        INavigationService navigationService,
+        IDialogService dialogService)
     {
         _dataService = dataService;
         _loc = localizationService;
+        _navigationService = navigationService;
+        _dialogService = dialogService;
     }
 
     [RelayCommand]
@@ -45,7 +53,7 @@ public partial class CategoriesViewModel : ObservableObject
     [RelayCommand]
     private async Task DeleteKategorie(Category kategorie)
     {
-        var confirm = await Shell.Current.DisplayAlert(
+        var confirm = await _dialogService.ShowConfirmationAsync(
             _loc.GetString(ResourceKeys.Dlg_KategorieLoeschen),
             _loc.GetString(ResourceKeys.Dlg_KategorieLoeschenFrage, kategorie.Name),
             _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
@@ -62,6 +70,6 @@ public partial class CategoriesViewModel : ObservableObject
         if (kategorie != null)
             parameter["Category"] = kategorie;
 
-        await Shell.Current.GoToAsync(nameof(CategoryDetailPage), parameter);
+        await _navigationService.GoToAsync(nameof(CategoryDetailPage), parameter);
     }
 }

--- a/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
@@ -10,6 +10,7 @@ namespace Finanzuebersicht.ViewModels;
 public partial class CategoryDetailViewModel : ObservableObject
 {
     private readonly IDataService _dataService;
+    private readonly INavigationService _navigationService;
     private Category? _existingCategory;
 
     [ObservableProperty]
@@ -57,9 +58,10 @@ public partial class CategoryDetailViewModel : ObservableObject
         }
     }
 
-    public CategoryDetailViewModel(IDataService dataService)
+    public CategoryDetailViewModel(IDataService dataService, INavigationService navigationService)
     {
         _dataService = dataService;
+        _navigationService = navigationService;
     }
 
     [RelayCommand]
@@ -74,6 +76,6 @@ public partial class CategoryDetailViewModel : ObservableObject
         category.Typ = Typ;
 
         await _dataService.SaveCategoryAsync(category);
-        await Shell.Current.GoToAsync("..");
+        await _navigationService.GoBackAsync();
     }
 }

--- a/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -3,7 +3,6 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
-using Finanzuebersicht.Resources.Strings;
 
 namespace Finanzuebersicht.ViewModels;
 
@@ -12,7 +11,7 @@ public partial class RecurringTransactionDetailViewModel : ObservableObject
 {
     private readonly IDataService _dataService;
     private RecurringTransaction? _existing;
-    private readonly ILocalizationService _loc;
+    private readonly INavigationService _navigationService;
 
     [ObservableProperty]
     private string betragText = string.Empty;
@@ -69,10 +68,12 @@ public partial class RecurringTransactionDetailViewModel : ObservableObject
         }
     }
 
-    public RecurringTransactionDetailViewModel(IDataService dataService, ILocalizationService localizationService)
+    public RecurringTransactionDetailViewModel(
+        IDataService dataService,
+        INavigationService navigationService)
     {
         _dataService = dataService;
-        _loc = localizationService;
+        _navigationService = navigationService;
     }
 
     [RelayCommand]
@@ -115,7 +116,7 @@ public partial class RecurringTransactionDetailViewModel : ObservableObject
         recurring.Aktiv = Aktiv;
 
         await _dataService.SaveRecurringTransactionAsync(recurring);
-        await Shell.Current.GoToAsync("..");
+        await _navigationService.GoBackAsync();
     }
 
     private async Task SetKategorieAsync(string kategorieId)

--- a/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
@@ -12,6 +12,8 @@ public partial class RecurringTransactionsViewModel : ObservableObject
 {
     private readonly IDataService _dataService;
     private readonly ILocalizationService _loc;
+    private readonly INavigationService _navigationService;
+    private readonly IDialogService _dialogService;
 
     [ObservableProperty]
     private ObservableCollection<RecurringTransaction> dauerauftraege = [];
@@ -19,10 +21,16 @@ public partial class RecurringTransactionsViewModel : ObservableObject
     [ObservableProperty]
     private bool isLoading;
 
-    public RecurringTransactionsViewModel(IDataService dataService, ILocalizationService localizationService)
+    public RecurringTransactionsViewModel(
+        IDataService dataService,
+        ILocalizationService localizationService,
+        INavigationService navigationService,
+        IDialogService dialogService)
     {
         _dataService = dataService;
         _loc = localizationService;
+        _navigationService = navigationService;
+        _dialogService = dialogService;
     }
 
     [RelayCommand]
@@ -54,7 +62,7 @@ public partial class RecurringTransactionsViewModel : ObservableObject
     [RelayCommand]
     private async Task DeleteDauerauftrag(RecurringTransaction dauerauftrag)
     {
-        var bestaetigt = await Shell.Current.DisplayAlert(
+        var bestaetigt = await _dialogService.ShowConfirmationAsync(
             _loc.GetString(ResourceKeys.Dlg_DauerauftragLoeschen),
             _loc.GetString(ResourceKeys.Dlg_DauerauftragLoeschenFrage, dauerauftrag.Titel),
             _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
@@ -72,6 +80,6 @@ public partial class RecurringTransactionsViewModel : ObservableObject
         if (dauerauftrag != null)
             parameter["RecurringTransaction"] = dauerauftrag;
 
-        await Shell.Current.GoToAsync(nameof(RecurringTransactionDetailPage), parameter);
+        await _navigationService.GoToAsync(nameof(RecurringTransactionDetailPage), parameter);
     }
 }

--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -11,6 +11,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly SettingsService _settings;
     private readonly ThemeService _themeService;
     private readonly ILocalizationService _loc;
+    private readonly IDialogService _dialogService;
 
     [ObservableProperty]
     private int selectedThemeIndex;
@@ -32,11 +33,16 @@ public partial class SettingsViewModel : ObservableObject
         new("xUnit", "Unit-Test-Framework (nur Tests)"),
     ];
 
-    public SettingsViewModel(SettingsService settings, ThemeService themeService, ILocalizationService localizationService)
+    public SettingsViewModel(
+        SettingsService settings,
+        ThemeService themeService,
+        ILocalizationService localizationService,
+        IDialogService dialogService)
     {
         _settings = settings;
         _themeService = themeService;
         _loc = localizationService;
+        _dialogService = dialogService;
 
         // Version aus Assembly-Metadaten lesen (von Nerdbank.GitVersioning gesetzt)
         var asm = Assembly.GetExecutingAssembly();
@@ -124,7 +130,7 @@ public partial class SettingsViewModel : ObservableObject
                 if (newPath.StartsWith(tempPath, StringComparison.OrdinalIgnoreCase) ||
                     newPath.Contains(Path.Combine("var", "folders"), StringComparison.OrdinalIgnoreCase))
                 {
-                    await Shell.Current.DisplayAlert(
+                    await _dialogService.ShowAlertAsync(
                         _loc.GetString(ResourceKeys.Stn_UngueltigerOrdner),
                         _loc.GetString(ResourceKeys.Stn_UngueltigerOrdnerDesc),
                         _loc.GetString(ResourceKeys.Btn_OK));
@@ -134,7 +140,7 @@ public partial class SettingsViewModel : ObservableObject
                 _settings.Set("DataPath", newPath);
                 DataPath = newPath;
 
-                await Shell.Current.DisplayAlert(
+                await _dialogService.ShowAlertAsync(
                     _loc.GetString(ResourceKeys.Stn_SpeicherortGeaendert),
                     _loc.GetString(ResourceKeys.Stn_SpeicherortGeaendertDesc, newPath),
                     _loc.GetString(ResourceKeys.Btn_OK));
@@ -142,7 +148,10 @@ public partial class SettingsViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            await Shell.Current.DisplayAlert(_loc.GetString(ResourceKeys.Err_Titel), _loc.GetString(ResourceKeys.Err_OrdnerNichtWaehlbar, ex.Message), _loc.GetString(ResourceKeys.Btn_OK));
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_OrdnerNichtWaehlbar, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
         }
     }
 
@@ -152,7 +161,7 @@ public partial class SettingsViewModel : ObservableObject
         _settings.Set("DataPath", "");
         DataPath = GetDefaultDataDir();
 
-        await Shell.Current.DisplayAlert(
+        await _dialogService.ShowAlertAsync(
             _loc.GetString(ResourceKeys.Stn_SpeicherortZurueckgesetzt),
             _loc.GetString(ResourceKeys.Stn_SpeicherortZurueckgesetztDesc),
             _loc.GetString(ResourceKeys.Btn_OK));

--- a/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
@@ -13,6 +13,8 @@ public partial class TransactionDetailViewModel : ObservableObject
     private readonly IDataService _dataService;
     private Transaction? _existingTransaction;
     private readonly ILocalizationService _loc;
+    private readonly INavigationService _navigationService;
+    private readonly IDialogService _dialogService;
 
     [ObservableProperty]
     private string betragText = string.Empty;
@@ -51,10 +53,16 @@ public partial class TransactionDetailViewModel : ObservableObject
         }
     }
 
-    public TransactionDetailViewModel(IDataService dataService, ILocalizationService localizationService)
+    public TransactionDetailViewModel(
+        IDataService dataService,
+        ILocalizationService localizationService,
+        INavigationService navigationService,
+        IDialogService dialogService)
     {
         _dataService = dataService;
         _loc = localizationService;
+        _navigationService = navigationService;
+        _dialogService = dialogService;
     }
 
     [RelayCommand]
@@ -81,29 +89,37 @@ public partial class TransactionDetailViewModel : ObservableObject
                     System.Globalization.CultureInfo.CurrentCulture,
                     out var betrag))
             {
-                await MainThread.InvokeOnMainThreadAsync(() => 
-                    Shell.Current.DisplayAlert(_loc.GetString(ResourceKeys.Err_Titel), _loc.GetString(ResourceKeys.Err_UngueltigerBetrag), _loc.GetString(ResourceKeys.Btn_OK)));
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Err_Titel),
+                    _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                    _loc.GetString(ResourceKeys.Btn_OK));
                 return;
             }
 
             if (betrag <= 0)
             {
-                await MainThread.InvokeOnMainThreadAsync(() => 
-                    Shell.Current.DisplayAlert(_loc.GetString(ResourceKeys.Err_Titel), _loc.GetString(ResourceKeys.Err_BetragGroesserNull), _loc.GetString(ResourceKeys.Btn_OK)));
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Err_Titel),
+                    _loc.GetString(ResourceKeys.Err_BetragGroesserNull),
+                    _loc.GetString(ResourceKeys.Btn_OK));
                 return;
             }
 
             if (string.IsNullOrWhiteSpace(Titel))
             {
-                await MainThread.InvokeOnMainThreadAsync(() => 
-                    Shell.Current.DisplayAlert(_loc.GetString(ResourceKeys.Err_Titel), _loc.GetString(ResourceKeys.Err_TitelErforderlich), _loc.GetString(ResourceKeys.Btn_OK)));
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Err_Titel),
+                    _loc.GetString(ResourceKeys.Err_TitelErforderlich),
+                    _loc.GetString(ResourceKeys.Btn_OK));
                 return;
             }
 
             if (SelectedKategorie == null)
             {
-                await MainThread.InvokeOnMainThreadAsync(() => 
-                    Shell.Current.DisplayAlert(_loc.GetString(ResourceKeys.Err_Titel), _loc.GetString(ResourceKeys.Err_KategorieErforderlich), _loc.GetString(ResourceKeys.Btn_OK)));
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Err_Titel),
+                    _loc.GetString(ResourceKeys.Err_KategorieErforderlich),
+                    _loc.GetString(ResourceKeys.Btn_OK));
                 return;
             }
 
@@ -115,13 +131,15 @@ public partial class TransactionDetailViewModel : ObservableObject
             transaction.Typ = Typ;
 
             await _dataService.SaveTransactionAsync(transaction);
-            await Shell.Current.GoToAsync("..");
+            await _navigationService.GoBackAsync();
         }
         catch (Exception ex)
         {
             System.Diagnostics.Debug.WriteLine($"Error saving transaction: {ex.Message}");
-            await MainThread.InvokeOnMainThreadAsync(() => 
-                Shell.Current.DisplayAlert(_loc.GetString(ResourceKeys.Err_Titel), _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message), _loc.GetString(ResourceKeys.Btn_OK)));
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
         }
     }
 

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -10,6 +10,7 @@ namespace Finanzuebersicht.ViewModels;
 public partial class TransactionsViewModel : MonthNavigationViewModel
 {
     private readonly IDataService _dataService;
+    private readonly INavigationService _navigationService;
 
     [ObservableProperty]
     private ObservableCollection<TransactionGroup> transaktionsGruppen = [];
@@ -17,9 +18,10 @@ public partial class TransactionsViewModel : MonthNavigationViewModel
     [ObservableProperty]
     private bool isLoading;
 
-    public TransactionsViewModel(IDataService dataService)
+    public TransactionsViewModel(IDataService dataService, INavigationService navigationService)
     {
         _dataService = dataService;
+        _navigationService = navigationService;
     }
 
     protected override async Task OnMonthChangedAsync() => await LoadTransaktionen();
@@ -77,6 +79,6 @@ public partial class TransactionsViewModel : MonthNavigationViewModel
         if (transaktion != null)
             parameter["Transaction"] = transaktion;
 
-        await Shell.Current.GoToAsync(nameof(TransactionDetailPage), parameter);
+        await _navigationService.GoToAsync(nameof(TransactionDetailPage), parameter);
     }
 }

--- a/README.md
+++ b/README.md
@@ -71,6 +71,12 @@ dotnet test Finanzuebersicht.Tests
 | Persistenz | JSON-Dateien (lokal, kein Cloud-Zwang) |
 | Versionierung | [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) |
 
+## Architektur-Roadmap
+
+Eine konkrete Zielarchitektur inkl. inkrementellem Migrationspfad findest du in:
+
+- [docs/ARCHITEKTUR-ROADMAP.md](docs/ARCHITEKTUR-ROADMAP.md)
+
 ## Contributing
 
 Pull Requests sind willkommen! Bitte erstelle zuerst einen Branch:

--- a/docs/ARCHITEKTUR-ROADMAP.md
+++ b/docs/ARCHITEKTUR-ROADMAP.md
@@ -1,0 +1,199 @@
+# Architektur-Roadmap (Wachstumsfähig)
+
+## Ziel
+
+Diese Roadmap beschreibt eine **inkrementelle Zielarchitektur** für Finanzübersicht,
+so dass neue Features (z. B. Budgets, Ziele, Sync, Import/Export, Reports) leicht
+hinzugefügt werden können, ohne dass ViewModels oder ein zentraler Service zu groß
+werden.
+
+Die Umsetzung ist bewusst in **3 kleine PRs** aufgeteilt, damit das Risiko niedrig
+bleibt und die App jederzeit lauffähig ist.
+
+---
+
+## Leitprinzipien
+
+1. **UI bleibt dünn**
+   - ViewModels orchestrieren nur, enthalten aber keine Navigation/Dialog-Details.
+2. **Fachlogik in Core**
+   - Regeln, Validierungen und Berechnungen liegen in App-unabhängigen Services.
+3. **Ports vor Implementierungen**
+   - Interfaces definieren Verträge; konkrete Klassen sind austauschbar.
+4. **Inkrementelle Migration**
+   - Keine Big-Bang-Refactorings; jeder Schritt ist rückwärtskompatibel.
+5. **Testbarkeit zuerst**
+   - Neue Logik wird zuerst über Unit-Tests abgesichert.
+
+---
+
+## Zielarchitektur (Soll-Zustand)
+
+## Projektgrenzen
+
+- `Finanzuebersicht` (MAUI App)
+  - Views, ViewModels, Plattform-spezifische Adapter
+  - DI-Komposition (`MauiProgram`)
+- `Finanzuebersicht.Core`
+  - Models, UseCases/Fachservices, Repository-Interfaces, Validierung
+- `Finanzuebersicht.Tests`
+  - Unit-Tests für Core + ViewModel-Tests (mit Mocks/Fakes)
+
+> Optional mittelfristig: `Finanzuebersicht.Infrastructure` für Persistenzadapter
+> (JSON, später SQLite/Cloud), falls Core weiter wächst.
+
+### Ziel-Ordnerstruktur (Core)
+
+```text
+Finanzuebersicht.Core/
+  Models/
+  Interfaces/
+    Repositories/
+      ICategoryRepository.cs
+      ITransactionRepository.cs
+      IRecurringTransactionRepository.cs
+    Services/
+      IRecurringGenerationService.cs
+      IReportingService.cs
+      ITransactionValidationService.cs
+  UseCases/
+    Transactions/
+      SaveTransactionUseCase.cs
+      DeleteTransactionUseCase.cs
+      GetMonthlyTransactionsUseCase.cs
+    Dashboard/
+      GetDashboardMonthUseCase.cs
+      GetDashboardYearUseCase.cs
+    Recurring/
+      GeneratePendingRecurringUseCase.cs
+  Services/
+    RecurringGenerationService.cs
+    ReportingService.cs
+    TransactionValidationService.cs
+```
+
+### Ziel-Ordnerstruktur (App)
+
+```text
+Finanzuebersicht/
+  Services/
+    Navigation/
+      INavigationService.cs
+      ShellNavigationService.cs
+    Dialogs/
+      IDialogService.cs
+      ShellDialogService.cs
+    (bestehende Theme/Localization Services)
+  ViewModels/
+    (nutzen nur Interfaces, keine Shell.Current-Aufrufe)
+```
+
+---
+
+## Migrationsplan in 3 kleinen PRs
+
+## PR 1 — UI-Kopplung lösen (niedriges Risiko)
+
+**Ziel:** ViewModels von `Shell.Current` und direkten `DisplayAlert`-Aufrufen entkoppeln.
+
+### Änderungen
+- App-Projekt:
+  - `INavigationService` + `ShellNavigationService`
+  - `IDialogService` + `ShellDialogService`
+- ViewModels umstellen:
+  - `TransactionsViewModel`, `CategoriesViewModel`, `RecurringTransactionsViewModel`
+  - `TransactionDetailViewModel`, `RecurringTransactionDetailViewModel`, `SettingsViewModel`
+- DI-Registrierung in `MauiProgram.cs`
+
+### Ergebnis
+- Bessere Testbarkeit der ViewModels
+- Kein Plattformwissen in ViewModels
+- Keine funktionale Verhaltensänderung
+
+### Akzeptanzkriterien
+- Alle bestehenden UI-Flows funktionieren unverändert
+- ViewModels enthalten keine `Shell.Current`-Zugriffe mehr
+- Neue Unit-Tests für Navigation/Dialog-Aufrufe vorhanden
+
+---
+
+## PR 2 — `IDataService` hinter Ports aufsplitten (ohne Datenformatänderung)
+
+**Ziel:** Monolithischen Service in klar getrennte Verträge zerlegen.
+
+### Änderungen
+- Core:
+  - Repository-Interfaces einführen:
+    - `ICategoryRepository`
+    - `ITransactionRepository`
+    - `IRecurringTransactionRepository`
+  - Service-Interfaces für Aggregation/Recurring einführen:
+    - `IReportingService`
+    - `IRecurringGenerationService`
+- App/Core Implementierung:
+  - `LocalDataService` bleibt zunächst bestehen, implementiert aber die neuen Interfaces
+  - `IDataService` bleibt temporär als Kompatibilitäts-Fassade
+- ViewModels/Services schrittweise auf neue Interfaces umstellen
+
+### Ergebnis
+- Verantwortlichkeiten klar getrennt
+- Künftige Persistenzwechsel (JSON → SQLite/Cloud) einfacher
+- Kein Big-Bang und kein Datenmigrationszwang
+
+### Akzeptanzkriterien
+- Alle bestehenden Tests grün
+- Neue Tests pro Interface-Vertrag
+- Funktional identisches Verhalten zur vorherigen Version
+
+---
+
+## PR 3 — Fachlogik zentralisieren + Styles konsolidieren
+
+**Ziel:** Regeln aus ViewModels herausziehen und wiederverwendbar machen.
+
+### Änderungen
+- Core UseCases/Services einführen:
+  - Speichern/Validieren von Transaktionen
+  - Wiederkehrende Buchungen generieren
+  - Dashboard-/Jahresaggregationen
+- ViewModels vereinfachen:
+  - nur Input sammeln, UseCase aufrufen, Ergebnis für UI mappen
+- Hardcoded Werte reduzieren:
+  - Farbwerte aus ViewModels/Convertern/Charts über zentrale Ressourcen/Tokens beziehen
+
+### Ergebnis
+- Einheitliche Fachregeln
+- Weniger Duplikate, weniger Regressionen
+- Bessere Erweiterbarkeit (z. B. Budget-Checks, Warnungen, Forecast-Regeln)
+
+### Akzeptanzkriterien
+- Kernregeln liegen nicht mehr in ViewModels
+- Neue UseCase-Unit-Tests decken Erfolgs- und Fehlerpfade ab
+- UI verwendet zentrale Style-/Theme-Definitionen
+
+---
+
+## Technische Schulden / Beobachtungen
+
+1. `LocalDataService` enthält aktuell mehrere Verantwortungen (CRUD + Reporting + Recurring).
+2. Einige ViewModels enthalten UI-Details (Navigation/Dialogs), was Tests erschwert.
+3. Mehrere Farbwerte sind hart kodiert und nicht zentral konfiguriert.
+4. Readme und Projektanleitung sollten Sprach-/Plattformangaben konsistent halten.
+
+---
+
+## Definition of Done (gesamt)
+
+- Neue Features können ohne Änderungen an bestehenden ViewModels in klaren UseCases ergänzt werden.
+- Austausch der Persistenz ist auf Infrastructure/Adapter begrenzt.
+- ViewModels bleiben dünn und testbar.
+- Tests schützen Kernlogik und verhindern Regressionsfehler bei Wachstum.
+
+---
+
+## Vorschlag für nächste konkrete Umsetzung
+
+Start mit **PR 1 (UI-Kopplung lösen)**, weil:
+- sehr geringe Fachrisiken,
+- sofort messbarer Testbarkeitsgewinn,
+- ideale Basis für PR 2 und PR 3.


### PR DESCRIPTION
## Zusammenfassung
- Navigation/Dialog aus ViewModels entkoppelt über INavigationService und IDialogService
- Shell-basierte Implementierungen (ShellNavigationService, ShellDialogService) eingeführt
- DI-Registrierung in MauiProgram ergänzt
- Direkte Shell.Current-Aufrufe in ViewModels entfernt
- Architektur-Roadmap ergänzt und im README verlinkt

## Betroffene Bereiche
- Finanzuebersicht/MauiProgram.cs
- Finanzuebersicht/ViewModels/*
- Finanzuebersicht/Services/Navigation/*
- Finanzuebersicht/Services/Dialogs/*
- docs/ARCHITEKTUR-ROADMAP.md
- README.md

## Validierung
- [x] Build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst
- [x] Tests grün (Finanzuebersicht.Tests, 18/18)
- [x] App lokal gestartet (Mac Catalyst)

## Hinweise
- .vscode/ bleibt untracked und ist nicht Teil dieses PRs.
