### PR TITLE
🐛 fix(service,viewmodel): fix functional bugs from post-v1.0 review

### DIFF
--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -7,6 +7,7 @@ using System.Text.Json;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Finanzuebersicht.Services;
+using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Core.Services
 {
@@ -190,12 +191,12 @@ namespace Finanzuebersicht.Core.Services
                     archiveData = await _migrationService.MigrateAsync(archiveData, CurrentSchemaVersion);
                 }
 
-                // Deserialisiere die (ggf. migrierten) Daten
-                var categories = DeserializeFile<List<object>>(archiveData, "categories.json");
-                var transactions = DeserializeFile<List<object>>(archiveData, "transactions.json");
-                var recurring = DeserializeFile<List<object>>(archiveData, "recurring.json");
-                var budgets = DeserializeFile<List<object>>(archiveData, "budgets.json");
-                var sparziele = DeserializeFile<List<object>>(archiveData, "sparziele.json");
+                // Deserialisiere die (ggf. migrierten) Daten in konkrete Typen
+                var categories = DeserializeFile<List<Category>>(archiveData, "categories.json");
+                var transactions = DeserializeFile<List<Transaction>>(archiveData, "transactions.json");
+                var recurring = DeserializeFile<List<RecurringTransaction>>(archiveData, "recurring.json");
+                var budgets = DeserializeFile<List<CategoryBudget>>(archiveData, "budgets.json");
+                var sparziele = DeserializeFile<List<SparZiel>>(archiveData, "sparziele.json");
 
                 if (categories == null || transactions == null || recurring == null || budgets == null || sparziele == null)
                     return new RestoreResult { Success = false, ErrorMessage = "ZIP-Datei ist beschädigt oder unvollständig" };
@@ -232,34 +233,50 @@ namespace Finanzuebersicht.Core.Services
         /// <summary>
         /// Führt atomare Wiederherstellung mit Validierung durch.
         /// </summary>
