### PR TITLE
📝 docs: Roadmap hinzufügen

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ See [Quick Start (docs/QUICK_START.md)](docs/QUICK_START.md) for a concise guide
 
 ## Dokumentation
 
+- Roadmap & geplante Features: [docs/ROADMAP.md](docs/ROADMAP.md)
 - Kategorisierungs-Regeln: [docs/CATEGORIZATION_RULES.md](docs/CATEGORIZATION_RULES.md)
 - (Einige alte Docs wurden entfernt oder zusammengeführt.)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,7 +16,7 @@
 
 ---
 
-## 🔧 v1.1 — Qualität & Performance *(geplant)*
+## 🔧 v1.1 — Qualität & Performance *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/5)
 
 Fokus: Code-Qualität, technische Schulden abbauen, Performance verbessern.
 
@@ -29,7 +29,7 @@ Fokus: Code-Qualität, technische Schulden abbauen, Performance verbessern.
 
 ---
 
-## 📊 v1.2 — Export & Auswertungen *(geplant)*
+## 📊 v1.2 — Export & Auswertungen *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/6)
 
 Fokus: Erweiterte Exportmöglichkeiten für Steuern und Analysen.
 
@@ -39,7 +39,7 @@ Fokus: Erweiterte Exportmöglichkeiten für Steuern und Analysen.
 
 ---
 
-## 🔐 v2.0 — Sicherheit & Multi-Account *(geplant)*
+## 🔐 v2.0 — Sicherheit & Multi-Account *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/7)
 
 Fokus: Größere Architekturänderungen – eigener Release-Zyklus.
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,64 @@
+# Roadmap
+
+Übersicht über geplante Releases und Features. Die Roadmap wird fortlaufend aktualisiert.
+
+---
+
+## ✅ v1.0 — Stable Release *(abgeschlossen)*
+
+- Transaktionen, Kategorien, Daueraufträge
+- Dashboard mit Charts (Monatsübersicht, Jahresverlauf)
+- Budgetverwaltung & Sparziele
+- Backup / Restore mit Schema-Migrations-Framework
+- Accessibility (VoiceOver / Tastaturnavigation)
+- CI/CD: Build-Artifacts für macOS & Windows
+- Vollständige Fehlerbehandlung in allen ViewModels
+
+---
+
+## 🔧 v1.1 — Qualität & Performance *(geplant)*
+
+Fokus: Code-Qualität, technische Schulden abbauen, Performance verbessern.
+
+| Issue | Thema | Aufwand |
+|-------|-------|---------|
+| [#101](https://github.com/tom4711/finanzuebersicht/issues/101) | Store-Basisklasse (`JsonStore<T>`) – DRY für alle 5 Stores | M |
+| [#102](https://github.com/tom4711/finanzuebersicht/issues/102) | `YearOverviewViewModel`: `List<>` → `ObservableCollection` | S |
+| [#103](https://github.com/tom4711/finanzuebersicht/issues/103) | Namespace-Bereinigung (ASCII-Konvention) | M |
+| [#100](https://github.com/tom4711/finanzuebersicht/issues/100) | Bulk-Replace API für Restore (O(n²) → O(n) I/O) | M |
+
+---
+
+## 📊 v1.2 — Export & Auswertungen *(geplant)*
+
+Fokus: Erweiterte Exportmöglichkeiten für Steuern und Analysen.
+
+| Issue | Thema | Aufwand |
+|-------|-------|---------|
+| [#64](https://github.com/tom4711/finanzuebersicht/issues/64) | CSV/PDF-Export für Steuerzwecke | M |
+
+---
+
+## 🔐 v2.0 — Sicherheit & Multi-Account *(geplant)*
+
+Fokus: Größere Architekturänderungen – eigener Release-Zyklus.
+
+| Issue | Thema | Aufwand |
+|-------|-------|---------|
+| [#53](https://github.com/tom4711/finanzuebersicht/issues/53) | Optionale lokale Verschlüsselung (PBKDF2/Argon2) | L |
+| [#49](https://github.com/tom4711/finanzuebersicht/issues/49) | Multi-Account & Währungsunterstützung | XL |
+
+---
+
+## 💡 Ideen / Nicht eingeplant
+
+Features, die diskutiert wurden aber noch keinen Milestone haben:
+
+- CloudKit-Sync (erfordert Apple Developer Membership)
+- Widget für iOS/macOS
+- Wiederkehrende Transaktionen mit variablem Betrag
+- Kategorien-Hierarchie (Ober-/Unterkategorien)
+
+---
+
+*Versionsschema: [Nerdbank.GitVersioning](https://github.com/dotnet/Nerdbank.GitVersioning) – Patch-Version = Git-Commit-Höhe*


### PR DESCRIPTION
Fügt `docs/ROADMAP.md` mit strukturierten Meilensteinen hinzu.

## Inhalt

- **v1.0** ✅ als abgeschlossen markiert
- **v1.1** Refactoring-Issues #100–#103 (Store-Basisklasse, ObservableCollection, Namespace, Bulk-Replace)
- **v1.2** CSV/PDF-Export (#64)
- **v2.0** Verschlüsselung (#53) + Multi-Account (#49)
- Ideen-Sektion für nicht eingeplante Features