### PR TITLE
📝 docs: update README and docs for v1.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@
 
 [![CI](https://github.com/tom4711/finanzuebersicht/actions/workflows/ci.yml/badge.svg)](https://github.com/tom4711/finanzuebersicht/actions/workflows/ci.yml)
 [![Pre-Release](https://github.com/tom4711/finanzuebersicht/actions/workflows/prerelease.yml/badge.svg)](https://github.com/tom4711/finanzuebersicht/actions/workflows/prerelease.yml)
+[![Release](https://github.com/tom4711/finanzuebersicht/actions/workflows/release.yml/badge.svg)](https://github.com/tom4711/finanzuebersicht/actions/workflows/release.yml)
 [![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
 [![.NET 10](https://img.shields.io/badge/.NET-10-blueviolet)](https://dotnet.microsoft.com/download)
 
@@ -17,10 +18,14 @@ Kurz: .NET 10 + MAUI, Multi-Language UI (Deutsch & Englisch), MVVM-Architektur.
 
 ## Kern-Features
 
-- Dashboard mit Monatsübersicht
+- Dashboard mit Monatsübersicht und Trend-Indikator
 - Transaktionen anlegen, editieren und filtern
 - Wiederkehrende Buchungen (Daueraufträge)
 - Kategorien mit Icon und Farbe
+- **Monatsbudgets** pro Kategorie mit Fortschrittsanzeige
+- **Sparziele** mit Fortschrittsbalken
+- **Backup & Restore** mit automatischer Schema-Migration (v1 → v2+)
+- Accessibility / VoiceOver-Unterstützung (iOS & macOS)
 - Dark Mode Unterstützung
 - Multi-Language Support (Deutsch & Englisch)
 
@@ -93,23 +98,15 @@ See [Quick Start (docs/QUICK_START.md)](docs/QUICK_START.md) for a concise guide
 ## Versionierung & CI
 
 - Nerdbank.GitVersioning (`version.json`) steuert Versionsnummern
-- CI / Pre-Release Workflows in `.github/workflows/`
+- CI / Pre-Release / Release Workflows in `.github/workflows/`
 
 Full MAUI build (macCatalyst)
 
 - Quick checks (unit tests, linters) werden bei Push auf Branches ausgeführt (ubuntu runner) — das spart macOS-Runner-Minuten.
 - Der vollständige MAUI macCatalyst-Build läuft für Pull Requests gegen `main` und für `main`-Pushes. Dadurch werden macOS-Ressourcen nur bei echten Integrationsprüfungen verwendet.
+- **Pre-Release:** Bei jedem Push auf `main` wird automatisch ein Beta-Release mit Artifacts erstellt.
+- **Release:** Bei Tag-Push (`v*`) oder manuellem Trigger werden Build-Artifacts (macOS + Windows) an das GitHub Release gehängt.
 - Um einen vollständigen MAUI-Build für einen PR explizit anzustoßen, füge das Label `run-maui` zur PR hinzu oder starte den Workflow manuell über Actions → "CI - Split quick and full" → Run workflow.
-- Wenn du lokal einen vollständigen Build machen willst, installiere die Workloads und baue mit:
-
-```bash
-# Workloads installieren (macOS)
-dotnet workload install maui
-# Mac Catalyst build
-dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst
-```
-
-Hinweis: Die CI-Strategie reduziert Kosten und macht Fehler (z. B. missing workloads oder MAUI-spezifische Probleme) früher sichtbar in PRs, bevor sie in main gemerged werden.
 
 ## Mitmachen
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -68,8 +68,11 @@ version.json                       ← Nerdbank.GitVersioning config
 Directory.Build.props              ← Shared MSBuild properties
 
 Finanzuebersicht.Core/             ← Shared library (net10.0)
-├── Models/                        ← Transaction, Category, RecurringTransaction, etc.
-└── Services/                      ← IDataService, LocalDataService, SettingsService
+├── Models/                        ← Transaction, Category, RecurringTransaction, CategoryBudget, SparZiel, etc.
+└── Services/                      ← IDataService, LocalDataService, SettingsService, BackupService, DataMigrationService
+
+Finanzuebersicht.Application/      ← Use Cases / Application Layer (net10.0)
+Finanzuebersicht.Infrastructure/   ← DI-Registrierung, Infrastrukturdienste (net10.0)
 
 Finanzuebersicht/                  ← MAUI app (net10.0-ios, net10.0-maccatalyst)
 ├── MauiProgram.cs
@@ -78,12 +81,12 @@ Finanzuebersicht/                  ← MAUI app (net10.0-ios, net10.0-maccatalys
 ├── ViewModels/                    ← DashboardVM, TransactionsVM, SettingsVM, etc.
 ├── Views/                         ← XAML pages
 ├── Converters/                    ← Value converters for UI
-├── Resources/Strings/             ← AppResources.resx (+ .en.resx)
+├── Resources/Strings/             ← AppResources.resx (+ .de.resx)
 ├── Resources/Styles/              ← Colors.xaml, Styles.xaml
 └── Platforms/                     ← iOS, MacCatalyst
 
 Finanzuebersicht.Tests/            ← xUnit tests (net10.0)
-└── Services/                      ← LocalDataService, InitializationService tests
+└── Services/                      ← BackupService, DataMigrationService, InitializationService tests
 ```
 
 ## 7. Entwicklungs-Konventionen
@@ -133,9 +136,20 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 ## 9. Backup & Restore
 
 Nutzer können in den Einstellungen:
-- ✅ Backup erstellen (Export zu Ordner)
+- ✅ Backup erstellen (ZIP-Export mit allen Daten inkl. Budgets & Sparziele)
+- ✅ Backup wiederherstellen mit automatischer Schema-Migration
 - ✅ CSV-Import durchführen (mit Auto-Kategorisierung)
-- ✅ Daten exportieren
+
+### Schema-Versionierung
+
+Backups sind versioniert (`SchemaVersion` in den Metadaten). Der `DataMigrationService` migriert ältere Backups beim Restore automatisch auf die aktuelle Version:
+
+| Version | Inhalt |
+|---------|--------|
+| v1 | categories, transactions, recurring |
+| v2 | + budgets, sparziele |
+
+Neue Migratoren können als `IDataMigrator`-Implementierungen in DI registriert werden.
 
 ## 10. Versionierung
 
@@ -158,8 +172,10 @@ nbgv set-version <new-version>
 
 ## 11. CI/CD
 
-- **Quick Checks:** Unit Tests, Linter auf Ubuntu (schnell, billig)
-- **Full MAUI Build:** Nur für PRs gegen `main` und `main`-Pushes
+- **Quick Checks:** Unit Tests auf Ubuntu (schnell, günstig) — bei jedem Branch-Push
+- **Full MAUI Build:** Nur für PRs gegen `main` und `main`-Pushes (macOS-Runner)
+- **Pre-Release:** Bei jedem `main`-Push → automatisches Beta-Release mit Artifacts (macOS + Windows)
+- **Release:** Bei Tag-Push `v*` oder manuellem Trigger → Artifacts werden an GitHub Release angehängt
 - **Explizit triggern:** Label `run-maui` zur PR hinzufügen oder manuell via Actions starten
 
 ## 12. Fragen & Mitwirken

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -49,7 +49,7 @@ dotnet test Finanzuebersicht.Tests
 
 ## Key Resources
 
-- **Localization:** `Finanzuebersicht/Resources/Strings/AppResources.resx` (German), `AppResources.en.resx` (English)
+- **Localization:** `Finanzuebersicht/Resources/Strings/AppResources.resx` (German), `AppResources.de.resx`
 - **Colors:** `Finanzuebersicht/Resources/Styles/Colors.xaml`
 - **Architecture:** MVVM with CommunityToolkit.Mvvm
 - **Data:** JSON via `LocalDataService` (persisted locally)
@@ -60,6 +60,17 @@ dotnet test Finanzuebersicht.Tests
 - **DI:** Register all services in `MauiProgram.cs`
 - **Localization:** German (default) + English support
 - **Data Persistence:** JSON files locally; CloudKit available but not maintained
+- **Backup:** ZIP-based with schema versioning and automatic migration (`DataMigrationService`)
+
+## Features
+
+- Dashboard with monthly summary, charts and trend indicator
+- Transactions, recurring transactions (Daueraufträge), categories
+- Monthly budgets per category with progress tracking
+- Savings goals (Sparziele) with progress bar
+- Backup & Restore with automatic schema migration
+- Accessibility / VoiceOver support
+- Dark Mode, German & English UI
 
 ## Development Conventions
 


### PR DESCRIPTION
Dokumentation auf den Stand von v1.0.0 gebracht.

**README.md**
- Release-Badge hinzugefügt
- Kern-Features: Budgets, Sparziele, Backup/Migration, Accessibility
- CI/CD: Release-Workflow dokumentiert

**docs/GUIDE.md**
- Projektstruktur: `Application/` + `Infrastructure/` Layer ergänzt
- Backup-Sektion: Schema-Versionierung und v1→v2 Migrationstabelle
- CI/CD: Pre-Release + Release-Workflow beschrieben

**docs/QUICK_START.md**
- Features-Sektion neu
- Dateiname `AppResources.de.resx` korrigiert