-        private async Task<bool> AtomicRestoreAsync<T>(List<T> categories, List<T> transactions, List<T> recurring, List<T> budgets, List<T> sparziele, BackupMetadata metadata)
-            where T : class
+        /// <summary>
+        /// Stellt alle Daten aus dem Backup wieder her: löscht vorhandene Daten und schreibt Backup-Daten zurück.
+        /// </summary>
+        private async Task<bool> AtomicRestoreAsync(
+            List<Category> categories,
+            List<Transaction> transactions,
+            List<RecurringTransaction> recurring,
+            List<CategoryBudget> budgets,
+            List<SparZiel> sparziele,
+            BackupMetadata metadata)
         {
             try
             {
-                // Hinweis: Diese Implementierung nutzt die vorhandenen Save-Methoden.
-                // Für echte Atomarität würde man eine Transaktions-Wrapper-Schicht benötigen.
-                // Vorläufig: Serielle Operationen mit Fehlerbehandlung.
-
-                // Validiere, dass Daten nicht null sind
-                if (categories == null || transactions == null || recurring == null || budgets == null || sparziele == null)
-                {
-                    _logger?.LogError("Restore-Daten sind null");
-                    return false;
-                }
-
-                _logger?.LogInformation("Starte atomare Wiederherstellung mit {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträgen, {BudCount} Budgets, {SparCount} Sparzielen",
+                _logger?.LogInformation("Starte Wiederherstellung: {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträge, {BudCount} Budgets, {SparCount} Sparziele",
                     categories.Count, transactions.Count, recurring.Count, budgets.Count, sparziele.Count);
 
-                // TODO: Implementiere Transaktions-Wrapper für echte Atomarität
-                // Für MVP: Die Operationen sind idempotent, daher ist Rollback durch erneute
-                // Wiederherstellung eines früheren Backups möglich.
+                // Vorhandene Daten löschen
+                var existingCategories = await _dataService.GetCategoriesAsync();
+                foreach (var c in existingCategories) await _dataService.DeleteCategoryAsync(c.Id);
+
+                var existingTransactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+                foreach (var t in existingTransactions) await _dataService.DeleteTransactionAsync(t.Id);
+
+                var existingRecurring = await _dataService.GetRecurringTransactionsAsync();
+                foreach (var r in existingRecurring) await _dataService.DeleteRecurringTransactionAsync(r.Id);
+
+                var existingBudgets = await _dataService.GetBudgetsAsync();
+                foreach (var b in existingBudgets) await _dataService.DeleteBudgetAsync(b.Id);
+
+                var existingSparziele = await _dataService.GetSparZieleAsync();
+                foreach (var s in existingSparziele) await _dataService.DeleteSparZielAsync(s.Id);
+
+                // Backup-Daten speichern
+                foreach (var c in categories) await _dataService.SaveCategoryAsync(c);
+                foreach (var t in transactions) await _dataService.SaveTransactionAsync(t);
+                foreach (var r in recurring) await _dataService.SaveRecurringTransactionAsync(r);
+                foreach (var b in budgets) await _dataService.SaveBudgetAsync(b);
+                foreach (var s in sparziele) await _dataService.SaveSparZielAsync(s);
 
                 return true;
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Fehler bei atomarer Wiederherstellung");
+                _logger?.LogError(ex, "Fehler bei der Wiederherstellung");
                 return false;
             }
         }

--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -202,7 +202,7 @@ namespace Finanzuebersicht.Core.Services
                     return new RestoreResult { Success = false, ErrorMessage = "ZIP-Datei ist beschädigt oder unvollständig" };
 
                 // Atomare Restore mit Rollback-Capability
-                var restoreSuccess = await AtomicRestoreAsync(categories, transactions, recurring, budgets, sparziele, archiveData.Metadata);
+                var restoreSuccess = await AtomicRestoreAsync(categories, transactions, recurring, budgets, sparziele);
 
                 if (!restoreSuccess)
                     return new RestoreResult { Success = false, ErrorMessage = "Fehler beim Speichern der wiederhergestellten Daten" };
@@ -231,9 +231,6 @@ namespace Finanzuebersicht.Core.Services
         }
 
         /// <summary>
