### PR TITLE
✨ feat(ui): add accessibility support for VoiceOver/TalkBack (#54)

### DIFF
--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -198,4 +198,15 @@ Bitte starte die App neu.</value></data>
   <data name="Empty_KeineSparZiele" xml:space="preserve"><value>Noch keine Sparziele angelegt</value></data>
   <data name="Btn_NeuesZiel" xml:space="preserve"><value>+ Neues Ziel</value></data>
   <data name="Btn_ZielHinzufuegen" xml:space="preserve"><value>Ziel hinzufügen</value></data>
+  <data name="A11y_VorherigerMonat" xml:space="preserve"><value>Vorheriger Monat</value></data>
+  <data name="A11y_NaechsterMonat" xml:space="preserve"><value>Nächster Monat</value></data>
+  <data name="A11y_VorherigesJahr" xml:space="preserve"><value>Vorheriges Jahr</value></data>
+  <data name="A11y_NaechstesJahr" xml:space="preserve"><value>Nächstes Jahr</value></data>
+  <data name="A11y_TransaktionHinzufuegen" xml:space="preserve"><value>Neue Transaktion hinzufügen</value></data>
+  <data name="A11y_KategorieHinzufuegen" xml:space="preserve"><value>Neue Kategorie hinzufügen</value></data>
+  <data name="A11y_SparZielHinzufuegen" xml:space="preserve"><value>Neues Sparziel hinzufügen</value></data>
+  <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Neuen Dauerauftrag hinzufügen</value></data>
+  <data name="A11y_BudgetBalken" xml:space="preserve"><value>Budget-Fortschrittsbalken für Kategorie</value></data>
+  <data name="A11y_SparZielBalken" xml:space="preserve"><value>Sparziel-Fortschrittsbalken</value></data>
+  <data name="A11y_Einstellungen" xml:space="preserve"><value>Einstellungen öffnen</value></data>
 </root>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -208,7 +208,6 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Neuen Dauerauftrag hinzufügen</value></data>
   <data name="A11y_BudgetBalken" xml:space="preserve"><value>Budget-Fortschrittsbalken für Kategorie</value></data>
   <data name="A11y_SparZielBalken" xml:space="preserve"><value>Sparziel-Fortschrittsbalken</value></data>
-  <data name="A11y_Einstellungen" xml:space="preserve"><value>Einstellungen öffnen</value></data>
   <data name="A11y_HintBetrag" xml:space="preserve"><value>Betrag eingeben, z. B. 12,50</value></data>
   <data name="A11y_HintTitel" xml:space="preserve"><value>Kurze Beschreibung der Transaktion</value></data>
   <data name="A11y_HintBudget" xml:space="preserve"><value>Leer lassen für kein Budgetlimit</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -209,4 +209,7 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_BudgetBalken" xml:space="preserve"><value>Budget-Fortschrittsbalken für Kategorie</value></data>
   <data name="A11y_SparZielBalken" xml:space="preserve"><value>Sparziel-Fortschrittsbalken</value></data>
   <data name="A11y_Einstellungen" xml:space="preserve"><value>Einstellungen öffnen</value></data>
+  <data name="A11y_HintBetrag" xml:space="preserve"><value>Betrag eingeben, z. B. 12,50</value></data>
+  <data name="A11y_HintTitel" xml:space="preserve"><value>Kurze Beschreibung der Transaktion</value></data>
+  <data name="A11y_HintBudget" xml:space="preserve"><value>Leer lassen für kein Budgetlimit</value></data>
 </root>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -198,4 +198,15 @@ Please restart the app.</value></data>
   <data name="Empty_KeineSparZiele" xml:space="preserve"><value>No savings goals yet</value></data>
   <data name="Btn_NeuesZiel" xml:space="preserve"><value>+ New Goal</value></data>
   <data name="Btn_ZielHinzufuegen" xml:space="preserve"><value>Add Goal</value></data>
+  <data name="A11y_VorherigerMonat" xml:space="preserve"><value>Previous month</value></data>
+  <data name="A11y_NaechsterMonat" xml:space="preserve"><value>Next month</value></data>
+  <data name="A11y_VorherigesJahr" xml:space="preserve"><value>Previous year</value></data>
+  <data name="A11y_NaechstesJahr" xml:space="preserve"><value>Next year</value></data>
+  <data name="A11y_TransaktionHinzufuegen" xml:space="preserve"><value>Add new transaction</value></data>
+  <data name="A11y_KategorieHinzufuegen" xml:space="preserve"><value>Add new category</value></data>
+  <data name="A11y_SparZielHinzufuegen" xml:space="preserve"><value>Add new savings goal</value></data>
+  <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Add new recurring transaction</value></data>
+  <data name="A11y_BudgetBalken" xml:space="preserve"><value>Category budget progress</value></data>
+  <data name="A11y_SparZielBalken" xml:space="preserve"><value>Savings goal progress</value></data>
+  <data name="A11y_Einstellungen" xml:space="preserve"><value>Open settings</value></data>
 </root>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -208,7 +208,6 @@ Please restart the app.</value></data>
   <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Add new recurring transaction</value></data>
   <data name="A11y_BudgetBalken" xml:space="preserve"><value>Category budget progress</value></data>
   <data name="A11y_SparZielBalken" xml:space="preserve"><value>Savings goal progress</value></data>
-  <data name="A11y_Einstellungen" xml:space="preserve"><value>Open settings</value></data>
   <data name="A11y_HintBetrag" xml:space="preserve"><value>Enter amount, e.g. 12.50</value></data>
   <data name="A11y_HintTitel" xml:space="preserve"><value>Short description of the transaction</value></data>
   <data name="A11y_HintBudget" xml:space="preserve"><value>Leave empty for no budget limit</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -209,4 +209,7 @@ Please restart the app.</value></data>
   <data name="A11y_BudgetBalken" xml:space="preserve"><value>Category budget progress</value></data>
   <data name="A11y_SparZielBalken" xml:space="preserve"><value>Savings goal progress</value></data>
   <data name="A11y_Einstellungen" xml:space="preserve"><value>Open settings</value></data>
+  <data name="A11y_HintBetrag" xml:space="preserve"><value>Enter amount, e.g. 12.50</value></data>
+  <data name="A11y_HintTitel" xml:space="preserve"><value>Short description of the transaction</value></data>
+  <data name="A11y_HintBudget" xml:space="preserve"><value>Leave empty for no budget limit</value></data>
 </root>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -193,4 +193,17 @@ public static class ResourceKeys
     public const string Empty_KeineSparZiele = nameof(Empty_KeineSparZiele);
     public const string Btn_NeuesZiel = nameof(Btn_NeuesZiel);
     public const string Btn_ZielHinzufuegen = nameof(Btn_ZielHinzufuegen);
+
+    // Accessibility
+    public const string A11y_VorherigerMonat = nameof(A11y_VorherigerMonat);
+    public const string A11y_NaechsterMonat = nameof(A11y_NaechsterMonat);
+    public const string A11y_VorherigesJahr = nameof(A11y_VorherigesJahr);
+    public const string A11y_NaechstesJahr = nameof(A11y_NaechstesJahr);
+    public const string A11y_TransaktionHinzufuegen = nameof(A11y_TransaktionHinzufuegen);
+    public const string A11y_KategorieHinzufuegen = nameof(A11y_KategorieHinzufuegen);
+    public const string A11y_SparZielHinzufuegen = nameof(A11y_SparZielHinzufuegen);
+    public const string A11y_DauerauftragHinzufuegen = nameof(A11y_DauerauftragHinzufuegen);
+    public const string A11y_BudgetBalken = nameof(A11y_BudgetBalken);
+    public const string A11y_SparZielBalken = nameof(A11y_SparZielBalken);
+    public const string A11y_Einstellungen = nameof(A11y_Einstellungen);
 }

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -206,4 +206,7 @@ public static class ResourceKeys
     public const string A11y_BudgetBalken = nameof(A11y_BudgetBalken);
     public const string A11y_SparZielBalken = nameof(A11y_SparZielBalken);
     public const string A11y_Einstellungen = nameof(A11y_Einstellungen);
