### PR TITLE
♻️ refactor(converter): zentralisiere Farbauflösung in Convertern

### DIFF
--- a/Finanzuebersicht/Converters/ColorResourceHelper.cs
+++ b/Finanzuebersicht/Converters/ColorResourceHelper.cs
@@ -1,0 +1,26 @@
+namespace Finanzuebersicht.Converters;
+
+internal static class ColorResourceHelper
+{
+    public static Color GetColor(string resourceKey, Color fallback)
+    {
+        if (Application.Current?.Resources.TryGetValue(resourceKey, out var resource) == true)
+        {
+            if (resource is Color color)
+                return color;
+
+            if (resource is SolidColorBrush brush)
+                return brush.Color;
+        }
+
+        return fallback;
+    }
+
+    public static Color GetThemeColor(string lightResourceKey, string darkResourceKey, Color lightFallback, Color darkFallback)
+    {
+        var isDarkTheme = Application.Current?.RequestedTheme == AppTheme.Dark;
+        return isDarkTheme
+            ? GetColor(darkResourceKey, darkFallback)
+            : GetColor(lightResourceKey, lightFallback);
+    }
+}

--- a/Finanzuebersicht/Converters/DashboardConverters.cs
+++ b/Finanzuebersicht/Converters/DashboardConverters.cs
@@ -7,9 +7,11 @@ public class BilanzColorConverter : IValueConverter
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is decimal bilanz)
-            return bilanz >= 0 ? Color.FromArgb("#34C759") : Color.FromArgb("#FF3B30");
+            return bilanz >= 0
+                ? ColorResourceHelper.GetColor("Einnahme", Color.FromArgb("#34C759"))
+                : ColorResourceHelper.GetColor("Ausgabe", Color.FromArgb("#FF3B30"));
 
-        return Colors.Gray;
+        return ColorResourceHelper.GetColor("Gray600", Colors.Gray);
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -64,7 +66,9 @@ public class BilanzDisplayConverter : IValueConverter
 public class ToggleActiveColorConverter : IValueConverter
 {
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => value is true ? Color.FromArgb("#007AFF") : Colors.Transparent;
+        => value is true
+            ? ColorResourceHelper.GetColor("Primary", Color.FromArgb("#007AFF"))
+            : Colors.Transparent;
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();
@@ -73,7 +77,9 @@ public class ToggleActiveColorConverter : IValueConverter
 public class ToggleActiveTextColorConverter : IValueConverter
 {
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
-        => value is true ? Colors.White : Color.FromArgb("#007AFF");
+        => value is true
+            ? ColorResourceHelper.GetColor("White", Colors.White)
+            : ColorResourceHelper.GetColor("Primary", Color.FromArgb("#007AFF"));
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();

--- a/Finanzuebersicht/Converters/ThemeConverters.cs
+++ b/Finanzuebersicht/Converters/ThemeConverters.cs
@@ -14,13 +14,15 @@ public class ThemeButtonConverter : IValueConverter
         {
             if (selected == idx)
             {
-                return Application.Current?.Resources.TryGetValue("Primary", out var primary) == true
-                    ? primary : Colors.Blue;
+                return ColorResourceHelper.GetColor("Primary", Colors.Blue);
             }
         }
-        return Application.Current?.RequestedTheme == AppTheme.Dark
-            ? Color.FromArgb("#3A3A3C")
-            : Color.FromArgb("#E5E5EA");
+
+        return ColorResourceHelper.GetThemeColor(
+            "Gray200",
+            "Gray900",
+            Color.FromArgb("#E5E5EA"),
+            Color.FromArgb("#3A3A3C"));
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -38,10 +40,14 @@ public class ThemeButtonTextConverter : IValueConverter
         if (value is int selected && parameter is string paramStr && int.TryParse(paramStr, out var idx))
         {
             if (selected == idx)
-                return Colors.White;
+                return ColorResourceHelper.GetColor("White", Colors.White);
         }
-        return Application.Current?.RequestedTheme == AppTheme.Dark
-            ? Colors.White : Color.FromArgb("#000000");
+
+        return ColorResourceHelper.GetThemeColor(
+            "Black",
+            "White",
+            Color.FromArgb("#000000"),
+            Colors.White);
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)


### PR DESCRIPTION
## Zusammenfassung
- fügt ColorResourceHelper für zentrale Farbauflösung aus Ressourcen hinzu
- ersetzt hardcodierte Hex-Farben in Dashboard- und Theme-Convertern durch Resource-Keys aus Colors.xaml
- behält bestehendes Verhalten über Fallback-Farben bei

## Validierung
- Tests: 29/29 grün (runTests full run)
- Build: dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst erfolgreich (nur bestehende MAUI-Deprecation-Warnings)

## Betroffene Dateien
- Finanzuebersicht/Converters/ColorResourceHelper.cs
- Finanzuebersicht/Converters/DashboardConverters.cs
- Finanzuebersicht/Converters/ThemeConverters.cs
