### PR TITLE
♻️ refactor(service): extract recurring generation use case

### DIFF
--- a/Finanzuebersicht.Core/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Core/Services/LocalDataService.cs
@@ -261,38 +261,8 @@ public class LocalDataService : IDataService, IDisposable
 
     public async Task GeneratePendingRecurringTransactionsAsync()
     {
-        var dauerauftraege = await GetRecurringTransactionsAsync();
-        var heute = DateTime.Today;
-
-        foreach (var da in dauerauftraege.Where(d => d.Aktiv))
-        {
-            if (da.Enddatum.HasValue && da.Enddatum.Value < heute)
-                continue;
-
-            var naechsterMonat = !da.LetzteAusfuehrung.HasValue
-                ? da.Startdatum
-                : new DateTime(da.LetzteAusfuehrung.Value.Year, da.LetzteAusfuehrung.Value.Month, 1).AddMonths(1);
-
-            while (naechsterMonat <= heute)
-            {
-                var transaction = new Transaction
-                {
-                    Betrag = da.Betrag,
-                    Titel = da.Titel,
-                    Datum = naechsterMonat,
-                    KategorieId = da.KategorieId,
-                    Typ = da.Typ,
-                    DauerauftragId = da.Id
-                };
-
-                await SaveTransactionAsync(transaction);
-
-                da.LetzteAusfuehrung = naechsterMonat;
-                naechsterMonat = naechsterMonat.AddMonths(1);
-            }
-
-            await SaveRecurringTransactionAsync(da);
-        }
+        var service = new RecurringGenerationService(this, this);
+        await service.GeneratePendingRecurringTransactionsAsync();
     }
 
     #endregion

--- a/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
+++ b/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
@@ -1,0 +1,56 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Services;
+
+public class RecurringGenerationService : IRecurringGenerationService
+{
+    private readonly IRecurringTransactionRepository _recurringRepository;
+    private readonly ITransactionRepository _transactionRepository;
+
+    public RecurringGenerationService(
+        IRecurringTransactionRepository recurringRepository,
+        ITransactionRepository transactionRepository)
+    {
+        _recurringRepository = recurringRepository;
+        _transactionRepository = transactionRepository;
+    }
+
+    public async Task GeneratePendingRecurringTransactionsAsync()
+    {
+        var recurringItems = await _recurringRepository.GetRecurringTransactionsAsync();
+        var today = DateTime.Today;
+
+        foreach (var recurring in recurringItems.Where(item => item.Aktiv))
+        {
+            if (recurring.Enddatum.HasValue && recurring.Enddatum.Value < today)
+                continue;
+
+            var nextMonth = !recurring.LetzteAusfuehrung.HasValue
+                ? recurring.Startdatum
+                : new DateTime(
+                    recurring.LetzteAusfuehrung.Value.Year,
+                    recurring.LetzteAusfuehrung.Value.Month,
+                    1).AddMonths(1);
+
+            while (nextMonth <= today)
+            {
+                var transaction = new Transaction
+                {
+                    Betrag = recurring.Betrag,
+                    Titel = recurring.Titel,
+                    Datum = nextMonth,
+                    KategorieId = recurring.KategorieId,
+                    Typ = recurring.Typ,
+                    DauerauftragId = recurring.Id
+                };
+
+                await _transactionRepository.SaveTransactionAsync(transaction);
+
+                recurring.LetzteAusfuehrung = nextMonth;
+                nextMonth = nextMonth.AddMonths(1);
+            }
+
+            await _recurringRepository.SaveRecurringTransactionAsync(recurring);
+        }
+    }
+}

--- a/Finanzuebersicht.Tests/Services/RecurringGenerationServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/RecurringGenerationServiceTests.cs
@@ -1,0 +1,77 @@
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Tests.Services;
+
+public class RecurringGenerationServiceTests
+{
+    [Fact]
+    public async Task GeneratePendingRecurringTransactionsAsync_CreatesExpectedTransactions()
+    {
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+
+        var recurring = new RecurringTransaction
+        {
+            Id = Guid.NewGuid().ToString(),
+            Titel = "Abo",
+            Betrag = 12m,
+            Typ = TransactionType.Ausgabe,
+            Startdatum = DateTime.Today.AddMonths(-2),
+            Aktiv = true,
+            KategorieId = "cat-1"
+        };
+
+        recurringRepository.GetRecurringTransactionsAsync()
+            .Returns(new List<RecurringTransaction> { recurring });
+
+        var service = new RecurringGenerationService(recurringRepository, transactionRepository);
+
+        await service.GeneratePendingRecurringTransactionsAsync();
+
+        var savedTransactions = transactionRepository
+            .ReceivedCalls()
+            .Where(call => call.GetMethodInfo().Name == nameof(ITransactionRepository.SaveTransactionAsync))
+            .Select(call => (Transaction)call.GetArguments()[0])
+            .ToList();
+
+        Assert.True(savedTransactions.Count >= 2);
+        Assert.All(savedTransactions, t =>
+        {
+            Assert.Equal(recurring.Id, t.DauerauftragId);
+            Assert.Equal("Abo", t.Titel);
+            Assert.Equal(12m, t.Betrag);
+        });
+
+        await recurringRepository.Received(1).SaveRecurringTransactionAsync(Arg.Is<RecurringTransaction>(r =>
+            r.Id == recurring.Id && r.LetzteAusfuehrung.HasValue));
+    }
+
+    [Fact]
+    public async Task GeneratePendingRecurringTransactionsAsync_IgnoresInactiveItems()
+    {
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+
+        recurringRepository.GetRecurringTransactionsAsync()
+            .Returns(new List<RecurringTransaction>
+            {
+                new()
+                {
+                    Id = Guid.NewGuid().ToString(),
+                    Titel = "Inaktiv",
+                    Betrag = 5m,
+                    Typ = TransactionType.Ausgabe,
+                    Startdatum = DateTime.Today.AddMonths(-3),
+                    Aktiv = false,
+                    KategorieId = "cat-1"
+                }
+            });
+
+        var service = new RecurringGenerationService(recurringRepository, transactionRepository);
+
+        await service.GeneratePendingRecurringTransactionsAsync();
+
+        await transactionRepository.DidNotReceiveWithAnyArgs().SaveTransactionAsync(default!);
+    }
+}

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -36,7 +36,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<ICategoryRepository>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<ITransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<IRecurringTransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
-		builder.Services.AddSingleton<IRecurringGenerationService>(sp => sp.GetRequiredService<LocalDataService>());
+		builder.Services.AddSingleton<IRecurringGenerationService, RecurringGenerationService>();
 		builder.Services.AddSingleton<IReportingService>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<ITransactionValidationService, TransactionValidationService>();
 		builder.Services.AddSingleton<InitializationService>();


### PR DESCRIPTION
Extrahiert die Generierung fälliger Daueraufträge in einen dedizierten Core-Service (RecurringGenerationService), hält LocalDataService über Delegation kompatibel, stellt DI auf die dedizierte IRecurringGenerationService-Implementierung um und ergänzt Unit-Tests. Validierung: Tests grün (25/25), Build net10.0-maccatalyst erfolgreich.