### PR TITLE
⚡ perf(service): Bulk-Replace API für O(1) Restore

### DIFF
--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -231,7 +231,7 @@ namespace Finanzuebersicht.Core.Services
         }
 
         /// <summary>
-        /// Stellt alle Daten aus dem Backup wieder her: löscht vorhandene Daten und schreibt Backup-Daten zurück.
+        /// Stellt alle Daten aus dem Backup wieder her in je einem einzigen Schreibvorgang pro Entity-Typ.
         /// Bei einem Fehler wird ein Rollback auf den vorherigen Zustand durchgeführt.
         /// </summary>
         private async Task<bool> AtomicRestoreAsync(
@@ -253,19 +253,11 @@ namespace Finanzuebersicht.Core.Services
                 _logger?.LogInformation("Starte Wiederherstellung: {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträge, {BudCount} Budgets, {SparCount} Sparziele",
                     categories.Count, transactions.Count, recurring.Count, budgets.Count, sparziele.Count);
 
-                // Vorhandene Daten löschen
-                foreach (var c in snapshotCategories) await _dataService.DeleteCategoryAsync(c.Id);
-                foreach (var t in snapshotTransactions) await _dataService.DeleteTransactionAsync(t.Id);
-                foreach (var r in snapshotRecurring) await _dataService.DeleteRecurringTransactionAsync(r.Id);
-                foreach (var b in snapshotBudgets) await _dataService.DeleteBudgetAsync(b.Id);
-                foreach (var s in snapshotSparziele) await _dataService.DeleteSparZielAsync(s.Id);
-
-                // Backup-Daten speichern
-                foreach (var c in categories) await _dataService.SaveCategoryAsync(c);
-                foreach (var t in transactions) await _dataService.SaveTransactionAsync(t);
-                foreach (var r in recurring) await _dataService.SaveRecurringTransactionAsync(r);
-                foreach (var b in budgets) await _dataService.SaveBudgetAsync(b);
-                foreach (var s in sparziele) await _dataService.SaveSparZielAsync(s);
+                await _dataService.ReplaceAllCategoriesAsync(categories);
+                await _dataService.ReplaceAllTransactionsAsync(transactions);
+                await _dataService.ReplaceAllRecurringTransactionsAsync(recurring);
+                await _dataService.ReplaceAllBudgetsAsync(budgets);
+                await _dataService.ReplaceAllSparZieleAsync(sparziele);
 
                 return true;
             }
@@ -286,26 +278,11 @@ namespace Finanzuebersicht.Core.Services
         {
             try
             {
-                var currentCategories = await _dataService.GetCategoriesAsync();
-                foreach (var c in currentCategories) await _dataService.DeleteCategoryAsync(c.Id);
-
-                var currentTransactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
-                foreach (var t in currentTransactions) await _dataService.DeleteTransactionAsync(t.Id);
-
-                var currentRecurring = await _dataService.GetRecurringTransactionsAsync();
-                foreach (var r in currentRecurring) await _dataService.DeleteRecurringTransactionAsync(r.Id);
-
-                var currentBudgets = await _dataService.GetBudgetsAsync();
-                foreach (var b in currentBudgets) await _dataService.DeleteBudgetAsync(b.Id);
-
-                var currentSparziele = await _dataService.GetSparZieleAsync();
-                foreach (var s in currentSparziele) await _dataService.DeleteSparZielAsync(s.Id);
-
-                foreach (var c in categories) await _dataService.SaveCategoryAsync(c);
-                foreach (var t in transactions) await _dataService.SaveTransactionAsync(t);
-                foreach (var r in recurring) await _dataService.SaveRecurringTransactionAsync(r);
-                foreach (var b in budgets) await _dataService.SaveBudgetAsync(b);
-                foreach (var s in sparziele) await _dataService.SaveSparZielAsync(s);
+                await _dataService.ReplaceAllCategoriesAsync(categories);
+                await _dataService.ReplaceAllTransactionsAsync(transactions);
+                await _dataService.ReplaceAllRecurringTransactionsAsync(recurring);
+                await _dataService.ReplaceAllBudgetsAsync(budgets);
+                await _dataService.ReplaceAllSparZieleAsync(sparziele);
 
                 _logger?.LogInformation("Rollback erfolgreich abgeschlossen");
             }

--- a/Finanzuebersicht.Core/Services/DataServiceFacade.cs
+++ b/Finanzuebersicht.Core/Services/DataServiceFacade.cs
@@ -28,6 +28,9 @@ public class DataServiceFacade(
     public Task DeleteCategoryAsync(string id)
         => _categoryRepository.DeleteCategoryAsync(id);
 
+    public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories)
+        => _categoryRepository.ReplaceAllCategoriesAsync(categories);
+
     public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum)
         => _transactionRepository.GetTransactionsAsync(vonDatum, bisDatum);
 