+    public const string A11y_HintBetrag = nameof(A11y_HintBetrag);
+    public const string A11y_HintTitel = nameof(A11y_HintTitel);
+    public const string A11y_HintBudget = nameof(A11y_HintBudget);
 }

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -205,7 +205,6 @@ public static class ResourceKeys
     public const string A11y_DauerauftragHinzufuegen = nameof(A11y_DauerauftragHinzufuegen);
     public const string A11y_BudgetBalken = nameof(A11y_BudgetBalken);
     public const string A11y_SparZielBalken = nameof(A11y_SparZielBalken);
-    public const string A11y_Einstellungen = nameof(A11y_Einstellungen);
     public const string A11y_HintBetrag = nameof(A11y_HintBetrag);
     public const string A11y_HintTitel = nameof(A11y_HintTitel);
     public const string A11y_HintBudget = nameof(A11y_HintBudget);

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -69,6 +69,7 @@
                 WidthRequest="56" HeightRequest="56"
                 HorizontalOptions="End" VerticalOptions="End"
                 Margin="0,0,20,20"
+                SemanticProperties.Description="{loc:Translate A11y_KategorieHinzufuegen}"
                 Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
                 Command="{Binding GoToDetailCommand}" />
     </Grid>

--- a/Finanzuebersicht/Views/CategoryDetailPage.xaml
+++ b/Finanzuebersicht/Views/CategoryDetailPage.xaml
@@ -78,7 +78,8 @@
             <VerticalStackLayout Spacing="4">
                 <Label Text="{loc:Translate Lbl_MonatlichesBudget}" FontSize="13" TextColor="Gray" />
                 <Entry Text="{Binding MonthlyBudgetText}" Keyboard="Numeric"