-        /// Führt atomare Wiederherstellung mit Validierung durch.
-        /// </summary>
-        /// <summary>
         /// Stellt alle Daten aus dem Backup wieder her: löscht vorhandene Daten und schreibt Backup-Daten zurück.
         /// </summary>
         private async Task<bool> AtomicRestoreAsync(
@@ -241,8 +238,7 @@ namespace Finanzuebersicht.Core.Services
             List<Transaction> transactions,
             List<RecurringTransaction> recurring,
             List<CategoryBudget> budgets,
-            List<SparZiel> sparziele,
-            BackupMetadata metadata)
+            List<SparZiel> sparziele)
         {
             try
             {

--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -232,6 +232,7 @@ namespace Finanzuebersicht.Core.Services
 
         /// <summary>
         /// Stellt alle Daten aus dem Backup wieder her: löscht vorhandene Daten und schreibt Backup-Daten zurück.
+        /// Bei einem Fehler wird ein Rollback auf den vorherigen Zustand durchgeführt.
         /// </summary>
         private async Task<bool> AtomicRestoreAsync(
             List<Category> categories,
@@ -240,26 +241,24 @@ namespace Finanzuebersicht.Core.Services
             List<CategoryBudget> budgets,
             List<SparZiel> sparziele)
         {
+            // Snapshot des aktuellen Zustands laden (für Rollback)
+            var snapshotCategories = await _dataService.GetCategoriesAsync();
+            var snapshotTransactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+            var snapshotRecurring = await _dataService.GetRecurringTransactionsAsync();
+            var snapshotBudgets = await _dataService.GetBudgetsAsync();
+            var snapshotSparziele = await _dataService.GetSparZieleAsync();
+
             try
             {
                 _logger?.LogInformation("Starte Wiederherstellung: {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträge, {BudCount} Budgets, {SparCount} Sparziele",
                     categories.Count, transactions.Count, recurring.Count, budgets.Count, sparziele.Count);
 
                 // Vorhandene Daten löschen
-                var existingCategories = await _dataService.GetCategoriesAsync();
-                foreach (var c in existingCategories) await _dataService.DeleteCategoryAsync(c.Id);
-
-                var existingTransactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
-                foreach (var t in existingTransactions) await _dataService.DeleteTransactionAsync(t.Id);
-
-                var existingRecurring = await _dataService.GetRecurringTransactionsAsync();
-                foreach (var r in existingRecurring) await _dataService.DeleteRecurringTransactionAsync(r.Id);
-
-                var existingBudgets = await _dataService.GetBudgetsAsync();
-                foreach (var b in existingBudgets) await _dataService.DeleteBudgetAsync(b.Id);
-
-                var existingSparziele = await _dataService.GetSparZieleAsync();
-                foreach (var s in existingSparziele) await _dataService.DeleteSparZielAsync(s.Id);
+                foreach (var c in snapshotCategories) await _dataService.DeleteCategoryAsync(c.Id);
+                foreach (var t in snapshotTransactions) await _dataService.DeleteTransactionAsync(t.Id);
+                foreach (var r in snapshotRecurring) await _dataService.DeleteRecurringTransactionAsync(r.Id);
+                foreach (var b in snapshotBudgets) await _dataService.DeleteBudgetAsync(b.Id);
+                foreach (var s in snapshotSparziele) await _dataService.DeleteSparZielAsync(s.Id);
 
                 // Backup-Daten speichern
                 foreach (var c in categories) await _dataService.SaveCategoryAsync(c);
@@ -272,8 +271,47 @@ namespace Finanzuebersicht.Core.Services
             }
             catch (Exception ex)
             {
-                _logger?.LogError(ex, "Fehler bei der Wiederherstellung");
+                _logger?.LogError(ex, "Fehler bei der Wiederherstellung – starte Rollback");
+                await RollbackAsync(snapshotCategories, snapshotTransactions, snapshotRecurring, snapshotBudgets, snapshotSparziele);
                 return false;
+            }
+        }
+
+        private async Task RollbackAsync(
+            List<Category> categories,
+            List<Transaction> transactions,
+            List<RecurringTransaction> recurring,
+            List<CategoryBudget> budgets,
+            List<SparZiel> sparziele)
+        {
+            try
+            {
+                var currentCategories = await _dataService.GetCategoriesAsync();
+                foreach (var c in currentCategories) await _dataService.DeleteCategoryAsync(c.Id);
+
+                var currentTransactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+                foreach (var t in currentTransactions) await _dataService.DeleteTransactionAsync(t.Id);
+
+                var currentRecurring = await _dataService.GetRecurringTransactionsAsync();
+                foreach (var r in currentRecurring) await _dataService.DeleteRecurringTransactionAsync(r.Id);
+
+                var currentBudgets = await _dataService.GetBudgetsAsync();
+                foreach (var b in currentBudgets) await _dataService.DeleteBudgetAsync(b.Id);
+
+                var currentSparziele = await _dataService.GetSparZieleAsync();
+                foreach (var s in currentSparziele) await _dataService.DeleteSparZielAsync(s.Id);
+
+                foreach (var c in categories) await _dataService.SaveCategoryAsync(c);
+                foreach (var t in transactions) await _dataService.SaveTransactionAsync(t);
+                foreach (var r in recurring) await _dataService.SaveRecurringTransactionAsync(r);
+                foreach (var b in budgets) await _dataService.SaveBudgetAsync(b);
+                foreach (var s in sparziele) await _dataService.SaveSparZielAsync(s);
+
+                _logger?.LogInformation("Rollback erfolgreich abgeschlossen");
+            }
+            catch (Exception rollbackEx)
+            {
+                _logger?.LogCritical(rollbackEx, "Rollback fehlgeschlagen – Datenzustand ist möglicherweise inkonsistent");
             }
         }
 

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -77,6 +77,8 @@ namespace Finanzuebersicht.Tests.Services
             _mockDataService.SetCategories(originalCategories);
             _mockDataService.SetTransactions(originalTransactions);
             _mockDataService.SetRecurring(originalRecurring);
+            _mockDataService.SetBudgets([new CategoryBudget { Id = "b1", KategorieId = "c1", Betrag = 300m }]);
+            _mockDataService.SetSparZiele([new SparZiel { Id = "s1", Titel = "Urlaub", ZielBetrag = 2000m }]);
 
             // Act 1: Create backup
             var backup = await service.CreateBackupAsync(backupPath);
@@ -86,12 +88,16 @@ namespace Finanzuebersicht.Tests.Services
             Assert.Equal(2, backup.EntityCounts["categories"]);
             Assert.Equal(2, backup.EntityCounts["transactions"]);
             Assert.Equal(1, backup.EntityCounts["recurring"]);
+            Assert.Equal(1, backup.EntityCounts["budgets"]);
+            Assert.Equal(1, backup.EntityCounts["sparziele"]);
             Assert.True(File.Exists(Path.Combine(backupPath, backup.FileName)));
 
             // Act 2: Restore backup — clear state first to verify data is re-saved
             _mockDataService.SetCategories([]);
             _mockDataService.SetTransactions([]);
             _mockDataService.SetRecurring([]);
+            _mockDataService.SetBudgets([]);
+            _mockDataService.SetSparZiele([]);
 
             var restoreResult = await service.RestoreBackupAsync(backupPath, backup.Id);
 
@@ -103,13 +109,19 @@ namespace Finanzuebersicht.Tests.Services
             var restoredCategories = await _mockDataService.GetCategoriesAsync();
             var restoredTransactions = await _mockDataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
             var restoredRecurring = await _mockDataService.GetRecurringTransactionsAsync();
+            var restoredBudgets = await _mockDataService.GetBudgetsAsync();
+            var restoredSparziele = await _mockDataService.GetSparZieleAsync();
 
             Assert.Equal(2, restoredCategories.Count);
             Assert.Equal(2, restoredTransactions.Count);
             Assert.Single(restoredRecurring);
+            Assert.Single(restoredBudgets);
+            Assert.Single(restoredSparziele);
             Assert.Contains(restoredCategories, c => c.Id == "c1" && c.Name == "Groceries");
             Assert.Contains(restoredTransactions, t => t.Id == "t1" && t.Betrag == 50.5m);
             Assert.Contains(restoredRecurring, r => r.Id == "r1" && r.Titel == "Rent");
+            Assert.Contains(restoredBudgets, b => b.Id == "b1" && b.Betrag == 300m);
+            Assert.Contains(restoredSparziele, s => s.Id == "s1" && s.Titel == "Urlaub");
         }
 
         [Fact]
@@ -264,6 +276,8 @@ namespace Finanzuebersicht.Tests.Services
             public void SetCategories(IEnumerable<Category> categories) => _categories = categories.ToList();
             public void SetTransactions(IEnumerable<Transaction> transactions) => _transactions = transactions.ToList();
             public void SetRecurring(IEnumerable<RecurringTransaction> recurring) => _recurring = recurring.ToList();
+            public void SetBudgets(IEnumerable<CategoryBudget> budgets) => _budgets = budgets.ToList();
+            public void SetSparZiele(IEnumerable<SparZiel> sparziele) => _sparziele = sparziele.ToList();
 
             public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(_categories.ToList());
             public Task SaveCategoryAsync(Category category)
@@ -320,7 +334,7 @@ namespace Finanzuebersicht.Tests.Services
                 if (idx >= 0) _sparziele[idx] = sparZiel; else _sparziele.Add(sparZiel);
                 return Task.CompletedTask;
             }
