### PR TITLE
♻️ refactor(service): migrate consumers to granular data ports

### DIFF
--- a/Finanzuebersicht.Core/Services/InitializationService.cs
+++ b/Finanzuebersicht.Core/Services/InitializationService.cs
@@ -4,16 +4,16 @@ namespace Finanzuebersicht.Services;
 
 public class InitializationService
 {
-    private readonly IDataService _dataService;
+    private readonly ICategoryRepository _categoryRepository;
 
-    public InitializationService(IDataService dataService)
+    public InitializationService(ICategoryRepository categoryRepository)
     {
-        _dataService = dataService;
+        _categoryRepository = categoryRepository;
     }
 
     public async Task InitializeAsync()
     {
-        var kategorien = await _dataService.GetCategoriesAsync();
+        var kategorien = await _categoryRepository.GetCategoriesAsync();
         if (kategorien.Count > 0) return;
 
         var standardKategorien = new List<Category>
@@ -29,7 +29,7 @@ public class InitializationService
 
         foreach (var kategorie in standardKategorien)
         {
-            await _dataService.SaveCategoryAsync(kategorie);
+            await _categoryRepository.SaveCategoryAsync(kategorie);
         }
     }
 }

--- a/Finanzuebersicht.Tests/Services/InitializationServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/InitializationServiceTests.cs
@@ -5,31 +5,31 @@ namespace Finanzuebersicht.Tests.Services;
 
 public class InitializationServiceTests
 {
-    private readonly IDataService _dataService = Substitute.For<IDataService>();
+    private readonly ICategoryRepository _categoryRepository = Substitute.For<ICategoryRepository>();
 
     [Fact]
     public async Task InitializeAsync_ErstelltStandardKategorien_WennKeineVorhanden()
     {
-        _dataService.GetCategoriesAsync().Returns(new List<Category>());
+        _categoryRepository.GetCategoriesAsync().Returns(new List<Category>());
 
-        var service = new InitializationService(_dataService);
+        var service = new InitializationService(_categoryRepository);
         await service.InitializeAsync();
 
         // 7 Standardkategorien werden erstellt
-        await _dataService.Received(7).SaveCategoryAsync(Arg.Any<Category>());
+        await _categoryRepository.Received(7).SaveCategoryAsync(Arg.Any<Category>());
     }
 
     [Fact]
     public async Task InitializeAsync_ErstelltNichts_WennKategorienVorhanden()
     {
-        _dataService.GetCategoriesAsync().Returns(new List<Category>
+        _categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
             new() { Id = "1", Name = "Existiert", Icon = "📦", Color = "#007AFF", Typ = TransactionType.Ausgabe }
         });
 
-        var service = new InitializationService(_dataService);
+        var service = new InitializationService(_categoryRepository);
         await service.InitializeAsync();
 
-        await _dataService.DidNotReceive().SaveCategoryAsync(Arg.Any<Category>());
+        await _categoryRepository.DidNotReceive().SaveCategoryAsync(Arg.Any<Category>());
     }
 }