@@ -37,6 +40,9 @@ public class DataServiceFacade(
     public Task DeleteTransactionAsync(string id)
         => _transactionRepository.DeleteTransactionAsync(id);
 
+    public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions)
+        => _transactionRepository.ReplaceAllTransactionsAsync(transactions);
+
     public Task<List<RecurringTransaction>> GetRecurringTransactionsAsync()
         => _recurringRepository.GetRecurringTransactionsAsync();
 
@@ -45,6 +51,9 @@ public class DataServiceFacade(
 
     public Task DeleteRecurringTransactionAsync(string id)
         => _recurringRepository.DeleteRecurringTransactionAsync(id);
+
+    public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring)
+        => _recurringRepository.ReplaceAllRecurringTransactionsAsync(recurring);
 
     public Task GeneratePendingRecurringTransactionsAsync()
         => _recurringGenerationService.GeneratePendingRecurringTransactionsAsync();
@@ -73,6 +82,9 @@ public class DataServiceFacade(
     public Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month)
         => _budgetRepository.GetBudgetForCategoryAsync(kategorieId, year, month);
 
+    public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets)
+        => _budgetRepository.ReplaceAllBudgetsAsync(budgets);
+
     public Task<List<SparZiel>> GetSparZieleAsync()
         => _sparZielRepository.GetSparZieleAsync();
 
@@ -81,4 +93,7 @@ public class DataServiceFacade(
 
     public Task DeleteSparZielAsync(string id)
         => _sparZielRepository.DeleteSparZielAsync(id);
+
+    public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele)
+        => _sparZielRepository.ReplaceAllSparZieleAsync(sparziele);
 }

--- a/Finanzuebersicht.Core/Services/IBudgetRepository.cs
+++ b/Finanzuebersicht.Core/Services/IBudgetRepository.cs
@@ -8,4 +8,5 @@ public interface IBudgetRepository
     Task SaveBudgetAsync(CategoryBudget budget);
     Task DeleteBudgetAsync(string id);
     Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month);
+    Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets);
 }

--- a/Finanzuebersicht.Core/Services/ICategoryRepository.cs
+++ b/Finanzuebersicht.Core/Services/ICategoryRepository.cs
@@ -7,4 +7,5 @@ public interface ICategoryRepository
     Task<List<Category>> GetCategoriesAsync();
     Task SaveCategoryAsync(Category category);
     Task DeleteCategoryAsync(string id);
+    Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories);
 }

--- a/Finanzuebersicht.Core/Services/IRecurringTransactionRepository.cs
+++ b/Finanzuebersicht.Core/Services/IRecurringTransactionRepository.cs
@@ -7,4 +7,5 @@ public interface IRecurringTransactionRepository
     Task<List<RecurringTransaction>> GetRecurringTransactionsAsync();
     Task SaveRecurringTransactionAsync(RecurringTransaction recurring);
     Task DeleteRecurringTransactionAsync(string id);
+    Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring);
 }