-            public Task DeleteSparZielAsync(string id) => Task.CompletedTask;
+            public Task DeleteSparZielAsync(string id) { _sparziele.RemoveAll(s => s.Id == id); return Task.CompletedTask; }
         }
 
         private class MockSettingsService : SettingsService

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -88,13 +88,28 @@ namespace Finanzuebersicht.Tests.Services
             Assert.Equal(1, backup.EntityCounts["recurring"]);
             Assert.True(File.Exists(Path.Combine(backupPath, backup.FileName)));
 
-            // Act 2: Restore backup
+            // Act 2: Restore backup — clear state first to verify data is re-saved
+            _mockDataService.SetCategories([]);
+            _mockDataService.SetTransactions([]);
+            _mockDataService.SetRecurring([]);
+
             var restoreResult = await service.RestoreBackupAsync(backupPath, backup.Id);
 
-            // Assert 2: Restore successful
+            // Assert 2: Restore successful and data actually written back
             Assert.True(restoreResult.Success, restoreResult.ErrorMessage);
             Assert.NotNull(restoreResult.RestoredMetadata);
             Assert.Equal(backup.Id, restoreResult.RestoredMetadata.Id);
+
+            var restoredCategories = await _mockDataService.GetCategoriesAsync();
+            var restoredTransactions = await _mockDataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+            var restoredRecurring = await _mockDataService.GetRecurringTransactionsAsync();
+
+            Assert.Equal(2, restoredCategories.Count);
+            Assert.Equal(2, restoredTransactions.Count);
+            Assert.Single(restoredRecurring);
+            Assert.Contains(restoredCategories, c => c.Id == "c1" && c.Name == "Groceries");
+            Assert.Contains(restoredTransactions, t => t.Id == "t1" && t.Betrag == 50.5m);
+            Assert.Contains(restoredRecurring, r => r.Id == "r1" && r.Titel == "Rent");
         }
 
         [Fact]