--- a/Finanzuebersicht/App.xaml.cs
+++ b/Finanzuebersicht/App.xaml.cs
@@ -4,19 +4,19 @@ namespace Finanzuebersicht;
 
 public partial class App : Application
 {
-	private readonly IDataService _dataService;
+	private readonly IRecurringGenerationService _recurringGenerationService;
 	private readonly InitializationService _initService;
 	private readonly ThemeService _themeService;
 	private readonly string _savedTheme;
 
-	public App(InitializationService initService, IDataService dataService, SettingsService settings,
+	public App(InitializationService initService, IRecurringGenerationService recurringGenerationService, SettingsService settings,
 		ThemeService themeService, ILocalizationService localizationService)
 	{
 		// Sprache vor InitializeComponent setzen, damit XAML-Bindings korrekt aufgelöst werden
 		localizationService.Initialize();
 
 		InitializeComponent();
-		_dataService = dataService;
+		_recurringGenerationService = recurringGenerationService;
 		_initService = initService;
 		_themeService = themeService;
 
@@ -34,7 +34,7 @@ public partial class App : Application
 
 		window.Resumed += async (s, e) =>
 		{
-			await _dataService.GeneratePendingRecurringTransactionsAsync();
+			await _recurringGenerationService.GeneratePendingRecurringTransactionsAsync();
 		};
 
 		return window;
@@ -44,6 +44,6 @@ public partial class App : Application
 	{
 		base.OnStart();
 		await _initService.InitializeAsync();
-		await _dataService.GeneratePendingRecurringTransactionsAsync();
+		await _recurringGenerationService.GeneratePendingRecurringTransactionsAsync();
 	}
 }

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -30,8 +30,14 @@ public static class MauiProgram
 
 		// Services
 		builder.Services.AddSingleton<SettingsService>();
-		builder.Services.AddSingleton<IDataService>(sp =>
+		builder.Services.AddSingleton<LocalDataService>(sp =>
 			new LocalDataService(sp.GetRequiredService<SettingsService>()));
+		builder.Services.AddSingleton<IDataService>(sp => sp.GetRequiredService<LocalDataService>());
+		builder.Services.AddSingleton<ICategoryRepository>(sp => sp.GetRequiredService<LocalDataService>());
+		builder.Services.AddSingleton<ITransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
+		builder.Services.AddSingleton<IRecurringTransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
+		builder.Services.AddSingleton<IRecurringGenerationService>(sp => sp.GetRequiredService<LocalDataService>());
+		builder.Services.AddSingleton<IReportingService>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<InitializationService>();
 		builder.Services.AddSingleton<ThemeService>();
 		builder.Services.AddSingleton<ILocalizationService, LocalizationService>();

--- a/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
@@ -10,7 +10,7 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class CategoriesViewModel : ObservableObject
 {
-    private readonly IDataService _dataService;
+    private readonly ICategoryRepository _categoryRepository;
     private readonly ILocalizationService _loc;
     private readonly INavigationService _navigationService;
     private readonly IDialogService _dialogService;
@@ -22,12 +22,12 @@ public partial class CategoriesViewModel : ObservableObject
     private bool isLoading;
 
     public CategoriesViewModel(
-        IDataService dataService,
+        ICategoryRepository categoryRepository,
         ILocalizationService localizationService,
         INavigationService navigationService,
         IDialogService dialogService)
     {
-        _dataService = dataService;
+        _categoryRepository = categoryRepository;
         _loc = localizationService;
         _navigationService = navigationService;
         _dialogService = dialogService;
@@ -41,7 +41,7 @@ public partial class CategoriesViewModel : ObservableObject
 
         try
         {
-            var liste = await _dataService.GetCategoriesAsync();
+            var liste = await _categoryRepository.GetCategoriesAsync();
             Kategorien = new ObservableCollection<Category>(liste);
         }
         finally
@@ -59,7 +59,7 @@ public partial class CategoriesViewModel : ObservableObject
             _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
         if (!confirm) return;
 
-        await _dataService.DeleteCategoryAsync(kategorie.Id);
+        await _categoryRepository.DeleteCategoryAsync(kategorie.Id);
         Kategorien.Remove(kategorie);
     }
 

--- a/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
@@ -9,7 +9,7 @@ namespace Finanzuebersicht.ViewModels;
 [QueryProperty(nameof(Category), "Category")]
 public partial class CategoryDetailViewModel : ObservableObject
 {
-    private readonly IDataService _dataService;
+    private readonly ICategoryRepository _categoryRepository;
     private readonly INavigationService _navigationService;
     private Category? _existingCategory;
 
@@ -58,9 +58,9 @@ public partial class CategoryDetailViewModel : ObservableObject
         }
     }
 
-    public CategoryDetailViewModel(IDataService dataService, INavigationService navigationService)
+    public CategoryDetailViewModel(ICategoryRepository categoryRepository, INavigationService navigationService)
     {
-        _dataService = dataService;
+        _categoryRepository = categoryRepository;
         _navigationService = navigationService;
     }
 
@@ -75,7 +75,7 @@ public partial class CategoryDetailViewModel : ObservableObject
         category.Color = Color;
         category.Typ = Typ;
 
-        await _dataService.SaveCategoryAsync(category);
+        await _categoryRepository.SaveCategoryAsync(category);
         await _navigationService.GoBackAsync();
     }
 }

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -8,7 +8,10 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class DashboardViewModel : MonthNavigationViewModel
 {
-    private readonly IDataService _dataService;
+    private readonly ICategoryRepository _categoryRepository;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+    private readonly IReportingService _reportingService;
 
     // --- Monatsansicht ---
 
@@ -58,9 +61,16 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private int _aktuellesJahr = DateTime.Today.Year;
     private List<Category> _alleKategorien = [];
 
-    public DashboardViewModel(IDataService dataService)
+    public DashboardViewModel(
+        ICategoryRepository categoryRepository,
+        ITransactionRepository transactionRepository,
+        IRecurringTransactionRepository recurringTransactionRepository,
+        IReportingService reportingService)
     {
-        _dataService = dataService;
+        _categoryRepository = categoryRepository;
+        _transactionRepository = transactionRepository;
+        _recurringTransactionRepository = recurringTransactionRepository;
+        _reportingService = reportingService;
         UpdateJahrAnzeige();
     }
 
@@ -86,17 +96,17 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     private async Task LadeMonatAsync()
     {
-        _alleKategorien = await _dataService.GetCategoriesAsync();
+        _alleKategorien = await _categoryRepository.GetCategoriesAsync();
 
         var von = AktuellerMonat;
         var bis = AktuellerMonat.AddMonths(1).AddDays(-1);
-        var transaktionen = await _dataService.GetTransactionsAsync(von, bis);
+        var transaktionen = await _transactionRepository.GetTransactionsAsync(von, bis);
 
         // Prognose: zukünftige Monate mit erwarteten Daueraufträgen ergänzen
         IstPrognose = AktuellerMonat > new DateTime(DateTime.Today.Year, DateTime.Today.Month, 1);
         if (IstPrognose)
         {
-            var dauerauftraege = await _dataService.GetRecurringTransactionsAsync();
+            var dauerauftraege = await _recurringTransactionRepository.GetRecurringTransactionsAsync();
             foreach (var da in dauerauftraege.Where(d => d.Aktiv))
             {
                 if (da.Startdatum <= bis && (!da.Enddatum.HasValue || da.Enddatum.Value >= von))
@@ -166,7 +176,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     private async Task LadeJahrAsync()
     {
-        var summary = await _dataService.GetYearSummaryAsync(_aktuellesJahr);
+        var summary = await _reportingService.GetYearSummaryAsync(_aktuellesJahr);
         if (summary != null)
         {
             JahrGesamtAusgaben = summary.Total;

--- a/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -9,7 +9,8 @@ namespace Finanzuebersicht.ViewModels;
 [QueryProperty(nameof(RecurringTransaction), "RecurringTransaction")]
 public partial class RecurringTransactionDetailViewModel : ObservableObject
 {
-    private readonly IDataService _dataService;
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
+    private readonly ICategoryRepository _categoryRepository;
     private RecurringTransaction? _existing;
     private readonly INavigationService _navigationService;
 
@@ -69,17 +70,19 @@ public partial class RecurringTransactionDetailViewModel : ObservableObject
     }
 
     public RecurringTransactionDetailViewModel(
-        IDataService dataService,
+        IRecurringTransactionRepository recurringTransactionRepository,
+        ICategoryRepository categoryRepository,
         INavigationService navigationService)
     {
-        _dataService = dataService;
+        _recurringTransactionRepository = recurringTransactionRepository;
+        _categoryRepository = categoryRepository;
         _navigationService = navigationService;
     }
 
     [RelayCommand]
     private async Task LoadKategorien()
     {
-        var liste = await _dataService.GetCategoriesAsync();
+        var liste = await _categoryRepository.GetCategoriesAsync();
         // Merke die aktuelle ID bevor die Collection ersetzt wird
         var currentId = SelectedKategorie?.Id ?? _existing?.KategorieId;
         Kategorien = new ObservableCollection<Category>(liste);
@@ -115,7 +118,7 @@ public partial class RecurringTransactionDetailViewModel : ObservableObject
         recurring.Enddatum = HatEnddatum ? EnddatumWert : null;
         recurring.Aktiv = Aktiv;
 
-        await _dataService.SaveRecurringTransactionAsync(recurring);
+        await _recurringTransactionRepository.SaveRecurringTransactionAsync(recurring);
         await _navigationService.GoBackAsync();
     }
 

--- a/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
@@ -10,7 +10,7 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class RecurringTransactionsViewModel : ObservableObject
 {
-    private readonly IDataService _dataService;
+    private readonly IRecurringTransactionRepository _recurringTransactionRepository;
     private readonly ILocalizationService _loc;
     private readonly INavigationService _navigationService;
     private readonly IDialogService _dialogService;
@@ -22,12 +22,12 @@ public partial class RecurringTransactionsViewModel : ObservableObject
     private bool isLoading;
 
     public RecurringTransactionsViewModel(
-        IDataService dataService,
+        IRecurringTransactionRepository recurringTransactionRepository,
         ILocalizationService localizationService,
         INavigationService navigationService,
         IDialogService dialogService)
     {
-        _dataService = dataService;
+        _recurringTransactionRepository = recurringTransactionRepository;
         _loc = localizationService;
         _navigationService = navigationService;
         _dialogService = dialogService;
@@ -41,7 +41,7 @@ public partial class RecurringTransactionsViewModel : ObservableObject
 
         try
         {
-            var liste = await _dataService.GetRecurringTransactionsAsync();
+            var liste = await _recurringTransactionRepository.GetRecurringTransactionsAsync();
             Dauerauftraege = new ObservableCollection<RecurringTransaction>(
                 liste.OrderByDescending(d => d.Aktiv).ThenBy(d => d.Titel));
         }
@@ -55,7 +55,7 @@ public partial class RecurringTransactionsViewModel : ObservableObject
     private async Task ToggleAktiv(RecurringTransaction dauerauftrag)
     {
         dauerauftrag.Aktiv = !dauerauftrag.Aktiv;
-        await _dataService.SaveRecurringTransactionAsync(dauerauftrag);
+        await _recurringTransactionRepository.SaveRecurringTransactionAsync(dauerauftrag);
         await LoadDauerauftraege();
     }
 
@@ -69,7 +69,7 @@ public partial class RecurringTransactionsViewModel : ObservableObject
 
         if (!bestaetigt) return;
 
-        await _dataService.DeleteRecurringTransactionAsync(dauerauftrag.Id);
+        await _recurringTransactionRepository.DeleteRecurringTransactionAsync(dauerauftrag.Id);
         Dauerauftraege.Remove(dauerauftrag);
     }
 

--- a/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
@@ -10,7 +10,8 @@ namespace Finanzuebersicht.ViewModels;
 [QueryProperty(nameof(Transaction), "Transaction")]
 public partial class TransactionDetailViewModel : ObservableObject
 {
-    private readonly IDataService _dataService;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ICategoryRepository _categoryRepository;
     private Transaction? _existingTransaction;
     private readonly ILocalizationService _loc;
     private readonly INavigationService _navigationService;
@@ -54,12 +55,14 @@ public partial class TransactionDetailViewModel : ObservableObject
     }
 
     public TransactionDetailViewModel(
-        IDataService dataService,
+        ITransactionRepository transactionRepository,
+        ICategoryRepository categoryRepository,
         ILocalizationService localizationService,
         INavigationService navigationService,
         IDialogService dialogService)
     {
-        _dataService = dataService;
+        _transactionRepository = transactionRepository;
+        _categoryRepository = categoryRepository;
         _loc = localizationService;
         _navigationService = navigationService;
         _dialogService = dialogService;
@@ -68,7 +71,7 @@ public partial class TransactionDetailViewModel : ObservableObject
     [RelayCommand]
     private async Task LoadKategorien()
     {
-        var liste = await _dataService.GetCategoriesAsync();
+        var liste = await _categoryRepository.GetCategoriesAsync();
         Kategorien = new ObservableCollection<Category>(liste);
     }
 
@@ -130,7 +133,7 @@ public partial class TransactionDetailViewModel : ObservableObject
             transaction.KategorieId = SelectedKategorie.Id;
             transaction.Typ = Typ;
 
-            await _dataService.SaveTransactionAsync(transaction);
+            await _transactionRepository.SaveTransactionAsync(transaction);
             await _navigationService.GoBackAsync();
         }
         catch (Exception ex)

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -9,7 +9,8 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class TransactionsViewModel : MonthNavigationViewModel
 {
-    private readonly IDataService _dataService;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ICategoryRepository _categoryRepository;
     private readonly INavigationService _navigationService;
 
     [ObservableProperty]
@@ -18,9 +19,13 @@ public partial class TransactionsViewModel : MonthNavigationViewModel
     [ObservableProperty]
     private bool isLoading;
 
-    public TransactionsViewModel(IDataService dataService, INavigationService navigationService)
+    public TransactionsViewModel(
+        ITransactionRepository transactionRepository,
+        ICategoryRepository categoryRepository,
+        INavigationService navigationService)
     {
-        _dataService = dataService;
+        _transactionRepository = transactionRepository;
+        _categoryRepository = categoryRepository;
         _navigationService = navigationService;
     }
 
@@ -36,7 +41,7 @@ public partial class TransactionsViewModel : MonthNavigationViewModel
         {
             var von = AktuellerMonat;
             var bis = AktuellerMonat.AddMonths(1).AddDays(-1);
-            var liste = await _dataService.GetTransactionsAsync(von, bis);
+            var liste = await _transactionRepository.GetTransactionsAsync(von, bis);
 
             var gruppen = liste
                 .GroupBy(t => t.Datum.Date)
@@ -47,7 +52,7 @@ public partial class TransactionsViewModel : MonthNavigationViewModel
             TransaktionsGruppen = new ObservableCollection<TransactionGroup>(gruppen);
 
             // Kategorie-Icon-Cache für Converter aktualisieren
-            var categories = await _dataService.GetCategoriesAsync();
+            var categories = await _categoryRepository.GetCategoriesAsync();
             Converters.KategorieIdToIconConverter.SetCache(
                 categories.ToDictionary(c => c.Id, c => c.Icon ?? "📁"));
         }
@@ -60,7 +65,7 @@ public partial class TransactionsViewModel : MonthNavigationViewModel
     [RelayCommand]
     private async Task DeleteTransaktion(Transaction transaktion)
     {
-        await _dataService.DeleteTransactionAsync(transaktion.Id);
+        await _transactionRepository.DeleteTransactionAsync(transaktion.Id);
         foreach (var gruppe in TransaktionsGruppen)
         {
             if (gruppe.Remove(transaktion))

--- a/Finanzuebersicht/ViewModels/YearOverviewViewModel.cs
+++ b/Finanzuebersicht/ViewModels/YearOverviewViewModel.cs
@@ -12,11 +12,11 @@ namespace Finanzuebersicht.ViewModels
 {
     public partial class YearOverviewViewModel : ObservableObject
     {
-        private readonly IDataService _dataService;
+        private readonly IReportingService _reportingService;
 
-        public YearOverviewViewModel(IDataService dataService)
+        public YearOverviewViewModel(IReportingService reportingService)
         {
-            _dataService = dataService;
+            _reportingService = reportingService;
             Year = DateTime.Now.Year;
             Categories = new List<CategorySummary>();
         }
@@ -35,7 +35,7 @@ namespace Finanzuebersicht.ViewModels
         {
             try
             {
-                var summary = await _dataService.GetYearSummaryAsync(Year);
+                var summary = await _reportingService.GetYearSummaryAsync(Year);
                 MainThread.BeginInvokeOnMainThread(() =>
                 {
                     try


### PR DESCRIPTION
## Zusammenfassung
- Consumer von IDataService auf kleinere Service-Ports umgestellt
- App-Lifecycle nutzt IRecurringGenerationService
- InitializationService nutzt ICategoryRepository
- ViewModels nutzen jeweils nur benötigte Interfaces (Category/Transaction/Recurring/Reporting)
- DI so erweitert, dass LocalDataService über alle Ports aufgelöst wird

## Ziel
Dieser Schritt reduziert Kopplung auf die große Fassade und macht Abhängigkeiten expliziter, ohne das Laufzeitverhalten zu ändern.

## Betroffene Dateien
- Finanzuebersicht/App.xaml.cs
- Finanzuebersicht/MauiProgram.cs
- Finanzuebersicht.Core/Services/InitializationService.cs
- Finanzuebersicht.Tests/Services/InitializationServiceTests.cs
- Finanzuebersicht/ViewModels/CategoriesViewModel.cs
- Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
- Finanzuebersicht/ViewModels/TransactionsViewModel.cs
- Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
- Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
- Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
- Finanzuebersicht/ViewModels/DashboardViewModel.cs
- Finanzuebersicht/ViewModels/YearOverviewViewModel.cs

## Validierung
- [x] Build erfolgreich: dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst
- [x] Tests grün (18/18)
- [x] Keine funktionale Verhaltensänderung beabsichtigt
