### PR TITLE
✨ feat(workflow): add Stryker mutation testing job to CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,6 +43,7 @@ jobs:
         run: |
           export PATH="$PATH:$HOME/.dotnet/tools"
           cd Finanzuebersicht.Core
+          dotnet build -c Debug
           dotnet-stryker --test-project ../Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj --log-to-file
 
   build:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,13 +35,15 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.100'
+      - name: Restore dependencies
+        run: dotnet restore Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
       - name: Install Stryker
         run: dotnet tool install -g dotnet-stryker
       - name: Run Stryker mutation tests
         run: |
+          export PATH="$PATH:$HOME/.dotnet/tools"
           cd Finanzuebersicht.Core
-          dotnet tool install -g dotnet-stryker --no-cache
-          ~/.dotnet/tools/dotnet-stryker --test-project ../Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
+          dotnet-stryker --test-project ../Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj --log-to-file
 
   build:
     name: Build (Mac Catalyst)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install Stryker
         run: dotnet tool install -g dotnet-stryker
       - name: Run Stryker mutation tests
-        run: dotnet stryker --project-files Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
+        run: dotnet stryker --test-project Finanzuebersicht.Tests
 
   build:
     name: Build (Mac Catalyst)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,8 @@ jobs:
         uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '10.0.100'
+      - name: Install Stryker
+        run: dotnet tool install -g dotnet-stryker
       - name: Run Stryker mutation tests
         run: dotnet stryker --project-files Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,6 +31,8 @@ jobs:
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
       - name: Setup .NET
         uses: actions/setup-dotnet@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,20 @@ jobs:
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --logger "console;verbosity=minimal"
 
+  mutation-test:
+    name: Mutation Tests (Stryker)
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v4
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: '10.0.100'
+      - name: Run Stryker mutation tests
+        run: dotnet stryker --project-files Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
+
   build:
     name: Build (Mac Catalyst)
     runs-on: macos-15

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,10 @@ jobs:
       - name: Install Stryker
         run: dotnet tool install -g dotnet-stryker
       - name: Run Stryker mutation tests
-        run: dotnet stryker --test-project Finanzuebersicht.Tests
+        run: |
+          cd Finanzuebersicht.Core
+          dotnet tool install -g dotnet-stryker --no-cache
+          ~/.dotnet/tools/dotnet-stryker --test-project ../Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
 
   build:
     name: Build (Mac Catalyst)

--- a/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
+++ b/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
@@ -5,6 +5,7 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <IsPackable>false</IsPackable>
+    <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Finanzuebersicht.Tests/Services/ImportServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/ImportServiceTests.cs
@@ -20,8 +20,8 @@ namespace Finanzuebersicht.Tests.Services
 
             var dtos = new List<TransactionDto>
             {
-                new TransactionDto { Buchungsdatum = System.DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "A" },
-                new TransactionDto { Buchungsdatum = System.DateTime.Today, Betrag = -5m, Zahlungsempfaenger = "B" }
+                new TransactionDto { Buchungsdatum = System.DateTime.Today, Betrag = 10m, Verwendungszweck = "A" },
+                new TransactionDto { Buchungsdatum = System.DateTime.Today, Betrag = -5m, Verwendungszweck = "B" }
             };
 
             parser.Parse(Arg.Any<Stream>()).Returns(dtos);
@@ -34,6 +34,129 @@ namespace Finanzuebersicht.Tests.Services
 
             Assert.Equal(2, result.Count);
             repo.Received(2).SaveTransactionAsync(Arg.Any<Transaction>());
