### PR TITLE
♻️ refactor(service): compose IDataService via facade

### DIFF
--- a/Finanzuebersicht.Core/Services/DataServiceFacade.cs
+++ b/Finanzuebersicht.Core/Services/DataServiceFacade.cs
@@ -1,0 +1,62 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Services;
+
+public class DataServiceFacade : IDataService
+{
+    private readonly ICategoryRepository _categoryRepository;
+    private readonly ITransactionRepository _transactionRepository;
+    private readonly IRecurringTransactionRepository _recurringRepository;
+    private readonly IRecurringGenerationService _recurringGenerationService;
+    private readonly IReportingService _reportingService;
+
+    public DataServiceFacade(
+        ICategoryRepository categoryRepository,
+        ITransactionRepository transactionRepository,
+        IRecurringTransactionRepository recurringRepository,
+        IRecurringGenerationService recurringGenerationService,
+        IReportingService reportingService)
+    {
+        _categoryRepository = categoryRepository;
+        _transactionRepository = transactionRepository;
+        _recurringRepository = recurringRepository;
+        _recurringGenerationService = recurringGenerationService;
+        _reportingService = reportingService;
+    }
+
+    public Task<List<Category>> GetCategoriesAsync()
+        => _categoryRepository.GetCategoriesAsync();
+
+    public Task SaveCategoryAsync(Category category)
+        => _categoryRepository.SaveCategoryAsync(category);
+
+    public Task DeleteCategoryAsync(string id)
+        => _categoryRepository.DeleteCategoryAsync(id);
+
+    public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum)
+        => _transactionRepository.GetTransactionsAsync(vonDatum, bisDatum);
+
+    public Task SaveTransactionAsync(Transaction transaction)
+        => _transactionRepository.SaveTransactionAsync(transaction);
+
+    public Task DeleteTransactionAsync(string id)
+        => _transactionRepository.DeleteTransactionAsync(id);
+
+    public Task<List<RecurringTransaction>> GetRecurringTransactionsAsync()
+        => _recurringRepository.GetRecurringTransactionsAsync();
+
+    public Task SaveRecurringTransactionAsync(RecurringTransaction recurring)
+        => _recurringRepository.SaveRecurringTransactionAsync(recurring);
+
+    public Task DeleteRecurringTransactionAsync(string id)
+        => _recurringRepository.DeleteRecurringTransactionAsync(id);
+
+    public Task GeneratePendingRecurringTransactionsAsync()
+        => _recurringGenerationService.GeneratePendingRecurringTransactionsAsync();
+
+    public Task<YearSummary> GetYearSummaryAsync(int year)
+        => _reportingService.GetYearSummaryAsync(year);
+
+    public Task<MonthSummary> GetMonthSummaryAsync(int year, int month)
+        => _reportingService.GetMonthSummaryAsync(year, month);
+}

--- a/Finanzuebersicht.Core/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Core/Services/LocalDataService.cs
@@ -5,10 +5,10 @@ using Finanzuebersicht.Models;
 namespace Finanzuebersicht.Services;
 
 /// <summary>
-/// Lokale JSON-basierte Implementierung von IDataService.
+/// Lokale JSON-basierte Implementierung der Repository-Ports.
 /// Unterstützt einen konfigurierbaren Speicherpfad (z.B. iCloud Drive).
 /// </summary>
-public class LocalDataService : IDataService, IDisposable
+public class LocalDataService : ICategoryRepository, ITransactionRepository, IRecurringTransactionRepository, IDisposable
 {
     private static readonly string DefaultDataDir = AppPaths.GetDefaultDataDir();
 

--- a/Finanzuebersicht.Tests/Services/DataServiceFacadeTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataServiceFacadeTests.cs
@@ -1,0 +1,52 @@
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Tests.Services;
+
+public class DataServiceFacadeTests
+{
+    [Fact]
+    public async Task GeneratePendingRecurringTransactionsAsync_DelegatesToRecurringGenerationService()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var recurringGenerationService = Substitute.For<IRecurringGenerationService>();
+        var reportingService = Substitute.For<IReportingService>();
+
+        var facade = new DataServiceFacade(
+            categoryRepository,
+            transactionRepository,
+            recurringRepository,
+            recurringGenerationService,
+            reportingService);
+
+        await facade.GeneratePendingRecurringTransactionsAsync();
+
+        await recurringGenerationService.Received(1).GeneratePendingRecurringTransactionsAsync();
+    }
+
+    [Fact]
+    public async Task GetYearSummaryAsync_DelegatesToReportingService()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var recurringGenerationService = Substitute.For<IRecurringGenerationService>();
+        var reportingService = Substitute.For<IReportingService>();
+
+        var expected = new YearSummary { Year = 2025, Total = 123m };
+        reportingService.GetYearSummaryAsync(2025).Returns(expected);
+
+        var facade = new DataServiceFacade(
+            categoryRepository,
+            transactionRepository,
+            recurringRepository,
+            recurringGenerationService,
+            reportingService);
+
+        var result = await facade.GetYearSummaryAsync(2025);
+
+        Assert.Same(expected, result);
+    }
+}

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -32,12 +32,12 @@ public static class MauiProgram
 		builder.Services.AddSingleton<SettingsService>();
 		builder.Services.AddSingleton<LocalDataService>(sp =>
 			new LocalDataService(sp.GetRequiredService<SettingsService>()));
-		builder.Services.AddSingleton<IDataService>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<ICategoryRepository>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<ITransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<IRecurringTransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
 		builder.Services.AddSingleton<IRecurringGenerationService, RecurringGenerationService>();
 		builder.Services.AddSingleton<IReportingService, ReportingService>();
+		builder.Services.AddSingleton<IDataService, DataServiceFacade>();
 		builder.Services.AddSingleton<ITransactionValidationService, TransactionValidationService>();
 		builder.Services.AddSingleton<InitializationService>();
 		builder.Services.AddSingleton<ThemeService>();


### PR DESCRIPTION
Führt DataServiceFacade als explizite Komposition von Repository- und Domain-Services ein, verdrahtet IDataService in DI auf diese Fassade, verengt LocalDataService auf Repository-Ports und ergänzt Unit-Tests für Delegation. Validierung: Tests grün (29/29), Build net10.0-maccatalyst erfolgreich.