--- a/Finanzuebersicht.Core/Services/ISparZielRepository.cs
+++ b/Finanzuebersicht.Core/Services/ISparZielRepository.cs
@@ -7,4 +7,5 @@ public interface ISparZielRepository
     Task<List<SparZiel>> GetSparZieleAsync();
     Task SaveSparZielAsync(SparZiel sparZiel);
     Task DeleteSparZielAsync(string id);
+    Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele);
 }

--- a/Finanzuebersicht.Core/Services/ITransactionRepository.cs
+++ b/Finanzuebersicht.Core/Services/ITransactionRepository.cs
@@ -7,6 +7,7 @@ public interface ITransactionRepository
     Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum);
     Task SaveTransactionAsync(Transaction transaction);
     Task DeleteTransactionAsync(string id);
+    Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions);
 
     /// <summary>
     /// Finds the most common (non-Unkategorisiert) category for a given payee name.

--- a/Finanzuebersicht.Infrastructure/Services/BudgetStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/BudgetStore.cs
@@ -43,6 +43,9 @@ public class BudgetStore : JsonDataStoreBase, IBudgetRepository
         finally { StoreLock.Release(); }
     }
 
+    public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets)
+        => ReplaceAllAsync(BudgetsFile, budgets);
+
     public async Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month)
     {
         var budgets = await GetBudgetsAsync();

--- a/Finanzuebersicht.Infrastructure/Services/CategoryStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/CategoryStore.cs
@@ -62,4 +62,7 @@ public class CategoryStore : JsonDataStoreBase, ICategoryRepository
             StoreLock.Release();
         }
     }
+
+    public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories)
+        => ReplaceAllAsync(CategoriesFile, categories);
 }

--- a/Finanzuebersicht.Infrastructure/Services/JsonDataStoreBase.cs
+++ b/Finanzuebersicht.Infrastructure/Services/JsonDataStoreBase.cs
@@ -57,8 +57,9 @@ public abstract class JsonDataStoreBase : IDisposable
     }
 
     /// <summary>
-    /// Atomically replaces the entire collection in the JSON file with the given items.
-    /// O(1) I/O regardless of collection size — use for bulk restore operations.
+    /// Replaces the entire collection in the JSON file with the given items.
+    /// Thread-safe via <see cref="StoreLock"/>. One file write regardless of collection size —
+    /// use for bulk restore operations instead of individual Save/Delete calls.
     /// </summary>
     protected async Task ReplaceAllAsync<T>(string path, IEnumerable<T> items)
     {

--- a/Finanzuebersicht.Infrastructure/Services/JsonDataStoreBase.cs
+++ b/Finanzuebersicht.Infrastructure/Services/JsonDataStoreBase.cs
@@ -56,6 +56,23 @@ public abstract class JsonDataStoreBase : IDisposable
         await File.WriteAllTextAsync(path, json);
     }
 
+    /// <summary>
+    /// Atomically replaces the entire collection in the JSON file with the given items.
+    /// O(1) I/O regardless of collection size — use for bulk restore operations.
+    /// </summary>
+    protected async Task ReplaceAllAsync<T>(string path, IEnumerable<T> items)
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            await SaveAsync(path, [..items]);
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
     public virtual void Dispose()
     {
         StoreLock.Dispose();

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -73,6 +73,9 @@ public class LocalDataService : IDataService, IDisposable
     public async Task DeleteCategoryAsync(string id)
         => await _categoryStore.DeleteCategoryAsync(id);
 
+    public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories)
+        => _categoryStore.ReplaceAllCategoriesAsync(categories);
+
     #endregion
 
     #region ITransactionRepository delegation
@@ -85,6 +88,9 @@ public class LocalDataService : IDataService, IDisposable
 
     public async Task DeleteTransactionAsync(string id)
         => await _transactionStore.DeleteTransactionAsync(id);
