### PR TITLE
♻️ refactor(service): extract transaction input validation

### DIFF
--- a/Finanzuebersicht.Core/Services/ITransactionValidationService.cs
+++ b/Finanzuebersicht.Core/Services/ITransactionValidationService.cs
@@ -1,0 +1,22 @@
+using System.Globalization;
+
+namespace Finanzuebersicht.Services;
+
+public interface ITransactionValidationService
+{
+    bool TryValidate(
+        string amountText,
+        string title,
+        bool hasCategory,
+        CultureInfo culture,
+        out decimal amount,
+        out TransactionInputError? error);
+}
+
+public enum TransactionInputError
+{
+    InvalidAmountFormat,
+    AmountMustBePositive,
+    TitleRequired,
+    CategoryRequired
+}

--- a/Finanzuebersicht.Core/Services/TransactionValidationService.cs
+++ b/Finanzuebersicht.Core/Services/TransactionValidationService.cs
@@ -1,0 +1,44 @@
+using System.Globalization;
+
+namespace Finanzuebersicht.Services;
+
+public class TransactionValidationService : ITransactionValidationService
+{
+    public bool TryValidate(
+        string amountText,
+        string title,
+        bool hasCategory,
+        CultureInfo culture,
+        out decimal amount,
+        out TransactionInputError? error)
+    {
+        amount = 0;
+        error = null;
+
+        if (!decimal.TryParse(amountText, NumberStyles.Any, culture, out amount))
+        {
+            error = TransactionInputError.InvalidAmountFormat;
+            return false;
+        }
+
+        if (amount <= 0)
+        {
+            error = TransactionInputError.AmountMustBePositive;
+            return false;
+        }
+
+        if (string.IsNullOrWhiteSpace(title))
+        {
+            error = TransactionInputError.TitleRequired;
+            return false;
+        }
+
+        if (!hasCategory)
+        {
+            error = TransactionInputError.CategoryRequired;
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/Finanzuebersicht.Tests/Services/TransactionValidationServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/TransactionValidationServiceTests.cs
@@ -1,0 +1,85 @@
+using System.Globalization;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Tests.Services;
+
+public class TransactionValidationServiceTests
+{
+    private readonly TransactionValidationService _service = new();
+
+    [Fact]
+    public void TryValidate_InvalidAmountFormat_ReturnsFalseAndError()
+    {
+        var result = _service.TryValidate(
+            "abc",
+            "Test",
+            hasCategory: true,
+            CultureInfo.GetCultureInfo("de-DE"),
+            out _,
+            out var error);
+
+        Assert.False(result);
+        Assert.Equal(TransactionInputError.InvalidAmountFormat, error);
+    }
+
+    [Fact]
+    public void TryValidate_AmountLessOrEqualZero_ReturnsFalseAndError()
+    {
+        var result = _service.TryValidate(
+            "0",
+            "Test",
+            hasCategory: true,
+            CultureInfo.GetCultureInfo("de-DE"),
+            out _,
+            out var error);
+
+        Assert.False(result);
+        Assert.Equal(TransactionInputError.AmountMustBePositive, error);
+    }
+
+    [Fact]
+    public void TryValidate_TitleMissing_ReturnsFalseAndError()
+    {
+        var result = _service.TryValidate(
+            "12,50",
+            "   ",
+            hasCategory: true,
+            CultureInfo.GetCultureInfo("de-DE"),
+            out _,
+            out var error);
+
+        Assert.False(result);
+        Assert.Equal(TransactionInputError.TitleRequired, error);
+    }
+
+    [Fact]
+    public void TryValidate_CategoryMissing_ReturnsFalseAndError()
+    {
+        var result = _service.TryValidate(
+            "12,50",
+            "Test",
+            hasCategory: false,
+            CultureInfo.GetCultureInfo("de-DE"),
+            out _,
+            out var error);
+
+        Assert.False(result);
+        Assert.Equal(TransactionInputError.CategoryRequired, error);
+    }
+
+    [Fact]
+    public void TryValidate_ValidInput_ReturnsTrueAndAmount()
+    {
+        var result = _service.TryValidate(
+            "12,50",
+            "Test",
+            hasCategory: true,
+            CultureInfo.GetCultureInfo("de-DE"),
+            out var amount,
+            out var error);
+
+        Assert.True(result);
+        Assert.Equal(12.50m, amount);
+        Assert.Null(error);
+    }
+}

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -38,6 +38,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IRecurringTransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<IRecurringGenerationService>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<IReportingService>(sp => sp.GetRequiredService<LocalDataService>());
+		builder.Services.AddSingleton<ITransactionValidationService, TransactionValidationService>();
 		builder.Services.AddSingleton<InitializationService>();
 		builder.Services.AddSingleton<ThemeService>();
 		builder.Services.AddSingleton<ILocalizationService, LocalizationService>();

--- a/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -11,6 +11,7 @@ public partial class RecurringTransactionDetailViewModel : ObservableObject
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository;
     private readonly ICategoryRepository _categoryRepository;
+    private readonly ITransactionValidationService _validationService;
     private RecurringTransaction? _existing;
     private readonly INavigationService _navigationService;
 
@@ -72,10 +73,12 @@ public partial class RecurringTransactionDetailViewModel : ObservableObject
     public RecurringTransactionDetailViewModel(
         IRecurringTransactionRepository recurringTransactionRepository,
         ICategoryRepository categoryRepository,
+        ITransactionValidationService validationService,
         INavigationService navigationService)
     {
         _recurringTransactionRepository = recurringTransactionRepository;
         _categoryRepository = categoryRepository;
+        _validationService = validationService;
         _navigationService = navigationService;
     }
 
@@ -100,19 +103,21 @@ public partial class RecurringTransactionDetailViewModel : ObservableObject
     [RelayCommand]
     private async Task Save()
     {
-        if (!decimal.TryParse(BetragText,
-                System.Globalization.NumberStyles.Any,
+        if (!_validationService.TryValidate(
+                BetragText,
+                Titel,
+                SelectedKategorie != null,
                 System.Globalization.CultureInfo.CurrentCulture,
-                out var betrag) || betrag <= 0)
+                out var betrag,
+                out _))
             return;
 
-        if (string.IsNullOrWhiteSpace(Titel)) return;
-        if (SelectedKategorie == null) return;
+        var selectedCategory = SelectedKategorie!;
 
         var recurring = _existing ?? new RecurringTransaction();
         recurring.Betrag = betrag;
         recurring.Titel = Titel;
-        recurring.KategorieId = SelectedKategorie.Id;
+        recurring.KategorieId = selectedCategory.Id;
         recurring.Typ = Typ;
         recurring.Startdatum = Startdatum;
         recurring.Enddatum = HatEnddatum ? EnddatumWert : null;

--- a/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
@@ -12,6 +12,7 @@ public partial class TransactionDetailViewModel : ObservableObject
 {
     private readonly ITransactionRepository _transactionRepository;
     private readonly ICategoryRepository _categoryRepository;
+    private readonly ITransactionValidationService _validationService;
     private Transaction? _existingTransaction;
     private readonly ILocalizationService _loc;
     private readonly INavigationService _navigationService;
@@ -57,12 +58,14 @@ public partial class TransactionDetailViewModel : ObservableObject
     public TransactionDetailViewModel(
         ITransactionRepository transactionRepository,
         ICategoryRepository categoryRepository,
+        ITransactionValidationService validationService,
         ILocalizationService localizationService,
         INavigationService navigationService,
         IDialogService dialogService)
     {
         _transactionRepository = transactionRepository;
         _categoryRepository = categoryRepository;
+        _validationService = validationService;
         _loc = localizationService;
         _navigationService = navigationService;
         _dialogService = dialogService;
@@ -86,51 +89,37 @@ public partial class TransactionDetailViewModel : ObservableObject
     {
         try
         {
-            // Validierung
-            if (!decimal.TryParse(BetragText,
-                    System.Globalization.NumberStyles.Any,
+            if (!_validationService.TryValidate(
+                    BetragText,
+                    Titel,
+                    SelectedKategorie != null,
                     System.Globalization.CultureInfo.CurrentCulture,
-                    out var betrag))
+                    out var betrag,
+                    out var error))
             {
+                var message = error switch
+                {
+                    TransactionInputError.InvalidAmountFormat => _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                    TransactionInputError.AmountMustBePositive => _loc.GetString(ResourceKeys.Err_BetragGroesserNull),
+                    TransactionInputError.TitleRequired => _loc.GetString(ResourceKeys.Err_TitelErforderlich),
+                    TransactionInputError.CategoryRequired => _loc.GetString(ResourceKeys.Err_KategorieErforderlich),
+                    _ => _loc.GetString(ResourceKeys.Err_UngueltigerBetrag)
+                };
+
                 await _dialogService.ShowAlertAsync(
                     _loc.GetString(ResourceKeys.Err_Titel),
-                    _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                    message,
                     _loc.GetString(ResourceKeys.Btn_OK));
                 return;
             }
 
-            if (betrag <= 0)
-            {
-                await _dialogService.ShowAlertAsync(
-                    _loc.GetString(ResourceKeys.Err_Titel),
-                    _loc.GetString(ResourceKeys.Err_BetragGroesserNull),
-                    _loc.GetString(ResourceKeys.Btn_OK));
-                return;
-            }
-
-            if (string.IsNullOrWhiteSpace(Titel))
-            {
-                await _dialogService.ShowAlertAsync(
-                    _loc.GetString(ResourceKeys.Err_Titel),
-                    _loc.GetString(ResourceKeys.Err_TitelErforderlich),
-                    _loc.GetString(ResourceKeys.Btn_OK));
-                return;
-            }
-
-            if (SelectedKategorie == null)
-            {
-                await _dialogService.ShowAlertAsync(
-                    _loc.GetString(ResourceKeys.Err_Titel),
-                    _loc.GetString(ResourceKeys.Err_KategorieErforderlich),
-                    _loc.GetString(ResourceKeys.Btn_OK));
-                return;
-            }
+            var selectedCategory = SelectedKategorie!;
 
             var transaction = _existingTransaction ?? new Transaction();
             transaction.Betrag = betrag;
             transaction.Titel = Titel;
             transaction.Datum = Datum;
-            transaction.KategorieId = SelectedKategorie.Id;
+            transaction.KategorieId = selectedCategory.Id;
             transaction.Typ = Typ;
 
             await _transactionRepository.SaveTransactionAsync(transaction);


### PR DESCRIPTION
Extrahiert die Transaktions-Eingabevalidierung in einen Core-Service (ITransactionValidationService/TransactionValidationService), bindet die beiden Detail-ViewModels daran an, ergänzt DI und fügt Unit-Tests hinzu. Validierung: Tests grün (23/23), Build net10.0-maccatalyst erfolgreich.