@@ -243,41 +258,68 @@ namespace Finanzuebersicht.Tests.Services
             private List<Category> _categories = [];
             private List<Transaction> _transactions = [];
             private List<RecurringTransaction> _recurring = [];
+            private List<CategoryBudget> _budgets = [];
+            private List<SparZiel> _sparziele = [];
 
             public void SetCategories(IEnumerable<Category> categories) => _categories = categories.ToList();
             public void SetTransactions(IEnumerable<Transaction> transactions) => _transactions = transactions.ToList();
             public void SetRecurring(IEnumerable<RecurringTransaction> recurring) => _recurring = recurring.ToList();
 
-            public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(_categories);
-            public Task SaveCategoryAsync(Category category) => Task.CompletedTask;
-            public Task DeleteCategoryAsync(string id) => Task.CompletedTask;
+            public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(_categories.ToList());
+            public Task SaveCategoryAsync(Category category)
+            {
+                var idx = _categories.FindIndex(c => c.Id == category.Id);
+                if (idx >= 0) _categories[idx] = category; else _categories.Add(category);
+                return Task.CompletedTask;
+            }
+            public Task DeleteCategoryAsync(string id) { _categories.RemoveAll(c => c.Id == id); return Task.CompletedTask; }
 
             public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum)
                 => Task.FromResult(_transactions.Where(t => t.Datum >= vonDatum && t.Datum <= bisDatum).ToList());
-            public Task SaveTransactionAsync(Transaction transaction) => Task.CompletedTask;
-            public Task DeleteTransactionAsync(string id) => Task.CompletedTask;
+            public Task SaveTransactionAsync(Transaction transaction)
+            {
+                var idx = _transactions.FindIndex(t => t.Id == transaction.Id);
+                if (idx >= 0) _transactions[idx] = transaction; else _transactions.Add(transaction);
+                return Task.CompletedTask;
+            }
+            public Task DeleteTransactionAsync(string id) { _transactions.RemoveAll(t => t.Id == id); return Task.CompletedTask; }
             public Task<Category?> GetMostCommonCategoryForPayeeAsync(
                 string payee,
                 double confidenceThreshold = 0.5,
                 CancellationToken cancellationToken = default)
                 => Task.FromResult<Category?>(null);
 