+
+    public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions)
+        => _transactionStore.ReplaceAllTransactionsAsync(transactions);
 
     public async Task<Category?> GetMostCommonCategoryForPayeeAsync(
         string payee,
@@ -104,6 +110,9 @@ public class LocalDataService : IDataService, IDisposable
 
     public async Task DeleteRecurringTransactionAsync(string id)
         => await _recurringStore.DeleteRecurringTransactionAsync(id);
+
+    public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring)
+        => _recurringStore.ReplaceAllRecurringTransactionsAsync(recurring);
 
     #endregion
 
@@ -131,6 +140,8 @@ public class LocalDataService : IDataService, IDisposable
     public Task DeleteBudgetAsync(string id) => _budgetStore.DeleteBudgetAsync(id);
     public Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month)
         => _budgetStore.GetBudgetForCategoryAsync(kategorieId, year, month);
+    public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets)
+        => _budgetStore.ReplaceAllBudgetsAsync(budgets);
 
     #endregion
 
@@ -139,6 +150,8 @@ public class LocalDataService : IDataService, IDisposable
     public Task<List<SparZiel>> GetSparZieleAsync() => _sparZielStore.GetSparZieleAsync();
     public Task SaveSparZielAsync(SparZiel sparZiel) => _sparZielStore.SaveSparZielAsync(sparZiel);
     public Task DeleteSparZielAsync(string id) => _sparZielStore.DeleteSparZielAsync(id);
+    public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele)
+        => _sparZielStore.ReplaceAllSparZieleAsync(sparziele);
 
     #endregion
 

--- a/Finanzuebersicht.Infrastructure/Services/RecurringStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/RecurringStore.cs
@@ -62,4 +62,7 @@ public class RecurringStore : JsonDataStoreBase, IRecurringTransactionRepository
             StoreLock.Release();
         }
     }
+
+    public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring)
+        => ReplaceAllAsync(RecurringFile, recurring);
 }

--- a/Finanzuebersicht.Infrastructure/Services/SparZielStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/SparZielStore.cs
@@ -42,4 +42,7 @@ public class SparZielStore : JsonDataStoreBase, ISparZielRepository
         }
         finally { StoreLock.Release(); }
     }
+
+    public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele)
+        => ReplaceAllAsync(SparZieleFile, sparziele);
 }

--- a/Finanzuebersicht.Infrastructure/Services/TransactionStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/TransactionStore.cs
@@ -71,6 +71,9 @@ public class TransactionStore : JsonDataStoreBase, ITransactionRepository
         }
     }
 
+    public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions)
+        => ReplaceAllAsync(TransactionsFile, transactions);
+
     /// <summary>
     /// Finds the most common category for a given payee name (case-insensitive).
     /// Only considers non-Unkategorisiert categories with a confidence threshold.

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -287,6 +287,7 @@ namespace Finanzuebersicht.Tests.Services
                 return Task.CompletedTask;
             }
             public Task DeleteCategoryAsync(string id) { _categories.RemoveAll(c => c.Id == id); return Task.CompletedTask; }
+            public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories) { _categories = categories.ToList(); return Task.CompletedTask; }
 
             public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum)
                 => Task.FromResult(_transactions.Where(t => t.Datum >= vonDatum && t.Datum <= bisDatum).ToList());
@@ -297,6 +298,7 @@ namespace Finanzuebersicht.Tests.Services
                 return Task.CompletedTask;
             }
             public Task DeleteTransactionAsync(string id) { _transactions.RemoveAll(t => t.Id == id); return Task.CompletedTask; }
+            public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions) { _transactions = transactions.ToList(); return Task.CompletedTask; }
             public Task<Category?> GetMostCommonCategoryForPayeeAsync(
                 string payee,
                 double confidenceThreshold = 0.5,
@@ -311,6 +313,7 @@ namespace Finanzuebersicht.Tests.Services
                 return Task.CompletedTask;
             }
             public Task DeleteRecurringTransactionAsync(string id) { _recurring.RemoveAll(r => r.Id == id); return Task.CompletedTask; }
