### PR TITLE
🐛 fix(config): bump DependencyInjection.Abstractions to 10.0.6

### DIFF
--- a/Finanzuebersicht.Infrastructure/Finanzuebersicht.Infrastructure.csproj
+++ b/Finanzuebersicht.Infrastructure/Finanzuebersicht.Infrastructure.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.5" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Problem

After merging #90 (Microsoft.NET.Test.Sdk 18.4.0), CI failed with:

```
error NU1605: Detected package downgrade: Microsoft.Extensions.DependencyInjection.Abstractions from 10.0.6 to 10.0.5
```

## Root Cause

`Finanzuebersicht.Core` uses `Microsoft.Extensions.Logging.Abstractions` with floating version (`*`), which resolved to `10.0.6`. That package requires `DependencyInjection.Abstractions >= 10.0.6`, but `Finanzuebersicht.Infrastructure` had it pinned to `10.0.5`.

## Fix

Bump `Microsoft.Extensions.DependencyInjection.Abstractions` in Infrastructure from `10.0.5` → `10.0.6`.

## Testing
- ✅ `dotnet restore` succeeds
- ✅ 118/118 tests pass

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>