### PR TITLE
🐛 fix(config): fix remaining prerelease asset-resolution failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Install .NET MAUI workloads
         run: dotnet workload install maui-ios maui-maccatalyst
 
+      - name: Restore dependencies
+        run: dotnet restore Finanzuebersicht/Finanzuebersicht.csproj
+
       - name: Get version
         id: version
         run: |
@@ -53,7 +56,6 @@ jobs:
           cd Finanzuebersicht
           dotnet build -f net10.0-maccatalyst \
             -c Release \
-            -p:TargetFrameworks=net10.0-maccatalyst \
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
             -p:CodesignProvision="" \
@@ -85,7 +87,10 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Install .NET MAUI workloads
-        run: dotnet workload install maui-windows
+        run: dotnet workload install maui-windows maui-ios maui-maccatalyst
+
+      - name: Restore dependencies
+        run: dotnet restore Finanzuebersicht/Finanzuebersicht.csproj
 
       - name: Get version
         id: version
@@ -96,7 +101,7 @@ jobs:
       - name: Build Windows
         run: |
           cd Finanzuebersicht
-          dotnet build -f net10.0-windows10.0.19041.0 -c Release -p:TargetFrameworks=net10.0-windows10.0.19041.0
+          dotnet build -f net10.0-windows10.0.19041.0 -c Release
 
       - name: Upload Windows artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -54,12 +54,14 @@ jobs:
       - name: Install .NET MAUI workloads
         run: dotnet workload install maui-maccatalyst maui-ios
 
+      - name: Restore dependencies
+        run: dotnet restore Finanzuebersicht/Finanzuebersicht.csproj
+
       - name: Build Mac Catalyst (unsigned)
         run: |
           cd Finanzuebersicht
           dotnet build -f net10.0-maccatalyst \
             -c Release \
-            -p:TargetFrameworks=net10.0-maccatalyst \
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
             -p:CodesignProvision="" \
@@ -96,12 +98,15 @@ jobs:
           dotnet-version: '10.0.x'
 
       - name: Install .NET MAUI workloads
-        run: dotnet workload install maui-windows
+        run: dotnet workload install maui-windows maui-ios maui-maccatalyst
+
+      - name: Restore dependencies
+        run: dotnet restore Finanzuebersicht/Finanzuebersicht.csproj
 
       - name: Build Windows
         run: |
           cd Finanzuebersicht
-          dotnet build -f net10.0-windows10.0.19041.0 -c Release -p:TargetFrameworks=net10.0-windows10.0.19041.0
+          dotnet build -f net10.0-windows10.0.19041.0 -c Release
 
       - name: Pack Windows artifact
         shell: pwsh


### PR DESCRIPTION
## Zusammenfassung
Follow-up-Fix für den fehlgeschlagenen Pre-Release-Run nach PR #56.

## Restfehler aus Run 22691038820
- Assets-Dateien für referenzierte net10.0-Projekte enthielten keinen passenden Target-Eintrag
- Betraf macOS- und Windows-Job

## Änderungen
- Entfernt die TargetFrameworks-Override in Build-Aufrufen
- Fügt expliziten dotnet restore für Finanzuebersicht.csproj in CI/Pre-Release Jobs hinzu
- Windows-Jobs installieren wieder die benötigten MAUI-Workloads für die Multi-Target-Lösung

## Betroffene Dateien
- .github/workflows/ci.yml
- .github/workflows/prerelease.yml