+            public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring) { _recurring = recurring.ToList(); return Task.CompletedTask; }
 
             public Task GeneratePendingRecurringTransactionsAsync() => Task.CompletedTask;
 
@@ -326,6 +329,7 @@ namespace Finanzuebersicht.Tests.Services
             }
             public Task DeleteBudgetAsync(string id) { _budgets.RemoveAll(b => b.Id == id); return Task.CompletedTask; }
             public Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month) => Task.FromResult<CategoryBudget?>(null);
+            public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets) { _budgets = budgets.ToList(); return Task.CompletedTask; }
 
             public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(_sparziele.ToList());
             public Task SaveSparZielAsync(SparZiel sparZiel)
@@ -335,6 +339,7 @@ namespace Finanzuebersicht.Tests.Services
                 return Task.CompletedTask;
             }
             public Task DeleteSparZielAsync(string id) { _sparziele.RemoveAll(s => s.Id == id); return Task.CompletedTask; }
+            public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) { _sparziele = sparziele.ToList(); return Task.CompletedTask; }
         }
 
         private class MockSettingsService : SettingsService

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -377,12 +377,14 @@ namespace Finanzuebersicht.Tests.Services
         public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(_categories);
         public Task SaveCategoryAsync(Category category) => Task.CompletedTask;
         public Task DeleteCategoryAsync(string id) => Task.CompletedTask;
+        public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories) { _categories = categories.ToList(); return Task.CompletedTask; }
 
         // ITransactionRepository
         public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum) 
             => Task.FromResult(_transactions.Where(t => t.Datum >= vonDatum && t.Datum <= bisDatum).ToList());
         public Task SaveTransactionAsync(Transaction transaction) => Task.CompletedTask;
         public Task DeleteTransactionAsync(string id) => Task.CompletedTask;
+        public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions) { _transactions = transactions.ToList(); return Task.CompletedTask; }
         public Task<Category?> GetMostCommonCategoryForPayeeAsync(
             string payee,
             double confidenceThreshold = 0.5,
@@ -393,6 +395,7 @@ namespace Finanzuebersicht.Tests.Services
         public Task<List<RecurringTransaction>> GetRecurringTransactionsAsync() => Task.FromResult(_recurring);
         public Task SaveRecurringTransactionAsync(RecurringTransaction recurring) => Task.CompletedTask;
         public Task DeleteRecurringTransactionAsync(string id) => Task.CompletedTask;
+        public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring) { _recurring = recurring.ToList(); return Task.CompletedTask; }
 
         // IRecurringGenerationService
         public Task GeneratePendingRecurringTransactionsAsync() => Task.CompletedTask;
@@ -406,11 +409,13 @@ namespace Finanzuebersicht.Tests.Services
         public Task SaveBudgetAsync(CategoryBudget budget) => Task.CompletedTask;
         public Task DeleteBudgetAsync(string id) => Task.CompletedTask;
         public Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month) => Task.FromResult<CategoryBudget?>(null);
+        public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets) { _budgets = budgets.ToList(); return Task.CompletedTask; }
 
         // ISparZielRepository
         public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(_sparziele);
         public Task SaveSparZielAsync(SparZiel sparZiel) => Task.CompletedTask;
         public Task DeleteSparZielAsync(string id) => Task.CompletedTask;
+        public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) { _sparziele = sparziele.ToList(); return Task.CompletedTask; }
     }
 
     internal class MockSettingsService : SettingsService

--- a/Finanzuebersicht.Tests/Services/BudgetStoreTests.cs
+++ b/Finanzuebersicht.Tests/Services/BudgetStoreTests.cs
@@ -123,4 +123,36 @@ public class BudgetStoreTests : IDisposable
 
         Assert.Null(result);
     }