-            public Task<List<RecurringTransaction>> GetRecurringTransactionsAsync() => Task.FromResult(_recurring);
-            public Task SaveRecurringTransactionAsync(RecurringTransaction recurring) => Task.CompletedTask;
-            public Task DeleteRecurringTransactionAsync(string id) => Task.CompletedTask;
+            public Task<List<RecurringTransaction>> GetRecurringTransactionsAsync() => Task.FromResult(_recurring.ToList());
+            public Task SaveRecurringTransactionAsync(RecurringTransaction recurring)
+            {
+                var idx = _recurring.FindIndex(r => r.Id == recurring.Id);
+                if (idx >= 0) _recurring[idx] = recurring; else _recurring.Add(recurring);
+                return Task.CompletedTask;
+            }
+            public Task DeleteRecurringTransactionAsync(string id) { _recurring.RemoveAll(r => r.Id == id); return Task.CompletedTask; }
 
             public Task GeneratePendingRecurringTransactionsAsync() => Task.CompletedTask;
 
             public Task<YearSummary> GetYearSummaryAsync(int year) => Task.FromResult(new YearSummary());
             public Task<MonthSummary> GetMonthSummaryAsync(int year, int month) => Task.FromResult(new MonthSummary());
 
-            public Task<List<CategoryBudget>> GetBudgetsAsync() => Task.FromResult(new List<CategoryBudget>());
-            public Task SaveBudgetAsync(CategoryBudget budget) => Task.CompletedTask;
-            public Task DeleteBudgetAsync(string id) => Task.CompletedTask;
+            public Task<List<CategoryBudget>> GetBudgetsAsync() => Task.FromResult(_budgets.ToList());
+            public Task SaveBudgetAsync(CategoryBudget budget)
+            {
+                var idx = _budgets.FindIndex(b => b.Id == budget.Id);
+                if (idx >= 0) _budgets[idx] = budget; else _budgets.Add(budget);
+                return Task.CompletedTask;
+            }
+            public Task DeleteBudgetAsync(string id) { _budgets.RemoveAll(b => b.Id == id); return Task.CompletedTask; }
             public Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month) => Task.FromResult<CategoryBudget?>(null);
 
-            public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(new List<SparZiel>());
-            public Task SaveSparZielAsync(SparZiel sparZiel) => Task.CompletedTask;
+            public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(_sparziele.ToList());
+            public Task SaveSparZielAsync(SparZiel sparZiel)
+            {
+                var idx = _sparziele.FindIndex(s => s.Id == sparZiel.Id);
+                if (idx >= 0) _sparziele[idx] = sparZiel; else _sparziele.Add(sparZiel);
+                return Task.CompletedTask;
+            }
             public Task DeleteSparZielAsync(string id) => Task.CompletedTask;
         }
 

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -86,6 +86,7 @@
   <data name="Err_TitelErforderlich" xml:space="preserve"><value>Titel ist erforderlich</value></data>
   <data name="Err_KategorieErforderlich" xml:space="preserve"><value>Kategorie ist erforderlich</value></data>
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Fehler beim Speichern: {0}</value></data>
+  <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Löschen: {0}</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Ordner konnte nicht gewählt werden: {0}</value></data>
 
   <!-- Confirmation Dialogs -->

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -86,6 +86,7 @@
   <data name="Err_TitelErforderlich" xml:space="preserve"><value>Title is required</value></data>
   <data name="Err_KategorieErforderlich" xml:space="preserve"><value>Category is required</value></data>
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Error saving: {0}</value></data>
+  <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Error deleting: {0}</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Folder could not be selected: {0}</value></data>
 
   <!-- Confirmation Dialogs -->

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -86,6 +86,7 @@ public static class ResourceKeys
     public const string Err_TitelErforderlich = nameof(Err_TitelErforderlich);
     public const string Err_KategorieErforderlich = nameof(Err_KategorieErforderlich);
     public const string Err_SpeichernFehlgeschlagen = nameof(Err_SpeichernFehlgeschlagen);
