### PR TITLE
🐛 fix(config): stabilize macOS prerelease build on hosted runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,9 +59,10 @@ jobs:
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
             -p:CodesignProvision="" \
-            -p:MtouchLink=None \
+            -p:MtouchLink=SdkOnly \
             -p:UseInterpreter=true \
-            -p:EnableILLink=false
+            -p:EnableILLink=false \
+            -p:PublishTrimmed=false
 
       - name: Upload Mac Catalyst artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -65,9 +65,10 @@ jobs:
             -p:ValidateXcodeVersion=false \
             -p:CodesignKey="" \
             -p:CodesignProvision="" \
-            -p:MtouchLink=None \
+            -p:MtouchLink=SdkOnly \
             -p:UseInterpreter=true \
-            -p:EnableILLink=false
+            -p:EnableILLink=false \
+            -p:PublishTrimmed=false
 
       - name: Pack macOS artifact
         shell: bash


### PR DESCRIPTION
## Zusammenfassung
Der Mac Catalyst Build scheitert auf GitHub Hosted Runnern wegen Xcode/SDK-Mismatch im Linker-Setup.

## Änderungen
- .github/workflows/prerelease.yml: Mac Build auf MtouchLink=SdkOnly umgestellt
- .github/workflows/prerelease.yml: PublishTrimmed=false ergänzt
- .github/workflows/ci.yml: identische Anpassung für konsistentes Verhalten

## Warum
Auf macos-15 (Xcode 16.4) führt das bisherige Setup in Kombination mit .NET 10 MacCatalyst SDK zu MT0180/MT2301 und NETSDK1144.

## Ziel
Stabiler macOS Build in CI/Pre-Release bis ein Runner mit kompatiblerem Xcode verfügbar ist.
