### PR TITLE
♻️ refactor(service): extract reporting aggregation use case

### DIFF
--- a/Finanzuebersicht.Core/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Core/Services/LocalDataService.cs
@@ -124,100 +124,15 @@ public class LocalDataService : IDataService, IDisposable
     // Aggregation: month summary
     public async Task<MonthSummary> GetMonthSummaryAsync(int year, int month)
     {
-        var from = new DateTime(year, month, 1);
-        var to = from.AddMonths(1).AddTicks(-1);
-        var items = await GetTransactionsAsync(from, to);
-        var expenditure = items.Where(t => t.Typ == TransactionType.Ausgabe).ToList();
-
-        var categories = await GetCategoriesAsync();
-        var catDict = categories.ToDictionary(c => c.Id);
-
-        var monthSummary = new MonthSummary
-        {
-            Year = year,
-            Month = month,
-            Total = expenditure.Sum(t => t.Betrag),
-            ByCategory = expenditure
-                .GroupBy(t => t.KategorieId)
-                .Select(g =>
-                {
-                    catDict.TryGetValue(g.Key, out var cat);
-                    return new CategorySummary
-                    {
-                        CategoryId = g.Key,
-                        CategoryName = cat?.Name ?? string.Empty,
-                        Total = g.Sum(t => t.Betrag),
-                        Color = cat?.Color ?? "#007AFF",
-                        Icon = cat?.Icon ?? "📁"
-                    };
-                })
-                .ToList()
-        };
-
-        return monthSummary;
+        var service = new ReportingService(this, this);
+        return await service.GetMonthSummaryAsync(year, month);
     }
 
     // Aggregation: year summary (12 months + by category)
     public async Task<YearSummary> GetYearSummaryAsync(int year)
     {
-        var from = new DateTime(year, 1, 1);
-        var to = new DateTime(year, 12, 31, 23, 59, 59);
-        var items = await GetTransactionsAsync(from, to);
-        var expenditure = items.Where(t => t.Typ == TransactionType.Ausgabe).ToList();
-
-        var categories = await GetCategoriesAsync();
-        var catDict = categories.ToDictionary(c => c.Id);
-
-        var yearSummary = new YearSummary
-        {
-            Year = year,
-            Total = expenditure.Sum(t => t.Betrag)
-        };
-
-        for (int m = 1; m <= 12; m++)
-        {
-            var monthItems = expenditure.Where(t => t.Datum.Month == m).ToList();
-            var ms = new MonthSummary
-            {
-                Year = year,
-                Month = m,
-                Total = monthItems.Sum(t => t.Betrag),
-                ByCategory = monthItems
-                    .GroupBy(t => t.KategorieId)
-                    .Select(g =>
-                    {
-                        catDict.TryGetValue(g.Key, out var cat);
-                        return new CategorySummary
-                        {
-                            CategoryId = g.Key,
-                            CategoryName = cat?.Name ?? string.Empty,
-                            Total = g.Sum(t => t.Betrag),
-                            Color = cat?.Color ?? "#007AFF",
-                            Icon = cat?.Icon ?? "📁"
-                        };
-                    })
-                    .ToList()
-            };
-            yearSummary.Months.Add(ms);
-        }
-
-        yearSummary.ByCategory = expenditure
-            .GroupBy(t => t.KategorieId)
-            .Select(g =>
-            {
-                catDict.TryGetValue(g.Key, out var cat);
-                return new CategorySummary
-                {
-                    CategoryId = g.Key,
-                    CategoryName = cat?.Name ?? string.Empty,
-                    Total = g.Sum(t => t.Betrag),
-                    Color = cat?.Color ?? "#007AFF",
-                    Icon = cat?.Icon ?? "📁"
-                };
-            })
-            .ToList();
-
-        return yearSummary;
+        var service = new ReportingService(this, this);
+        return await service.GetYearSummaryAsync(year);
     }
 
     #endregion