+    public const string Err_LoeschenFehlgeschlagen = nameof(Err_LoeschenFehlgeschlagen);
     public const string Err_OrdnerNichtWaehlbar = nameof(Err_OrdnerNichtWaehlbar);
 
     // Confirmation Dialogs

--- a/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -8,6 +8,7 @@ using Finanzuebersicht.Application.UseCases.RecurringTransactions;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Views;
+using Finanzuebersicht.Resources.Strings;
 
 namespace Finanzuebersicht.ViewModels;
 
@@ -19,6 +20,8 @@ public partial class RecurringTransactionDetailViewModel(
     RemoveRecurringExceptionUseCase removeRecurringExceptionUseCase,
     ITransactionValidationService validationService,
     INavigationService navigationService,
+    IDialogService dialogService,
+    ILocalizationService localizationService,
     ILogger<RecurringTransactionDetailViewModel>? logger = null,
     Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject
 {
@@ -29,6 +32,8 @@ public partial class RecurringTransactionDetailViewModel(
     private readonly ITransactionValidationService _validationService = validationService;
     private RecurringTransaction? _existing;
     private readonly INavigationService _navigationService = navigationService;
+    private readonly IDialogService _dialogService = dialogService;
+    private readonly ILocalizationService _loc = localizationService;
     private readonly ILogger<RecurringTransactionDetailViewModel>? _logger = logger;
     private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
 
@@ -138,8 +143,22 @@ public partial class RecurringTransactionDetailViewModel(
                 SelectedKategorie != null,
                 System.Globalization.CultureInfo.CurrentCulture,
                 out var betrag,
-                out _))
+                out var error))
+        {
+            var message = error switch
+            {
+                TransactionInputError.InvalidAmountFormat => _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                TransactionInputError.AmountMustBePositive => _loc.GetString(ResourceKeys.Err_BetragGroesserNull),
+                TransactionInputError.TitleRequired => _loc.GetString(ResourceKeys.Err_TitelErforderlich),
+                TransactionInputError.CategoryRequired => _loc.GetString(ResourceKeys.Err_KategorieErforderlich),
+                _ => _loc.GetString(ResourceKeys.Err_UngueltigerBetrag)
+            };
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                message,
+                _loc.GetString(ResourceKeys.Btn_OK));
             return;
+        }
 
         // parse numeric text fields (Entry bindings)
         if (!int.TryParse(IntervalFactorText, out var parsedFactor) || parsedFactor <= 0)

--- a/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
@@ -73,7 +73,7 @@ public partial class RecurringTransactionsViewModel(
         {
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
         }
     }

--- a/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
@@ -64,8 +64,18 @@ public partial class RecurringTransactionsViewModel(
 
         if (!bestaetigt) return;
 
-        await _deleteRecurringTransactionUseCase.ExecuteAsync(dauerauftrag.Id);
-        Dauerauftraege.Remove(dauerauftrag);
+        try
+        {
+            await _deleteRecurringTransactionUseCase.ExecuteAsync(dauerauftrag.Id);
+            Dauerauftraege.Remove(dauerauftrag);
+        }
+        catch
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, dauerauftrag.Titel),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
@@ -69,11 +69,11 @@ public partial class RecurringTransactionsViewModel(
             await _deleteRecurringTransactionUseCase.ExecuteAsync(dauerauftrag.Id);
             Dauerauftraege.Remove(dauerauftrag);
         }
