### PR TITLE
♻️ refactor(service): split IDataService into smaller contracts

### DIFF
--- a/Finanzuebersicht.Core/Services/ICategoryRepository.cs
+++ b/Finanzuebersicht.Core/Services/ICategoryRepository.cs
@@ -1,0 +1,10 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Services;
+
+public interface ICategoryRepository
+{
+    Task<List<Category>> GetCategoriesAsync();
+    Task SaveCategoryAsync(Category category);
+    Task DeleteCategoryAsync(string id);
+}

--- a/Finanzuebersicht.Core/Services/IDataService.cs
+++ b/Finanzuebersicht.Core/Services/IDataService.cs
@@ -1,28 +1,10 @@
-using Finanzuebersicht.Models;
-
 namespace Finanzuebersicht.Services;
 
-public interface IDataService
+public interface IDataService :
+    ICategoryRepository,
+    ITransactionRepository,
+    IRecurringTransactionRepository,
+    IRecurringGenerationService,
+    IReportingService
 {
-    // Categories
-    Task<List<Category>> GetCategoriesAsync();
-    Task SaveCategoryAsync(Category category);
-    Task DeleteCategoryAsync(string id);
-
-    // Transactions
-    Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum);
-    Task SaveTransactionAsync(Transaction transaction);
-    Task DeleteTransactionAsync(string id);
-
-    // Recurring Transactions
-    Task<List<RecurringTransaction>> GetRecurringTransactionsAsync();
-    Task SaveRecurringTransactionAsync(RecurringTransaction recurring);
-    Task DeleteRecurringTransactionAsync(string id);
-
-    // Fällige wiederkehrende Zahlungen als Transactions erzeugen
-    Task GeneratePendingRecurringTransactionsAsync();
-
-    // Aggregation helpers for year/month/category summaries
-    Task<YearSummary> GetYearSummaryAsync(int year);
-    Task<MonthSummary> GetMonthSummaryAsync(int year, int month);
 }

--- a/Finanzuebersicht.Core/Services/IRecurringGenerationService.cs
+++ b/Finanzuebersicht.Core/Services/IRecurringGenerationService.cs
@@ -1,0 +1,6 @@
+namespace Finanzuebersicht.Services;
+
+public interface IRecurringGenerationService
+{
+    Task GeneratePendingRecurringTransactionsAsync();
+}

--- a/Finanzuebersicht.Core/Services/IRecurringTransactionRepository.cs
+++ b/Finanzuebersicht.Core/Services/IRecurringTransactionRepository.cs
@@ -1,0 +1,10 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Services;
+
+public interface IRecurringTransactionRepository
+{
+    Task<List<RecurringTransaction>> GetRecurringTransactionsAsync();
+    Task SaveRecurringTransactionAsync(RecurringTransaction recurring);
+    Task DeleteRecurringTransactionAsync(string id);
+}

--- a/Finanzuebersicht.Core/Services/IReportingService.cs
+++ b/Finanzuebersicht.Core/Services/IReportingService.cs
@@ -1,0 +1,9 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Services;
+
+public interface IReportingService
+{
+    Task<YearSummary> GetYearSummaryAsync(int year);
+    Task<MonthSummary> GetMonthSummaryAsync(int year, int month);
+}

--- a/Finanzuebersicht.Core/Services/ITransactionRepository.cs
+++ b/Finanzuebersicht.Core/Services/ITransactionRepository.cs
@@ -1,0 +1,10 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Services;
+
+public interface ITransactionRepository
+{
+    Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum);
+    Task SaveTransactionAsync(Transaction transaction);
+    Task DeleteTransactionAsync(string id);
+}


### PR DESCRIPTION
## Zusammenfassung
- IDataService in kleinere, klar getrennte Verträge aufgeteilt
- Neue Interfaces eingeführt: ICategoryRepository, ITransactionRepository, IRecurringTransactionRepository, IRecurringGenerationService, IReportingService
- IDataService als Kompatibilitäts-Fassade beibehalten (Aggregation der neuen Interfaces)

## Ziel
Diese Änderung ist der erste technische Schritt von PR 2 und bleibt bewusst ohne Verhaltensänderung. Sie schafft eine bessere Grundlage für inkrementelle Migration der Abhängigkeiten.

## Betroffene Dateien
- Finanzuebersicht.Core/Services/IDataService.cs
- Finanzuebersicht.Core/Services/ICategoryRepository.cs
- Finanzuebersicht.Core/Services/ITransactionRepository.cs
- Finanzuebersicht.Core/Services/IRecurringTransactionRepository.cs
- Finanzuebersicht.Core/Services/IRecurringGenerationService.cs
- Finanzuebersicht.Core/Services/IReportingService.cs

## Validierung
- [x] Keine Compiler-/Analyzer-Fehler
- [x] Tests grün (18/18)
- [x] Keine Änderung an Laufzeitverhalten