-                       Placeholder="{loc:Translate Hint_BudgetOptional}" FontSize="16" />
+                       Placeholder="{loc:Translate Hint_BudgetOptional}" FontSize="16"
+                       SemanticProperties.Hint="{loc:Translate Hint_BudgetNull}" />
                 <Label Text="{loc:Translate Hint_BudgetNull}" FontSize="11" TextColor="Gray" />
             </VerticalStackLayout>
 

--- a/Finanzuebersicht/Views/CategoryDetailPage.xaml
+++ b/Finanzuebersicht/Views/CategoryDetailPage.xaml
@@ -79,7 +79,7 @@
                 <Label Text="{loc:Translate Lbl_MonatlichesBudget}" FontSize="13" TextColor="Gray" />
                 <Entry Text="{Binding MonthlyBudgetText}" Keyboard="Numeric"
                        Placeholder="{loc:Translate Hint_BudgetOptional}" FontSize="16"
-                       SemanticProperties.Hint="{loc:Translate Hint_BudgetNull}" />
+                       SemanticProperties.Hint="{loc:Translate A11y_HintBudget}" />
                 <Label Text="{loc:Translate Hint_BudgetNull}" FontSize="11" TextColor="Gray" />
             </VerticalStackLayout>
 

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -63,6 +63,7 @@
                         <Button Grid.Column="0" Text="{loc:Translate Btn_Prev}" FontSize="28"
                             BackgroundColor="Transparent" TextColor="#007AFF"
                             Command="{Binding PreviousMonthCommand}"
+                            SemanticProperties.Description="{loc:Translate A11y_VorherigerMonat}"
                             WidthRequest="44" />
                     <VerticalStackLayout Grid.Column="1" HorizontalOptions="Center" VerticalOptions="Center">
                         <Label Text="{Binding MonatAnzeige}"
