### PR TITLE
🐛 fix(config): resolve prerelease workflow failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,10 +53,12 @@ jobs:
           cd Finanzuebersicht
           dotnet build -f net10.0-maccatalyst \
             -c Release \
+            -p:TargetFrameworks=net10.0-maccatalyst \
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
             -p:CodesignProvision="" \
-            -p:MtouchLink=SdkOnly \
+            -p:MtouchLink=None \
+            -p:UseInterpreter=true \
             -p:EnableILLink=false
 
       - name: Upload Mac Catalyst artifact
@@ -94,7 +96,7 @@ jobs:
       - name: Build Windows
         run: |
           cd Finanzuebersicht
-          dotnet build -f net10.0-windows10.0.19041.0 -c Release
+          dotnet build -f net10.0-windows10.0.19041.0 -c Release -p:TargetFrameworks=net10.0-windows10.0.19041.0
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -59,10 +59,12 @@ jobs:
           cd Finanzuebersicht
           dotnet build -f net10.0-maccatalyst \
             -c Release \
+            -p:TargetFrameworks=net10.0-maccatalyst \
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
             -p:CodesignProvision="" \
-            -p:MtouchLink=SdkOnly \
+            -p:MtouchLink=None \
+            -p:UseInterpreter=true \
             -p:EnableILLink=false
 
       - name: Pack macOS artifact
@@ -99,7 +101,7 @@ jobs:
       - name: Build Windows
         run: |
           cd Finanzuebersicht
-          dotnet build -f net10.0-windows10.0.19041.0 -c Release
+          dotnet build -f net10.0-windows10.0.19041.0 -c Release -p:TargetFrameworks=net10.0-windows10.0.19041.0
 
       - name: Pack Windows artifact
         shell: pwsh


### PR DESCRIPTION
## Zusammenfassung
Behebt die fehlgeschlagenen Pre-Release/CI-Builds auf GitHub Actions für Windows und Mac Catalyst.

## Ursache
- Windows-Job hat wegen Multi-Target-Projekt zusätzliche Workloads eingefordert (u. a. iOS)
- Mac Catalyst-Job ist auf Hosted Runnern in Linker/API-Verfügbarkeitsfehler gelaufen

## Änderungen
- Build-Aufrufe auf platform-spezifische TargetFrameworks begrenzt
- Mac Catalyst Build in CI/Pre-Release auf MtouchLink=None + UseInterpreter=true gestellt
- Release-Artefaktpfade und Packaging unverändert

## Betroffene Dateien
- .github/workflows/ci.yml
- .github/workflows/prerelease.yml