+        }
+
+        [Fact]
+        public void ImportFromCsv_WithEmptyStream_ReturnsEmpty()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+
+            parser.Parse(Arg.Any<Stream>()).Returns(Enumerable.Empty<TransactionDto>());
+
+            var logger = Substitute.For<ILogger<ImportService>>();
+            var svc = new ImportService(new[] { parser }, repo, logger);
+
+            using var ms = new MemoryStream();
+            var result = svc.ImportFromCsv(ms).ToList();
+
+            Assert.Empty(result);
+            repo.DidNotReceive().SaveTransactionAsync(Arg.Any<Transaction>());
+        }
+
+        [Fact]
+        public void ImportFromCsv_WithMultipleParsers_UsesFirstMatchingParser()
+        {
+            var parser1 = Substitute.For<IStatementParser>();
+            var parser2 = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+
+            var dtos = new List<TransactionDto>
+            {
+                new TransactionDto { Buchungsdatum = System.DateTime.Today, Betrag = 50m, Verwendungszweck = "Parser2" }
+            };
+
+            parser1.Parse(Arg.Any<Stream>()).Returns(Enumerable.Empty<TransactionDto>());
+            parser2.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            var logger = Substitute.For<ILogger<ImportService>>();
+            var svc = new ImportService(new[] { parser1, parser2 }, repo, logger);
+
+            using var ms = new MemoryStream();
+            var result = svc.ImportFromCsv(ms).ToList();
+
+            Assert.Single(result);
+            Assert.Equal("Parser2", result[0].Verwendungszweck);
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(-100)]
+        [InlineData(10000)]
+        public void ImportFromCsv_WithVariousAmounts_PersistsCorrectly(decimal amount)
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+
+            var dtos = new List<TransactionDto>
+            {
+                new TransactionDto { Buchungsdatum = System.DateTime.Today, Betrag = amount, Verwendungszweck = "Test" }
+            };
+
+            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            var logger = Substitute.For<ILogger<ImportService>>();
+            var svc = new ImportService(new[] { parser }, repo, logger);
+
+            using var ms = new MemoryStream();
+            var result = svc.ImportFromCsv(ms).ToList();
+
+            Assert.Single(result);
+            Assert.Equal(amount, result[0].Betrag);
+        }
+
+        [Theory]
+        [InlineData("")]
+        [InlineData("Short")]
+        [InlineData("This is a very long description that should still be handled correctly")]
+        public void ImportFromCsv_WithVariousDescriptions_PersistsCorrectly(string description)
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+
+            var dtos = new List<TransactionDto>
+            {
+                new TransactionDto { Buchungsdatum = System.DateTime.Today, Betrag = 10m, Verwendungszweck = description }
+            };
+
+            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            var logger = Substitute.For<ILogger<ImportService>>();
+            var svc = new ImportService(new[] { parser }, repo, logger);
+
+            using var ms = new MemoryStream();
+            var result = svc.ImportFromCsv(ms).ToList();
+
+            Assert.Single(result);
+            Assert.Equal(description, result[0].Verwendungszweck);
+        }
+
+        [Fact]
+        public void ImportFromCsv_PastAndFutureDates_BothHandledCorrectly()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+
+            var pastDate = System.DateTime.Today.AddDays(-30);
+            var futureDate = System.DateTime.Today.AddDays(30);
+
+            var dtos = new List<TransactionDto>
+            {
+                new TransactionDto { Buchungsdatum = pastDate, Betrag = 10m, Verwendungszweck = "Past" },
+                new TransactionDto { Buchungsdatum = futureDate, Betrag = 20m, Verwendungszweck = "Future" }
+            };
+
+            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            var logger = Substitute.For<ILogger<ImportService>>();
+            var svc = new ImportService(new[] { parser }, repo, logger);
+
+            using var ms = new MemoryStream();
+            var result = svc.ImportFromCsv(ms).ToList();
+
+            Assert.Equal(2, result.Count);
+            Assert.Equal(pastDate.Date, result[0].Datum.Date);
+            Assert.Equal(futureDate.Date, result[1].Datum.Date);
         }
     }
 }


### PR DESCRIPTION
Add Stryker mutation testing job to CI pipeline that runs on PRs only.

- Added mutation-test job that runs after test job completes
- Runs only on pull_request events (not on main branch pushes)
- Executes Stryker for Finanzuebersicht.Tests project
- Validates test quality via mutation testing

This ensures we catch poor test coverage early via mutation testing, while saving free-tier CI minutes by skipping the job on main branch.