-        catch
+        catch (Exception ex)
         {
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, dauerauftrag.Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
         }
     }

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -79,7 +79,7 @@ public partial class TransactionsViewModel(
             try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsViewModel", $"DeleteTransaktion failed for {transaktion.Id}", ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_Titel),
-                _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
                 _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Btn_OK));
         }
     }

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -65,24 +65,21 @@ public partial class TransactionsViewModel(
         try
         {
             await _deleteTransactionUseCase.ExecuteAsync(transaktion.Id);
-            foreach (var gruppe in TransaktionsGruppen)
+            var gruppe = TransaktionsGruppen.FirstOrDefault(g => g.Contains(transaktion));
+            if (gruppe != null)
             {
-                if (gruppe.Remove(transaktion))
-                {
-                    if (gruppe.Count == 0)
-                    {
-                        TransaktionsGruppen.Remove(gruppe);
-                    }
-
-                    break;
-                }
+                gruppe.Remove(transaktion);
+                if (gruppe.Count == 0)
+                    TransaktionsGruppen.Remove(gruppe);
             }
         }
-        catch
+        catch (Exception ex)
         {
+            _logger?.LogError(ex, "DeleteTransaktion failed for transaction {Id}", transaktion.Id);
+            try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsViewModel", $"DeleteTransaktion failed for {transaktion.Id}", ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_Titel),
-                _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_SpeichernFehlgeschlagen, transaktion.Titel),
+                _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Btn_OK));
         }
     }

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -62,18 +62,28 @@ public partial class TransactionsViewModel(
     [RelayCommand]
     private async Task DeleteTransaktion(Transaction transaktion)
     {
-        await _deleteTransactionUseCase.ExecuteAsync(transaktion.Id);
-        foreach (var gruppe in TransaktionsGruppen)
+        try
         {
-            if (gruppe.Remove(transaktion))
+            await _deleteTransactionUseCase.ExecuteAsync(transaktion.Id);
+            foreach (var gruppe in TransaktionsGruppen)
             {
-                if (gruppe.Count == 0)
+                if (gruppe.Remove(transaktion))
                 {
-                    TransaktionsGruppen.Remove(gruppe);
-                }
+                    if (gruppe.Count == 0)
+                    {
+                        TransaktionsGruppen.Remove(gruppe);
+                    }
 
-                break;
+                    break;
+                }
             }
+        }
+        catch
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_Titel),
+                _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_SpeichernFehlgeschlagen, transaktion.Titel),
+                _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Btn_OK));
         }
     }
 


### PR DESCRIPTION
Behebt 4 funktionale Bugs die beim Code Review nach v1.0.0 gefunden wurden.

### 🔴 Kritisch: Restore hat nie Daten gespeichert
`AtomicRestoreAsync` war ein kompletter Stub — gab immer `true` zurück ohne eine einzige Zeile zu schreiben. Benutzer bekamen eine Erfolgsmeldung, aber ihre Daten wurden nicht wiederhergestellt.

**Fix:** Implementiert delete-all + save-all für alle 5 Entity-Typen (categories, transactions, recurring, budgets, sparziele). Deserialisierung auf konkrete Typen umgestellt.

**Test:** `FullBackupRestoreCycle` prüft jetzt wirklich ob Daten nach dem Restore im DataService vorhanden sind (MockDataService trackt Save/Delete).

### 🟠 Validation ohne Fehlerdialog (`RecurringTransactionDetailViewModel`)
`Save()` zeigte bei ungültigem Input keinen Dialog — inkonsistent mit `TransactionDetailViewModel`.
**Fix:** `IDialogService` + `ILocalizationService` injiziert, Alert-Dialog wie in TransactionDetail.

### 🟠 Delete-Fehler ohne Handling
`DeleteDauerauftrag` und `DeleteTransaktion` hatten kein try-catch — Exceptions führten zu unbehandelten Fehlern.
**Fix:** try-catch mit Fehlerdialog, UI-Remove nur bei Erfolg.