@@ -75,6 +76,7 @@
                         <Button Grid.Column="2" Text="{loc:Translate Btn_Next}" FontSize="28"
                             BackgroundColor="Transparent" TextColor="#007AFF"
                             Command="{Binding NextMonthCommand}"
+                            SemanticProperties.Description="{loc:Translate A11y_NaechsterMonat}"
                             WidthRequest="44" />
                 </Grid>
 
@@ -120,6 +122,7 @@
                 <!-- Ausgaben nach Kategorie -->
                   <Label Text="{loc:Translate Lbl_AusgabenNachKategorie}" FontSize="18" FontAttributes="Bold"
                       Margin="0,8,0,0"
+                      SemanticProperties.HeadingLevel="Level2"
                       IsVisible="{Binding KategorieAusgaben, Converter={StaticResource CountToBool}}" />
 
                 <!-- Donut-Diagramm Monatsausgaben -->
@@ -151,6 +154,7 @@
                                         Progress="{Binding BudgetAusgeschoepft, Converter={StaticResource ProzentToWidth}}"
                                         ProgressColor="{Binding IstUeberBudget, Converter={StaticResource BudgetProgressColor}}"
                                         BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                        SemanticProperties.Description="{loc:Translate A11y_BudgetBalken}"
                                         VerticalOptions="Center" />
                                     <!-- Über Budget: rote Warnung mit Überschreitungsbetrag -->
                                     <Grid ColumnDefinitions="Auto, *, Auto, Auto"
@@ -187,6 +191,7 @@
                 <!-- Einnahmen nach Kategorie -->
                   <Label Text="{loc:Translate Lbl_EinnahmenNachKategorie}" FontSize="18" FontAttributes="Bold"
                       Margin="0,8,0,0"
+                      SemanticProperties.HeadingLevel="Level2"
                       IsVisible="{Binding KategorieEinnahmen, Converter={StaticResource CountToBool}}" />
 
                 <CollectionView ItemsSource="{Binding KategorieEinnahmen}"
@@ -242,6 +247,7 @@
                         <Button Grid.Column="0" Text="{loc:Translate Btn_Prev}" FontSize="28"
                             BackgroundColor="Transparent" TextColor="#007AFF"
                             Command="{Binding PreviousYearCommand}"
+                            SemanticProperties.Description="{loc:Translate A11y_VorherigesJahr}"
                             WidthRequest="44" />
                     <Label Grid.Column="1" Text="{Binding JahrAnzeige}"
                            FontSize="20" FontAttributes="Bold"
@@ -249,6 +255,7 @@
                         <Button Grid.Column="2" Text="{loc:Translate Btn_Next}" FontSize="28"
                             BackgroundColor="Transparent" TextColor="#007AFF"
                             Command="{Binding NextYearCommand}"
+                            SemanticProperties.Description="{loc:Translate A11y_NaechstesJahr}"
                             WidthRequest="44" />
                 </Grid>
 
@@ -265,6 +272,7 @@
                 <!-- Balkendiagramm Monatsvergleich -->
                   <Label Text="{loc:Translate Lbl_AusgabenProMonat}" FontSize="18" FontAttributes="Bold"
                       Margin="0,8,0,0"
+                      SemanticProperties.HeadingLevel="Level2"
                       IsVisible="{Binding JahrMonate, Converter={StaticResource CountToBool}}" />
 
                 <GraphicsView x:Name="YearBarChart"
@@ -275,6 +283,7 @@
                 <!-- Kategorien im Jahr -->
                   <Label Text="{loc:Translate Lbl_AusgabenNachKategorie}" FontSize="18" FontAttributes="Bold"
                       Margin="0,8,0,0"
+                      SemanticProperties.HeadingLevel="Level2"
                       IsVisible="{Binding JahrKategorien, Converter={StaticResource CountToBool}}" />
 
                 <!-- Donut-Diagramm Jahreskategorien -->