+
+    [Fact]
+    public async Task ReplaceAll_ReplacesExistingBudgetsWithNewList()
+    {
+        var existing = new CategoryBudget { KategorieId = "cat-old", Betrag = 100m };
+        await _store.SaveBudgetAsync(existing);
+
+        var newBudgets = new List<CategoryBudget>
+        {
+            new() { KategorieId = "cat-a", Betrag = 200m },
+            new() { KategorieId = "cat-b", Betrag = 300m },
+        };
+
+        await _store.ReplaceAllBudgetsAsync(newBudgets);
+
+        var result = await _store.GetBudgetsAsync();
+        Assert.Equal(2, result.Count);
+        Assert.All(result, b => Assert.Contains(b.KategorieId, new[] { "cat-a", "cat-b" }));
+        Assert.DoesNotContain(result, b => b.KategorieId == "cat-old");
+    }
+
+    [Fact]
+    public async Task ReplaceAll_WithEmptyList_ClearsAllBudgets()
+    {
+        await _store.SaveBudgetAsync(new CategoryBudget { KategorieId = "cat-1", Betrag = 100m });
+        await _store.SaveBudgetAsync(new CategoryBudget { KategorieId = "cat-2", Betrag = 200m });
+
+        await _store.ReplaceAllBudgetsAsync([]);
+
+        var result = await _store.GetBudgetsAsync();
+        Assert.Empty(result);
+    }
 }

--- a/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
@@ -272,6 +272,8 @@ namespace Finanzuebersicht.Tests.Services
             private readonly List<Category> _categories = [];
             private readonly List<Transaction> _transactions = [];
             private readonly List<RecurringTransaction> _recurring = [];
+            private readonly List<CategoryBudget> _budgets = [];
+            private readonly List<SparZiel> _sparziele = [];
 
             // ICategoryRepository
             public Task<List<Category>> GetCategoriesAsync() =>
@@ -374,17 +376,27 @@ namespace Finanzuebersicht.Tests.Services
                 Task.FromResult(new MonthSummary());
 
             // IBudgetRepository
-            public Task<List<CategoryBudget>> GetBudgetsAsync() => Task.FromResult(new List<CategoryBudget>());
-            public Task SaveBudgetAsync(CategoryBudget budget) => Task.CompletedTask;
-            public Task DeleteBudgetAsync(string id) => Task.CompletedTask;
+            public Task<List<CategoryBudget>> GetBudgetsAsync() => Task.FromResult(new List<CategoryBudget>(_budgets));
+            public Task SaveBudgetAsync(CategoryBudget budget)
+            {
+                var idx = _budgets.FindIndex(b => b.Id == budget.Id);
+                if (idx >= 0) _budgets[idx] = budget; else _budgets.Add(budget);
+                return Task.CompletedTask;
+            }
+            public Task DeleteBudgetAsync(string id) { _budgets.RemoveAll(b => b.Id == id); return Task.CompletedTask; }
             public Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month) => Task.FromResult<CategoryBudget?>(null);
-            public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets) => Task.CompletedTask;
+            public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets) { _budgets.Clear(); _budgets.AddRange(budgets); return Task.CompletedTask; }
 
             // ISparZielRepository
-            public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(new List<SparZiel>());
-            public Task SaveSparZielAsync(SparZiel sparZiel) => Task.CompletedTask;
-            public Task DeleteSparZielAsync(string id) => Task.CompletedTask;
-            public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) => Task.CompletedTask;
+            public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(new List<SparZiel>(_sparziele));
+            public Task SaveSparZielAsync(SparZiel sparZiel)
+            {
+                var idx = _sparziele.FindIndex(s => s.Id == sparZiel.Id);
+                if (idx >= 0) _sparziele[idx] = sparZiel; else _sparziele.Add(sparZiel);
+                return Task.CompletedTask;
+            }
+            public Task DeleteSparZielAsync(string id) { _sparziele.RemoveAll(s => s.Id == id); return Task.CompletedTask; }
+            public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) { _sparziele.Clear(); _sparziele.AddRange(sparziele); return Task.CompletedTask; }
         }
     }
 }