--- a/Finanzuebersicht.Core/Services/ReportingService.cs
+++ b/Finanzuebersicht.Core/Services/ReportingService.cs
@@ -1,0 +1,113 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Services;
+
+public class ReportingService : IReportingService
+{
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly ICategoryRepository _categoryRepository;
+
+    public ReportingService(
+        ITransactionRepository transactionRepository,
+        ICategoryRepository categoryRepository)
+    {
+        _transactionRepository = transactionRepository;
+        _categoryRepository = categoryRepository;
+    }
+
+    public async Task<MonthSummary> GetMonthSummaryAsync(int year, int month)
+    {
+        var from = new DateTime(year, month, 1);
+        var to = from.AddMonths(1).AddTicks(-1);
+        var items = await _transactionRepository.GetTransactionsAsync(from, to);
+        var expenditure = items.Where(t => t.Typ == TransactionType.Ausgabe).ToList();
+
+        var categories = await _categoryRepository.GetCategoriesAsync();
+        var catDict = categories.ToDictionary(c => c.Id);
+
+        return new MonthSummary
+        {
+            Year = year,
+            Month = month,
+            Total = expenditure.Sum(t => t.Betrag),
+            ByCategory = expenditure
+                .GroupBy(t => t.KategorieId)
+                .Select(g =>
+                {
+                    catDict.TryGetValue(g.Key, out var cat);
+                    return new CategorySummary
+                    {
+                        CategoryId = g.Key,
+                        CategoryName = cat?.Name ?? string.Empty,
+                        Total = g.Sum(t => t.Betrag),
+                        Color = cat?.Color ?? "#007AFF",
+                        Icon = cat?.Icon ?? "📁"
+                    };
+                })
+                .ToList()
+        };
+    }
+
+    public async Task<YearSummary> GetYearSummaryAsync(int year)
+    {
+        var from = new DateTime(year, 1, 1);
+        var to = new DateTime(year, 12, 31, 23, 59, 59);
+        var items = await _transactionRepository.GetTransactionsAsync(from, to);
+        var expenditure = items.Where(t => t.Typ == TransactionType.Ausgabe).ToList();
+
+        var categories = await _categoryRepository.GetCategoriesAsync();
+        var catDict = categories.ToDictionary(c => c.Id);
+
+        var yearSummary = new YearSummary
+        {
+            Year = year,
+            Total = expenditure.Sum(t => t.Betrag)
+        };
+
+        for (int m = 1; m <= 12; m++)
+        {
+            var monthItems = expenditure.Where(t => t.Datum.Month == m).ToList();
+            var monthSummary = new MonthSummary
+            {
+                Year = year,
+                Month = m,
+                Total = monthItems.Sum(t => t.Betrag),
+                ByCategory = monthItems
+                    .GroupBy(t => t.KategorieId)
+                    .Select(g =>
+                    {
+                        catDict.TryGetValue(g.Key, out var cat);
+                        return new CategorySummary
+                        {
+                            CategoryId = g.Key,
+                            CategoryName = cat?.Name ?? string.Empty,
+                            Total = g.Sum(t => t.Betrag),
+                            Color = cat?.Color ?? "#007AFF",
+                            Icon = cat?.Icon ?? "📁"
+                        };
+                    })
+                    .ToList()
+            };
+
+            yearSummary.Months.Add(monthSummary);
+        }
+
+        yearSummary.ByCategory = expenditure
+            .GroupBy(t => t.KategorieId)
+            .Select(g =>
+            {
+                catDict.TryGetValue(g.Key, out var cat);
+                return new CategorySummary
+                {
+                    CategoryId = g.Key,
+                    CategoryName = cat?.Name ?? string.Empty,
+                    Total = g.Sum(t => t.Betrag),
+                    Color = cat?.Color ?? "#007AFF",
+                    Icon = cat?.Icon ?? "📁"
+                };
+            })
+            .ToList();
+
+        return yearSummary;
+    }
+}

--- a/Finanzuebersicht.Tests/Services/ReportingServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/ReportingServiceTests.cs
@@ -1,0 +1,67 @@
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Tests.Services;
+
+public class ReportingServiceTests
+{
+    [Fact]
+    public async Task GetMonthSummaryAsync_UsesOnlyExpenseTransactions()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "c1", Name = "Essen", Color = "#FF0000", Icon = "🛒" }
+        });
+
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Betrag = 25m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 6, 5) },
+                new() { Betrag = 10m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 6, 6) },
+                new() { Betrag = 100m, KategorieId = "c1", Typ = TransactionType.Einnahme, Datum = new DateTime(2025, 6, 7) }
+            });
+
+        var service = new ReportingService(transactionRepository, categoryRepository);
+
+        var summary = await service.GetMonthSummaryAsync(2025, 6);
+
+        Assert.Equal(35m, summary.Total);
+        Assert.Single(summary.ByCategory);
+        Assert.Equal("Essen", summary.ByCategory[0].CategoryName);
+        Assert.Equal(35m, summary.ByCategory[0].Total);
+    }
+
+    [Fact]
+    public async Task GetYearSummaryAsync_ComputesTotalsAndMonths()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "c1", Name = "Essen", Color = "#FF0000", Icon = "🛒" },
+            new() { Id = "c2", Name = "Transport", Color = "#007AFF", Icon = "🚗" }
+        });
+
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Betrag = 40m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 1, 3) },
+                new() { Betrag = 20m, KategorieId = "c2", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 2, 15) },
+                new() { Betrag = 200m, KategorieId = "c1", Typ = TransactionType.Einnahme, Datum = new DateTime(2025, 3, 1) }
+            });
+
+        var service = new ReportingService(transactionRepository, categoryRepository);
+
+        var summary = await service.GetYearSummaryAsync(2025);
+
+        Assert.Equal(60m, summary.Total);
+        Assert.Equal(12, summary.Months.Count);
+        Assert.Equal(2, summary.ByCategory.Count);
+        Assert.Contains(summary.ByCategory, c => c.CategoryId == "c1" && c.Total == 40m);
+        Assert.Contains(summary.ByCategory, c => c.CategoryId == "c2" && c.Total == 20m);
+    }
+}

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -37,7 +37,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<ITransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<IRecurringTransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<IRecurringGenerationService, RecurringGenerationService>();
-		builder.Services.AddSingleton<IReportingService>(sp => sp.GetRequiredService<LocalDataService>());
+		builder.Services.AddSingleton<IReportingService, ReportingService>();
 		builder.Services.AddSingleton<ITransactionValidationService, TransactionValidationService>();
 		builder.Services.AddSingleton<InitializationService>();
 		builder.Services.AddSingleton<ThemeService>();


### PR DESCRIPTION
Extrahiert Monats-/Jahresaggregation in einen dedizierten Core-Service (ReportingService), hält LocalDataService per Delegation kompatibel, stellt DI auf die dedizierte IReportingService-Implementierung um und ergänzt Unit-Tests. Validierung: Tests grün (27/27), Build net10.0-maccatalyst erfolgreich.