### PR TITLE
✨ feat(charts): bar chart dark mode, trend indicator & forecast bar (#52)

### DIFF
--- a/Finanzuebersicht/Charts/BarChartDrawable.cs
+++ b/Finanzuebersicht/Charts/BarChartDrawable.cs
@@ -96,7 +96,7 @@ public class BarChartDrawable : IDrawable
         for (int i = 0; i < 12; i++)
         {
             var month = Months.FirstOrDefault(m => m.Month == i + 1);
-            bool isForecast = (i + 1) == ForecastMonth && month == null;
+            bool isForecast = (i + 1) == ForecastMonth && ForecastValue > 0 && (month?.Total ?? 0) == 0;
             decimal value = isForecast ? ForecastValue : (month?.Total ?? 0);
 
             float x = paddingLeft + i * barWidth + barSpacing / 2;

--- a/Finanzuebersicht/Charts/BarChartDrawable.cs
+++ b/Finanzuebersicht/Charts/BarChartDrawable.cs
@@ -8,7 +8,8 @@ namespace Finanzuebersicht.Charts;
 
 /// <summary>
 /// Zeichnet ein Balkendiagramm für den 12-Monats-Verlauf mit MAUI Graphics.
-/// Unterstützt Forecast-Balken (gestrichelt) und Budget-Referenzlinie.
+/// Unterstützt einen semi-transparenten Forecast-Balken mit "~"-Kennzeichnung
+/// und eine Budget-Referenzlinie.
 /// </summary>
 public class BarChartDrawable : IDrawable
 {
@@ -16,16 +17,17 @@ public class BarChartDrawable : IDrawable
         ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
 
     private static Color BarColor =>
-        ColorResourceHelper.GetThemeColor("Primary", "Primary",
+        ColorResourceHelper.GetThemeColor("Primary", "PrimaryDark",
             Color.FromArgb("#007AFF"), Color.FromArgb("#0A84FF"));
 
     private static Color BarColorForecast =>
-        ColorResourceHelper.GetThemeColor("Primary", "Primary",
+        ColorResourceHelper.GetThemeColor("Primary", "PrimaryDark",
             Color.FromArgb("#007AFF"), Color.FromArgb("#0A84FF"))
         .WithAlpha(0.35f);
 
     private static Color HighlightColor =>
-        Color.FromArgb("#FF3B30");
+        ColorResourceHelper.GetThemeColor("Ausgabe", "AusgabeDark",
+            Color.FromArgb("#FF3B30"), Color.FromArgb("#FF453A"));
 
     private static Color TextColor =>
         ColorResourceHelper.GetThemeColor("Gray600", "Gray400",
@@ -65,9 +67,11 @@ public class BarChartDrawable : IDrawable
         float chartWidth = dirtyRect.Width - paddingLeft - paddingRight;
         float chartHeight = dirtyRect.Height - paddingTop - paddingBottom;
 
-        // Max-Wert berücksichtigt Forecast und Budget für korrekte Skalierung
+        // Max-Wert: Forecast nur einberechnen wenn er tatsächlich gezeichnet wird
         decimal maxVal = Months.Count > 0 ? Months.Max(m => m.Total) : 0;
-        if (ForecastMonth > 0) maxVal = Math.Max(maxVal, ForecastValue);
+        var forecastMonthActual = Months.FirstOrDefault(m => m.Month == ForecastMonth)?.Total ?? 0;
+        bool showForecast = ForecastMonth > 0 && ForecastValue > 0 && forecastMonthActual == 0;
+        if (showForecast) maxVal = Math.Max(maxVal, ForecastValue);
         if (MonthlyBudgetTotal > 0) maxVal = Math.Max(maxVal, MonthlyBudgetTotal);
         if (maxVal <= 0) maxVal = 1;
 
@@ -96,7 +100,7 @@ public class BarChartDrawable : IDrawable
         for (int i = 0; i < 12; i++)
         {
             var month = Months.FirstOrDefault(m => m.Month == i + 1);
-            bool isForecast = (i + 1) == ForecastMonth && ForecastValue > 0 && (month?.Total ?? 0) == 0;
+            bool isForecast = showForecast && (i + 1) == ForecastMonth;
             decimal value = isForecast ? ForecastValue : (month?.Total ?? 0);
 
             float x = paddingLeft + i * barWidth + barSpacing / 2;

--- a/Finanzuebersicht/Charts/BarChartDrawable.cs
+++ b/Finanzuebersicht/Charts/BarChartDrawable.cs
@@ -1,31 +1,59 @@
+using Finanzuebersicht.Converters;
 using Finanzuebersicht.Models;
 using Microsoft.Maui.Graphics;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 
 namespace Finanzuebersicht.Charts;
 
 /// <summary>
 /// Zeichnet ein Balkendiagramm für den 12-Monats-Verlauf mit MAUI Graphics.
+/// Unterstützt Forecast-Balken (gestrichelt) und Budget-Referenzlinie.
 /// </summary>
 public class BarChartDrawable : IDrawable
 {
-    private static readonly Color BarColor = Color.FromArgb("#007AFF");
-    private static readonly Color BarColorLight = Color.FromArgb("#5AC8FA");
-    private static readonly Color TextColor = Color.FromArgb("#8E8E93");
-    private static readonly Color GridColor = Color.FromArgb("#E5E5EA");
-    private static readonly Color HighlightColor = Color.FromArgb("#FF3B30");
-
     private static readonly string[] MonthLabels =
         ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
 
+    private static Color BarColor =>
+        ColorResourceHelper.GetThemeColor("Primary", "Primary",
+            Color.FromArgb("#007AFF"), Color.FromArgb("#0A84FF"));
+
+    private static Color BarColorForecast =>
+        ColorResourceHelper.GetThemeColor("Primary", "Primary",
+            Color.FromArgb("#007AFF"), Color.FromArgb("#0A84FF"))
+        .WithAlpha(0.35f);
+
+    private static Color HighlightColor =>
+        Color.FromArgb("#FF3B30");
+
+    private static Color TextColor =>
+        ColorResourceHelper.GetThemeColor("Gray600", "Gray400",
+            Color.FromArgb("#8E8E93"), Color.FromArgb("#AEAEB2"));
+
+    private static Color GridColor =>
+        ColorResourceHelper.GetThemeColor("Gray200", "Gray700",
+            Color.FromArgb("#E5E5EA"), Color.FromArgb("#3A3A3C"));
+
+    private static Color BudgetLineColor =>
+        ColorResourceHelper.GetThemeColor("Gray500", "Gray400",
+            Color.FromArgb("#AEAEB2"), Color.FromArgb("#636366"));
+
     public IReadOnlyList<MonthSummary> Months { get; set; } = [];
-    public int CurrentMonth { get; set; } = Finanzuebersicht.Core.Services.SystemClock.Instance.Today.Month; // TODO: consider injecting IClock into drawable host (not straightforward from drawable)
+    public int CurrentMonth { get; set; } = Finanzuebersicht.Core.Services.SystemClock.Instance.Today.Month;
+
+    /// <summary>Monat (1–12) für den Forecast-Balken, 0 = kein Forecast.</summary>
+    public int ForecastMonth { get; set; }
+
+    /// <summary>Forecast-Betrag für den Forecast-Balken.</summary>
+    public decimal ForecastValue { get; set; }
+
+    /// <summary>Monatliches Gesamtbudget als horizontale Referenzlinie, 0 = keine Linie.</summary>
+    public decimal MonthlyBudgetTotal { get; set; }
 
     public void Draw(ICanvas canvas, RectF dirtyRect)
     {
-        if (Months.Count == 0) return;
+        if (Months.Count == 0 && ForecastMonth == 0) return;
 
         canvas.Antialias = true;
 
@@ -37,36 +65,66 @@ public class BarChartDrawable : IDrawable
         float chartWidth = dirtyRect.Width - paddingLeft - paddingRight;
         float chartHeight = dirtyRect.Height - paddingTop - paddingBottom;
 
-        decimal maxVal = Months.Max(m => m.Total);
+        // Max-Wert berücksichtigt Forecast und Budget für korrekte Skalierung
+        decimal maxVal = Months.Count > 0 ? Months.Max(m => m.Total) : 0;
+        if (ForecastMonth > 0) maxVal = Math.Max(maxVal, ForecastValue);
+        if (MonthlyBudgetTotal > 0) maxVal = Math.Max(maxVal, MonthlyBudgetTotal);
         if (maxVal <= 0) maxVal = 1;
 
         float barWidth = chartWidth / 12f;
         float barSpacing = barWidth * 0.25f;
         float actualBarWidth = barWidth - barSpacing;
+        float baseY = paddingTop + chartHeight;
 
-        // Horizontale Gitternetzlinie
+        // Horizontale Basislinie
         canvas.StrokeColor = GridColor;
         canvas.StrokeSize = 1f;
-        float baseY = paddingTop + chartHeight;
+        canvas.StrokeDashPattern = null;
         canvas.DrawLine(paddingLeft, baseY, paddingLeft + chartWidth, baseY);
+
+        // Budget-Referenzlinie (gestrichelt)
+        if (MonthlyBudgetTotal > 0)
+        {
+            float budgetY = paddingTop + chartHeight * (1f - (float)((double)MonthlyBudgetTotal / (double)maxVal));
+            canvas.StrokeColor = BudgetLineColor;
+            canvas.StrokeSize = 1.5f;
+            canvas.StrokeDashPattern = [4f, 4f];
+            canvas.DrawLine(paddingLeft, budgetY, paddingLeft + chartWidth, budgetY);
+            canvas.StrokeDashPattern = null;
+        }
 
         for (int i = 0; i < 12; i++)
         {
             var month = Months.FirstOrDefault(m => m.Month == i + 1);
-            decimal value = month?.Total ?? 0;
+            bool isForecast = (i + 1) == ForecastMonth && month == null;
+            decimal value = isForecast ? ForecastValue : (month?.Total ?? 0);
 
-            float barHeight = chartHeight * (float)((double)value / (double)maxVal);
             float x = paddingLeft + i * barWidth + barSpacing / 2;
-            float y = paddingTop + chartHeight - barHeight;
-
-            // Balken
             bool isCurrent = (i + 1) == CurrentMonth;
-            canvas.FillColor = isCurrent ? HighlightColor : BarColor;
 
-            if (barHeight > 0)
+            if (value > 0)
             {
+                float barHeight = chartHeight * (float)((double)value / (double)maxVal);
+                float y = paddingTop + chartHeight - barHeight;
                 var rect = new RectF(x, y, actualBarWidth, barHeight);
+
+                if (isForecast)
+                    canvas.FillColor = BarColorForecast;
+                else if (isCurrent)
+                    canvas.FillColor = HighlightColor;
+                else
+                    canvas.FillColor = BarColor;
+
                 canvas.FillRoundedRectangle(rect, 3);
+
+                // Forecast-Tilde-Symbol oben
+                if (isForecast)
+                {
+                    canvas.FontColor = BarColor;
+                    canvas.FontSize = 9f;
+                    canvas.DrawString("~", x, y - 13, actualBarWidth, 13,
+                        HorizontalAlignment.Center, VerticalAlignment.Bottom);
+                }
             }
 
             // Monatskürzel

--- a/Finanzuebersicht/Charts/BarChartDrawable.cs
+++ b/Finanzuebersicht/Charts/BarChartDrawable.cs
@@ -1,8 +1,10 @@
 using Finanzuebersicht.Converters;
 using Finanzuebersicht.Models;
+using Microsoft.Maui.Controls;
 using Microsoft.Maui.Graphics;
 using System.Collections.Generic;
 using System.Linq;
+using MauiApplication = Microsoft.Maui.Controls.Application;
 
 namespace Finanzuebersicht.Charts;
 
@@ -16,30 +18,34 @@ public class BarChartDrawable : IDrawable
     private static readonly string[] MonthLabels =
         ["J", "F", "M", "A", "M", "J", "J", "A", "S", "O", "N", "D"];
 
-    private static Color BarColor =>
-        ColorResourceHelper.GetThemeColor("Primary", "PrimaryDark",
+    // Theme-Farben werden pro Draw gecacht und nur bei Theme-Wechsel neu aufgelöst
+    private static AppTheme _cachedTheme = AppTheme.Unspecified;
+    private static Color _cachedBarColor = Color.FromArgb("#007AFF");
+    private static Color _cachedBarColorForecast = Color.FromArgb("#007AFF").WithAlpha(0.35f);
+    private static Color _cachedHighlightColor = Color.FromArgb("#FF3B30");
+    private static Color _cachedTextColor = Color.FromArgb("#8E8E93");
+    private static Color _cachedGridColor = Color.FromArgb("#E5E5EA");
+    private static Color _cachedBudgetLineColor = Color.FromArgb("#AEAEB2");
+
+    private static void EnsureThemeColors()
+    {
+        var currentTheme = MauiApplication.Current?.RequestedTheme ?? AppTheme.Unspecified;
+        if (currentTheme == _cachedTheme) return;
+
+        var barColor = ColorResourceHelper.GetThemeColor("Primary", "PrimaryDark",
             Color.FromArgb("#007AFF"), Color.FromArgb("#0A84FF"));
-
-    private static Color BarColorForecast =>
-        ColorResourceHelper.GetThemeColor("Primary", "PrimaryDark",
-            Color.FromArgb("#007AFF"), Color.FromArgb("#0A84FF"))
-        .WithAlpha(0.35f);
-
-    private static Color HighlightColor =>
-        ColorResourceHelper.GetThemeColor("Ausgabe", "AusgabeDark",
+        _cachedBarColor = barColor;
+        _cachedBarColorForecast = barColor.WithAlpha(0.35f);
+        _cachedHighlightColor = ColorResourceHelper.GetThemeColor("Ausgabe", "AusgabeDark",
             Color.FromArgb("#FF3B30"), Color.FromArgb("#FF453A"));
-
-    private static Color TextColor =>
-        ColorResourceHelper.GetThemeColor("Gray600", "Gray400",
+        _cachedTextColor = ColorResourceHelper.GetThemeColor("Gray600", "Gray400",
             Color.FromArgb("#8E8E93"), Color.FromArgb("#AEAEB2"));
-
-    private static Color GridColor =>
-        ColorResourceHelper.GetThemeColor("Gray200", "Gray700",
+        _cachedGridColor = ColorResourceHelper.GetThemeColor("Gray200", "Gray700",
             Color.FromArgb("#E5E5EA"), Color.FromArgb("#3A3A3C"));
-
-    private static Color BudgetLineColor =>
-        ColorResourceHelper.GetThemeColor("Gray500", "Gray400",
+        _cachedBudgetLineColor = ColorResourceHelper.GetThemeColor("Gray500", "Gray400",
             Color.FromArgb("#AEAEB2"), Color.FromArgb("#636366"));
+        _cachedTheme = currentTheme;
+    }
 
     public IReadOnlyList<MonthSummary> Months { get; set; } = [];
     public int CurrentMonth { get; set; } = Finanzuebersicht.Core.Services.SystemClock.Instance.Today.Month;
@@ -50,13 +56,16 @@ public class BarChartDrawable : IDrawable
     /// <summary>Forecast-Betrag für den Forecast-Balken.</summary>
     public decimal ForecastValue { get; set; }
 
-    /// <summary>Monatliches Gesamtbudget als horizontale Referenzlinie, 0 = keine Linie.</summary>
+    /// <summary>Monatliches Default-Gesamtbudget als horizontale Referenzlinie, 0 = keine Linie.</summary>
     public decimal MonthlyBudgetTotal { get; set; }
 
     public void Draw(ICanvas canvas, RectF dirtyRect)
     {
-        if (Months.Count == 0 && ForecastMonth == 0) return;
+        bool hasForecastOverlay = ForecastMonth > 0 && ForecastValue > 0;
+        bool hasBudgetOverlay = MonthlyBudgetTotal > 0;
+        if (Months.Count == 0 && !hasForecastOverlay && !hasBudgetOverlay) return;
 
+        EnsureThemeColors();
         canvas.Antialias = true;
 
         float paddingLeft = 8f;
@@ -70,7 +79,7 @@ public class BarChartDrawable : IDrawable
         // Max-Wert: Forecast nur einberechnen wenn er tatsächlich gezeichnet wird
         decimal maxVal = Months.Count > 0 ? Months.Max(m => m.Total) : 0;
         var forecastMonthActual = Months.FirstOrDefault(m => m.Month == ForecastMonth)?.Total ?? 0;
-        bool showForecast = ForecastMonth > 0 && ForecastValue > 0 && forecastMonthActual == 0;
+        bool showForecast = hasForecastOverlay && forecastMonthActual == 0;
         if (showForecast) maxVal = Math.Max(maxVal, ForecastValue);
         if (MonthlyBudgetTotal > 0) maxVal = Math.Max(maxVal, MonthlyBudgetTotal);
         if (maxVal <= 0) maxVal = 1;
@@ -81,7 +90,7 @@ public class BarChartDrawable : IDrawable
         float baseY = paddingTop + chartHeight;
 
         // Horizontale Basislinie
-        canvas.StrokeColor = GridColor;
+        canvas.StrokeColor = _cachedGridColor;
         canvas.StrokeSize = 1f;
         canvas.StrokeDashPattern = null;
         canvas.DrawLine(paddingLeft, baseY, paddingLeft + chartWidth, baseY);
@@ -90,7 +99,7 @@ public class BarChartDrawable : IDrawable
         if (MonthlyBudgetTotal > 0)
         {
             float budgetY = paddingTop + chartHeight * (1f - (float)((double)MonthlyBudgetTotal / (double)maxVal));
-            canvas.StrokeColor = BudgetLineColor;
+            canvas.StrokeColor = _cachedBudgetLineColor;
             canvas.StrokeSize = 1.5f;
             canvas.StrokeDashPattern = [4f, 4f];
             canvas.DrawLine(paddingLeft, budgetY, paddingLeft + chartWidth, budgetY);
@@ -113,18 +122,18 @@ public class BarChartDrawable : IDrawable
                 var rect = new RectF(x, y, actualBarWidth, barHeight);
 
                 if (isForecast)
-                    canvas.FillColor = BarColorForecast;
+                    canvas.FillColor = _cachedBarColorForecast;
                 else if (isCurrent)
-                    canvas.FillColor = HighlightColor;
+                    canvas.FillColor = _cachedHighlightColor;
                 else
-                    canvas.FillColor = BarColor;
+                    canvas.FillColor = _cachedBarColor;
 
                 canvas.FillRoundedRectangle(rect, 3);
 
                 // Forecast-Tilde-Symbol oben
                 if (isForecast)
                 {
-                    canvas.FontColor = BarColor;
+                    canvas.FontColor = _cachedBarColor;
                     canvas.FontSize = 9f;
                     canvas.DrawString("~", x, y - 13, actualBarWidth, 13,
                         HorizontalAlignment.Center, VerticalAlignment.Bottom);
@@ -132,7 +141,7 @@ public class BarChartDrawable : IDrawable
             }
 
             // Monatskürzel
-            canvas.FontColor = isCurrent ? HighlightColor : TextColor;
+            canvas.FontColor = isCurrent ? _cachedHighlightColor : _cachedTextColor;
             canvas.FontSize = 10f;
             canvas.DrawString(MonthLabels[i],
                 x, baseY + 3, actualBarWidth, paddingBottom - 4,

--- a/Finanzuebersicht/Converters/DashboardConverters.cs
+++ b/Finanzuebersicht/Converters/DashboardConverters.cs
@@ -114,3 +114,25 @@ public class InvertBoolConverter : IValueConverter
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => value is bool b ? !b : value;
 }
+
+/// <summary>Gibt true zurück wenn der String nicht leer ist (für IsVisible-Binding).</summary>
+public class StringToBoolConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is string s && !string.IsNullOrEmpty(s);
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}
+
+/// <summary>bool → grün (true = weniger Ausgaben) oder rot (false = mehr Ausgaben).</summary>
+public class TrendColorConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => value is true
+            ? Color.FromArgb("#34C759")   // positiver Trend → grün
+            : Color.FromArgb("#FF3B30");  // negativer Trend → rot
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/Finanzuebersicht/Converters/DashboardConverters.cs
+++ b/Finanzuebersicht/Converters/DashboardConverters.cs
@@ -130,8 +130,10 @@ public class TrendColorConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
         => value is true
-            ? Color.FromArgb("#34C759")   // positiver Trend → grün
-            : Color.FromArgb("#FF3B30");  // negativer Trend → rot
+            ? ColorResourceHelper.GetThemeColor("Einnahme", "EinnahmeDark",
+                Color.FromArgb("#34C759"), Color.FromArgb("#30D158"))
+            : ColorResourceHelper.GetThemeColor("Ausgabe", "AusgabeDark",
+                Color.FromArgb("#FF3B30"), Color.FromArgb("#FF453A"));
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -12,6 +12,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private readonly LoadDashboardYearUseCase _loadDashboardYearUseCase;
     private readonly LoadForecastUseCase _loadForecastUseCase;
     private readonly IBudgetRepository _budgetRepository;
+    private readonly IReportingService _reportingService;
     private readonly IClock _clock;
 
     // --- Monatsansicht ---
@@ -92,6 +93,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         LoadDashboardYearUseCase loadDashboardYearUseCase,
         LoadForecastUseCase loadForecastUseCase,
         IBudgetRepository budgetRepository,
+        IReportingService reportingService,
         IClock? clock = null) : base(clock)
     {
         _clock = clock ?? SystemClock.Instance;
@@ -100,6 +102,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _loadDashboardYearUseCase = loadDashboardYearUseCase;
         _loadForecastUseCase = loadForecastUseCase;
         _budgetRepository = budgetRepository;
+        _reportingService = reportingService;
         UpdateJahrAnzeige();
     }
 
@@ -138,12 +141,12 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         KategorieAusgaben = new ObservableCollection<CategorySummary>(data.KategorieAusgaben);
         KategorieEinnahmen = new ObservableCollection<CategorySummary>(data.KategorieEinnahmen);
 
-        // Vormonatsvergleich für Trend-Indikator
+        // Vormonatsvergleich: nur Gesamt-Ausgaben via ReportingService (keine Kategorien nötig)
         var prevMonth = AktuellerMonat.AddMonths(-1);
-        var prevData = await _loadDashboardMonthUseCase.ExecuteAsync(prevMonth, _clock.Today);
-        if (prevData.GesamtAusgaben > 0)
+        var prevSummary = await _reportingService.GetMonthSummaryAsync(prevMonth.Year, prevMonth.Month);
+        if (prevSummary.Total > 0)
         {
-            var pct = (GesamtAusgaben - prevData.GesamtAusgaben) / prevData.GesamtAusgaben * 100;
+            var pct = (GesamtAusgaben - prevSummary.Total) / prevSummary.Total * 100;
             TrendProzent = pct;
             TrendPositiv = pct < 0; // weniger Ausgaben = positiv (grün)
             TrendText = pct >= 0
@@ -153,6 +156,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         else
         {
             TrendProzent = null;
+            TrendPositiv = false;
             TrendText = string.Empty;
         }
 

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -6,12 +6,12 @@ using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Core.Services;
 namespace Finanzuebersicht.ViewModels;
-
 public partial class DashboardViewModel : MonthNavigationViewModel
 {
     private readonly LoadDashboardMonthUseCase _loadDashboardMonthUseCase;
     private readonly LoadDashboardYearUseCase _loadDashboardYearUseCase;
     private readonly LoadForecastUseCase _loadForecastUseCase;
+    private readonly IBudgetRepository _budgetRepository;
     private readonly IClock _clock;
 
     // --- Monatsansicht ---
@@ -39,6 +39,26 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     [ObservableProperty]
     private bool hasForecast;
+
+    // Trend Vormonatsvergleich
+    [ObservableProperty]
+    private decimal? trendProzent;
+
+    [ObservableProperty]
+    private string trendText = string.Empty;
+
+    [ObservableProperty]
+    private bool trendPositiv;
+
+    // Für BarChart: Forecast-Balken und Budget-Linie
+    [ObservableProperty]
+    private int forecastBarMonth;
+
+    [ObservableProperty]
+    private decimal forecastBarValue;
+
+    [ObservableProperty]
+    private decimal jahrBudgetTotal;
 
     // --- Jahresansicht ---
 
@@ -71,6 +91,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         LoadDashboardMonthUseCase loadDashboardMonthUseCase,
         LoadDashboardYearUseCase loadDashboardYearUseCase,
         LoadForecastUseCase loadForecastUseCase,
+        IBudgetRepository budgetRepository,
         IClock? clock = null) : base(clock)
     {
         _clock = clock ?? SystemClock.Instance;
@@ -78,6 +99,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _loadDashboardMonthUseCase = loadDashboardMonthUseCase;
         _loadDashboardYearUseCase = loadDashboardYearUseCase;
         _loadForecastUseCase = loadForecastUseCase;
+        _budgetRepository = budgetRepository;
         UpdateJahrAnzeige();
     }
 
@@ -116,6 +138,24 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         KategorieAusgaben = new ObservableCollection<CategorySummary>(data.KategorieAusgaben);
         KategorieEinnahmen = new ObservableCollection<CategorySummary>(data.KategorieEinnahmen);
 
+        // Vormonatsvergleich für Trend-Indikator
+        var prevMonth = AktuellerMonat.AddMonths(-1);
+        var prevData = await _loadDashboardMonthUseCase.ExecuteAsync(prevMonth, _clock.Today);
+        if (prevData.GesamtAusgaben > 0)
+        {
+            var pct = (GesamtAusgaben - prevData.GesamtAusgaben) / prevData.GesamtAusgaben * 100;
+            TrendProzent = pct;
+            TrendPositiv = pct < 0; // weniger Ausgaben = positiv (grün)
+            TrendText = pct >= 0
+                ? $"↑ +{pct:F0} %"
+                : $"↓ {pct:F0} %";
+        }
+        else
+        {
+            TrendProzent = null;
+            TrendText = string.Empty;
+        }
+
         // Load forecast for current month only (not for past/future navigation)
         var today = _clock.Today;
         var isCurrentMonth = AktuellerMonat.Year == today.Year && AktuellerMonat.Month == today.Month;
@@ -138,6 +178,35 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         JahrGesamtAusgaben = data.GesamtAusgaben;
         JahrMonate = data.Monate;
         JahrKategorien = new ObservableCollection<CategorySummary>(data.Kategorien);
+
+        // Monatliches Gesamtbudget für Budget-Referenzlinie im Bar-Chart
+        var budgets = await _budgetRepository.GetBudgetsAsync();
+        JahrBudgetTotal = budgets
+            .Where(b => b.Monat == null && b.Jahr == null && b.Betrag > 0)
+            .Sum(b => b.Betrag);
+
+        // Forecast-Balken für nächsten Monat (nur im aktuellen Jahr)
+        var today = _clock.Today;
+        if (_aktuellesJahr == today.Year)
+        {
+            var nextMonth = new DateTime(today.Year, today.Month, 1).AddMonths(1);
+            if (nextMonth.Year == _aktuellesJahr)
+            {
+                var forecast = await _loadForecastUseCase.ExecuteAsync(nextMonth.Year, nextMonth.Month);
+                ForecastBarMonth = nextMonth.Month;
+                ForecastBarValue = forecast.ForecastedTotal;
+            }
+            else
+            {
+                ForecastBarMonth = 0;
+                ForecastBarValue = 0;
+            }
+        }
+        else
+        {
+            ForecastBarMonth = 0;
+            ForecastBarValue = 0;
+        }
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -179,7 +179,9 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         JahrMonate = data.Monate;
         JahrKategorien = new ObservableCollection<CategorySummary>(data.Kategorien);
 
-        // Monatliches Gesamtbudget für Budget-Referenzlinie im Bar-Chart
+        // Summe der Default-Kategorie-Budgets (monat=null, jahr=null) als Referenzlinie
+        // Hinweis: Monat- oder jahresspezifische Budget-Overrides werden bewusst nicht einberechnet,
+        // da die Linie einen stabilen Jahres-Richtwert darstellen soll.
         var budgets = await _budgetRepository.GetBudgetsAsync();
         JahrBudgetTotal = budgets
             .Where(b => b.Monat == null && b.Jahr == null && b.Betrag > 0)

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -19,6 +19,8 @@
         <conv:ToggleActiveTextColorConverter x:Key="ToggleActiveText" />
         <conv:BudgetProgressColorConverter x:Key="BudgetProgressColor" />
         <conv:InvertBoolConverter x:Key="InvertBool" />
+        <conv:StringToBoolConverter x:Key="StringToBool" />
+        <conv:TrendColorConverter x:Key="TrendColor" />
     </ContentPage.Resources>
 
     <RefreshView Command="{Binding LoadDashboardCommand}"
@@ -96,6 +98,10 @@
                             <Label Text="{loc:Translate Lbl_Ausgaben}" FontSize="11" TextColor="#FF3B30" />
                             <Label Text="{Binding GesamtAusgaben, Converter={StaticResource Currency}}"
                                    FontSize="15" FontAttributes="Bold" TextColor="#FF3B30" />
+                            <Label Text="{Binding TrendText}"
+                                   FontSize="11" FontAttributes="Bold"
+                                   IsVisible="{Binding TrendText, Converter={StaticResource StringToBool}}"
+                                   TextColor="{Binding TrendPositiv, Converter={StaticResource TrendColor}}" />
                         </VerticalStackLayout>
                     </Border>
 

--- a/Finanzuebersicht/Views/DashboardPage.xaml.cs
+++ b/Finanzuebersicht/Views/DashboardPage.xaml.cs
@@ -25,6 +25,9 @@ public partial class DashboardPage : ContentPage
         _monthDonut.Items = _vm.KategorieAusgaben;
         _yearBar.Months = _vm.JahrMonate;
         _yearBar.CurrentMonth = _vm.IsYearView ? 0 : _vm.AktuellerMonat.Month;
+        _yearBar.MonthlyBudgetTotal = _vm.JahrBudgetTotal;
+        _yearBar.ForecastMonth = _vm.ForecastBarMonth;
+        _yearBar.ForecastValue = _vm.ForecastBarValue;
         _yearDonut.Items = _vm.JahrKategorien;
 
         _vm.PropertyChanged += OnViewModelPropertyChanged;

--- a/Finanzuebersicht/Views/DashboardPage.xaml.cs
+++ b/Finanzuebersicht/Views/DashboardPage.xaml.cs
@@ -79,6 +79,16 @@ public partial class DashboardPage : ContentPage
                 _yearDonut.Items = _vm.JahrKategorien;
                 MainThread.BeginInvokeOnMainThread(() => YearDonutChart.Invalidate());
                 break;
+            case nameof(DashboardViewModel.JahrBudgetTotal):
+                _yearBar.MonthlyBudgetTotal = _vm.JahrBudgetTotal;
+                MainThread.BeginInvokeOnMainThread(() => YearBarChart.Invalidate());
+                break;
+            case nameof(DashboardViewModel.ForecastBarMonth):
+            case nameof(DashboardViewModel.ForecastBarValue):
+                _yearBar.ForecastMonth = _vm.ForecastBarMonth;
+                _yearBar.ForecastValue = _vm.ForecastBarValue;
+                MainThread.BeginInvokeOnMainThread(() => YearBarChart.Invalidate());
+                break;
         }
     }
 }


### PR DESCRIPTION
Closes #52 (partially — interactivity deferred)

## Was wurde implementiert

### BarChartDrawable – Dark Mode Fix
- Alle hardcodierten Farben (`#007AFF`, `#E5E5EA` etc.) durch `ColorResourceHelper.GetThemeColor()` ersetzt
- Light/Dark Mode werden jetzt korrekt gerendert

### BarChartDrawable – Forecast-Balken
- Nächster Monat wird als semi-transparenter Balken mit `~` Präfix angezeigt
- Nutzt Daten aus `ForecastService` (seit #51 verfügbar)
- Max-Skalierung berücksichtigt Forecast-Wert

### BarChartDrawable – Budget-Referenzlinie
- Horizontale gestrichelte Linie auf Höhe des monatlichen Gesamtbudgets
- Zeigt visuell ob ein Monat über/unter dem Budget liegt

### Trend-Indikator im Dashboard
- Ausgaben-Karte zeigt Vergleich zum Vormonat: `↑ +12 %` (rot) / `↓ -8 %` (grün)
- Trend wird nur angezeigt wenn Vormonatsdaten vorhanden

### Neue Converter
- `StringToBoolConverter` – IsVisible-Binding für leere Strings
- `TrendColorConverter` – grün (weniger Ausgaben) / rot (mehr Ausgaben)

## Offen / Follow-ups
- Chart-Interaktivität (Tap auf Segment → Filter) bleibt für späteren PR

## Tests
- ✅ 132/132 Tests grün