--- a/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
@@ -293,6 +293,13 @@ namespace Finanzuebersicht.Tests.Services
                 return Task.CompletedTask;
             }
 
+            public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories)
+            {
+                _categories.Clear();
+                _categories.AddRange(categories);
+                return Task.CompletedTask;
+            }
+
             // ITransactionRepository
             public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum) =>
                 Task.FromResult(_transactions
@@ -312,6 +319,13 @@ namespace Finanzuebersicht.Tests.Services
             public Task DeleteTransactionAsync(string id)
             {
                 _transactions.RemoveAll(t => t.Id == id);
+                return Task.CompletedTask;
+            }
+
+            public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions)
+            {
+                _transactions.Clear();
+                _transactions.AddRange(transactions);
                 return Task.CompletedTask;
             }
 
@@ -341,6 +355,13 @@ namespace Finanzuebersicht.Tests.Services
                 return Task.CompletedTask;
             }
 
+            public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring)
+            {
+                _recurring.Clear();
+                _recurring.AddRange(recurring);
+                return Task.CompletedTask;
+            }
+
             // IRecurringGenerationService
             public Task GeneratePendingRecurringTransactionsAsync() =>
                 Task.CompletedTask;
@@ -357,11 +378,13 @@ namespace Finanzuebersicht.Tests.Services
             public Task SaveBudgetAsync(CategoryBudget budget) => Task.CompletedTask;
             public Task DeleteBudgetAsync(string id) => Task.CompletedTask;
             public Task<CategoryBudget?> GetBudgetForCategoryAsync(string kategorieId, int year, int month) => Task.FromResult<CategoryBudget?>(null);
+            public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> budgets) => Task.CompletedTask;
 
             // ISparZielRepository
             public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(new List<SparZiel>());
             public Task SaveSparZielAsync(SparZiel sparZiel) => Task.CompletedTask;
             public Task DeleteSparZielAsync(string id) => Task.CompletedTask;
+            public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) => Task.CompletedTask;
         }
     }
 }


### PR DESCRIPTION
## Änderungen

Schließt #100 und #101.

### Issue #101 – JsonStore-Basisklasse
`JsonDataStoreBase` war bereits implementiert und alle 5 Stores erbten davon. Keine weiteren Änderungen nötig.

### Issue #100 – Bulk-Replace API (O(n²) → O(1) I/O)

**Problem:** `AtomicRestoreAsync` und `RollbackAsync` im `BackupService` iterierten per Entity über `Delete*Async`/`Save*Async`, was bei jedem Call die gesamte JSON-Datei neu schrieb (O(n²) I/O).

**Lösung:**
- `JsonDataStoreBase`: Neuer `protected ReplaceAllAsync<T>` Helper – schreibt die komplette Collection in einem einzigen Dateizugriff, thread-safe via bestehenden `StoreLock`
- Alle 5 Repository-Interfaces: `ReplaceAll*Async` Methoden ergänzt
- Alle 5 Store-Klassen: Implementierung via Basisklasse (1 Zeile pro Store)
- `LocalDataService`, `DataServiceFacade`: Delegation der neuen Methoden
- `BackupService`: `AtomicRestoreAsync` und `RollbackAsync` nutzen jetzt `ReplaceAll*` → 5 statt O(n·2n) Dateizugriffe pro Restore

**Tests:**
- `BudgetStoreTests`: 2 neue Tests für `ReplaceAllBudgetsAsync`
- Mock-Implementierungen in 3 Testdateien aktualisiert

## Betroffene Dateien
`JsonDataStoreBase.cs`, alle Store-Klassen, alle Repository-Interfaces,
`LocalDataService.cs`, `DataServiceFacade.cs`, `BackupService.cs`, Tests