### PR TITLE
🐛 fix(ui): entferne veraltete controls in YearOverviewPage

### DIFF
--- a/Finanzuebersicht/Views/YearOverviewPage.xaml
+++ b/Finanzuebersicht/Views/YearOverviewPage.xaml
@@ -6,24 +6,22 @@
              Title="{loc:Translate Title_Jahresansicht}">
     <ScrollView>
         <VerticalStackLayout Padding="15" Spacing="15">
-            <Label Text="{loc:Translate Title_Jahresansicht}" FontSize="Large" FontAttributes="Bold" />
+            <Label Text="{loc:Translate Title_Jahresansicht}" FontSize="22" FontAttributes="Bold" />
             <Label Text="{Binding Year, StringFormat='Jahr: {0}'}" FontSize="16" />
             <Label Text="{Binding YearTotal, StringFormat='Jahressumme: {0:N2}€'}" FontSize="14" FontAttributes="Bold" />
 
             <Label Text="{loc:Translate Lbl_KategorienColon}" FontSize="14" FontAttributes="Bold" Margin="0,10,0,0" />
-            <ListView ItemsSource="{Binding Categories}" HasUnevenRows="True" SelectionMode="None">
-                <ListView.ItemTemplate>
+            <CollectionView ItemsSource="{Binding Categories}" SelectionMode="None">
+                <CollectionView.ItemTemplate>
                     <DataTemplate>
-                        <ViewCell>
-                            <Grid ColumnDefinitions="*,Auto,Auto" Padding="12">
-                                <Label Text="{Binding CategoryName}" Grid.Column="0" VerticalOptions="Center" />
-                                <Label Text="{Binding Total, StringFormat='{0:N2}€'}" Grid.Column="1" VerticalOptions="Center" HorizontalOptions="End" TextColor="Gray" />
-                                <Label Text="{Binding PercentageDisplay}" Grid.Column="2" VerticalOptions="Center" HorizontalOptions="End" FontAttributes="Bold" />
-                            </Grid>
-                        </ViewCell>
+                        <Grid ColumnDefinitions="*,Auto,Auto" Padding="12">
+                            <Label Text="{Binding CategoryName}" Grid.Column="0" VerticalOptions="Center" />
+                            <Label Text="{Binding Total, StringFormat='{0:N2}€'}" Grid.Column="1" VerticalOptions="Center" HorizontalOptions="End" TextColor="Gray" />
+                            <Label Text="{Binding PercentageDisplay}" Grid.Column="2" VerticalOptions="Center" HorizontalOptions="End" FontAttributes="Bold" />
+                        </Grid>
                     </DataTemplate>
-                </ListView.ItemTemplate>
-            </ListView>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
 
         </VerticalStackLayout>
     </ScrollView>


### PR DESCRIPTION
## Zusammenfassung
- ersetzt ListView/ViewCell durch CollectionView in der Jahresübersicht
- ersetzt NamedSize-Fontangabe durch numerische FontSize
- entfernt die bisherigen MAUI-Deprecation-Warnungen aus diesem Screen

## Validierung
- Build: dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst => 0 Warnung(en), 0 Fehler
- Tests: 29/29 grün

## Betroffene Datei
- Finanzuebersicht/Views/YearOverviewPage.xaml