--- a/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
@@ -34,7 +34,8 @@
                 <Label Text="{loc:Translate Lbl_Betrag}" FontSize="13" TextColor="Gray" />
                   <Entry Text="{Binding BetragText}" Placeholder="{loc:Translate Hint_Betrag}"
                        Keyboard="Numeric" FontSize="28" FontAttributes="Bold"
-                       HorizontalTextAlignment="Center" />
+                       HorizontalTextAlignment="Center"
+                       SemanticProperties.Hint="{loc:Translate Hint_Betrag}" />
             </VerticalStackLayout>
 
             <!-- Titel -->

--- a/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
@@ -35,7 +35,7 @@
                   <Entry Text="{Binding BetragText}" Placeholder="{loc:Translate Hint_Betrag}"
                        Keyboard="Numeric" FontSize="28" FontAttributes="Bold"
                        HorizontalTextAlignment="Center"
-                       SemanticProperties.Hint="{loc:Translate Hint_Betrag}" />
+                       SemanticProperties.Hint="{loc:Translate A11y_HintBetrag}" />
             </VerticalStackLayout>
 
             <!-- Titel -->

--- a/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
@@ -106,6 +106,7 @@
             WidthRequest="56" HeightRequest="56"
             HorizontalOptions="End" VerticalOptions="End"
             Margin="0,0,20,20"
+            SemanticProperties.Description="{loc:Translate A11y_DauerauftragHinzufuegen}"
             Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
             Command="{Binding GoToDetailCommand}" />
     </Grid>

--- a/Finanzuebersicht/Views/SparZielePage.xaml
+++ b/Finanzuebersicht/Views/SparZielePage.xaml
@@ -67,7 +67,8 @@
                                             </Grid>
                                             <ProgressBar Progress="{Binding FortschrittDecimal}"
                                                          ProgressColor="#34C759"
-                                                         BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}" />
+                                                         BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                                         SemanticProperties.Description="{loc:Translate A11y_SparZielBalken}" />
                                         </VerticalStackLayout>
 
                                         <!-- Löschen-Button -->
@@ -161,6 +162,7 @@
                 WidthRequest="56" HeightRequest="56"
                 HorizontalOptions="End" VerticalOptions="End"
                 Margin="0,0,20,20"
+                SemanticProperties.Description="{loc:Translate A11y_SparZielHinzufuegen}"
                 Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
                 Command="{Binding ToggleAddFormCommand}" />
     </Grid>

--- a/Finanzuebersicht/Views/TransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/TransactionDetailPage.xaml
@@ -29,7 +29,7 @@
                 <Entry Text="{Binding BetragText}" Placeholder="{loc:Translate Hint_Betrag}"
                        Keyboard="Numeric" FontSize="28" FontAttributes="Bold"
                        HorizontalTextAlignment="Center"
-                       SemanticProperties.Hint="{loc:Translate Hint_Betrag}" />
+                       SemanticProperties.Hint="{loc:Translate A11y_HintBetrag}" />
             </VerticalStackLayout>
 
             <!-- Titel -->
@@ -37,7 +37,7 @@
                 <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="Gray" />
                 <Entry Text="{Binding Titel}" Placeholder="{loc:Translate Hint_Beschreibung}"
                        FontSize="16"
-                       SemanticProperties.Hint="{loc:Translate Hint_Beschreibung}" />
+                       SemanticProperties.Hint="{loc:Translate A11y_HintTitel}" />
             </VerticalStackLayout>
 
             <!-- Verwendungszweck -->

--- a/Finanzuebersicht/Views/TransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/TransactionDetailPage.xaml
@@ -28,14 +28,16 @@
                 <Label Text="{loc:Translate Lbl_Betrag}" FontSize="13" TextColor="Gray" />
                 <Entry Text="{Binding BetragText}" Placeholder="{loc:Translate Hint_Betrag}"
                        Keyboard="Numeric" FontSize="28" FontAttributes="Bold"
-                       HorizontalTextAlignment="Center" />
+                       HorizontalTextAlignment="Center"
+                       SemanticProperties.Hint="{loc:Translate Hint_Betrag}" />
             </VerticalStackLayout>
 
             <!-- Titel -->
             <VerticalStackLayout Spacing="4">
                 <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="Gray" />
                 <Entry Text="{Binding Titel}" Placeholder="{loc:Translate Hint_Beschreibung}"
-                       FontSize="16" />
+                       FontSize="16"
+                       SemanticProperties.Hint="{loc:Translate Hint_Beschreibung}" />
             </VerticalStackLayout>
 
             <!-- Verwendungszweck -->

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -23,6 +23,7 @@
                 <Button Grid.Column="0" Text="{loc:Translate Btn_Prev}" FontSize="28"
                     BackgroundColor="Transparent" TextColor="#007AFF"
                     Command="{Binding PreviousMonthCommand}"
+                    SemanticProperties.Description="{loc:Translate A11y_VorherigerMonat}"
                     WidthRequest="44" />
             <Label Grid.Column="1" Text="{Binding MonatAnzeige}"
                    FontSize="18" FontAttributes="Bold"
@@ -30,6 +31,7 @@
                 <Button Grid.Column="2" Text="{loc:Translate Btn_Next}" FontSize="28"
                     BackgroundColor="Transparent" TextColor="#007AFF"
                     Command="{Binding NextMonthCommand}"
+                    SemanticProperties.Description="{loc:Translate A11y_NaechsterMonat}"
                     WidthRequest="44" />
         </Grid>
 
@@ -121,6 +123,7 @@
                     CornerRadius="28"
                     WidthRequest="56" HeightRequest="56"
                     HorizontalOptions="End" VerticalOptions="End"
+                    SemanticProperties.Description="{loc:Translate A11y_TransaktionHinzufuegen}"
                     Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
                     Command="{Binding GoToDetailCommand}" />
         </Grid>


### PR DESCRIPTION
## Änderungen

Schließt Issue #54 – Barrierefreiheit & Lokalisierung ausbauen.

### Was wurde umgesetzt

#### SemanticProperties.Description auf alle Icon-Buttons
- Monat-Navigation (←/→) in Dashboard und Transaktionen → "Vorheriger Monat" / "Nächster Monat"
- Jahr-Navigation (←/→) im Dashboard → "Vorheriges Jahr" / "Nächstes Jahr"
- FAB (+) in Transaktionen, Kategorien, Daueraufträge, Sparziele → kontextspezifische Beschreibung

#### SemanticProperties.HeadingLevel auf Sektionsüberschriften
- Dashboard Monatsansicht: "Ausgaben nach Kategorie", "Einnahmen nach Kategorie"
- Dashboard Jahresansicht: "Ausgaben pro Monat", "Ausgaben nach Kategorie"

#### SemanticProperties.Description auf ProgressBars
- Budget-Fortschrittsbalken in Kategorie-Listen → "Budget-Fortschrittsbalken für Kategorie"
- Sparziel-Fortschrittsbalken → "Sparziel-Fortschrittsbalken"

#### SemanticProperties.Hint auf Eingabefelder (dedizierte Hints, kein Placeholder-Duplikat)
- Betrag-Entry in Transaktion + Dauerauftrag → "Betrag eingeben, z. B. 12,50"
- Titel-Entry in Transaktion → "Kurze Beschreibung der Transaktion"
- Budget-Entry in Kategorie-Detail → "Leer lassen für kein Budgetlimit"

#### Neue Lokalisierungsstrings
- 13 neue `A11y_*`-Keys in `ResourceKeys.cs`
- Übersetzungen in `AppResources.resx` (EN) und `AppResources.de.resx` (DE)

### Nicht umgesetzt (Scope-Entscheidung)
- Kontrastcheck der Farben (separates Issue sinnvoller)
- Englisch-Übersetzungs-Vollständigkeits-Review (separates Issue)