### PR TITLE
♻️ refactor(core): Namespace-Bereinigung im gesamten Projekt

### DIFF
--- a/Finanzuebersicht.Application/UseCases/Categories/DeleteCategoryUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Categories/DeleteCategoryUseCase.cs
@@ -19,7 +19,7 @@ public class DeleteCategoryUseCase(
             return;
 
         var fallbackCategory = categories
-            .FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges && c.Id != categoryId)
+            .FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges && c.Id != categoryId)
             ?? categories.FirstOrDefault(c => c.Id != categoryId);
 
         if (fallbackCategory == null)
@@ -30,7 +30,7 @@ public class DeleteCategoryUseCase(
                 Icon = "📦",
                 Color = "#A2845E",
                 Typ = TransactionType.Ausgabe,
-                SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges
+                SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges
             };
 
             await _categoryRepository.SaveCategoryAsync(fallbackCategory);

--- a/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionDetailDataUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionDetailDataUseCase.cs
@@ -14,7 +14,7 @@ public class LoadTransactionDetailDataUseCase(ICategoryRepository categoryReposi
             ? null
             : categories.FirstOrDefault(c => c.Id == selectedCategoryId);
 
-        selectedCategory ??= categories.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges)
+        selectedCategory ??= categories.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges)
             ?? categories.FirstOrDefault();
 
         return new TransactionDetailData

--- a/Finanzuebersicht.Core/Constants/SystemCategoryKeys.cs
+++ b/Finanzuebersicht.Core/Constants/SystemCategoryKeys.cs
@@ -1,4 +1,4 @@
-namespace Finanzuebersicht.Core.Constants
+namespace Finanzuebersicht.Constants
 {
     /// <summary>
     /// Zentrale Schlüssel für System- und Fallback-Kategorien zur Vermeidung von Magic Strings.

--- a/Finanzuebersicht.Core/Models/Category.cs
+++ b/Finanzuebersicht.Core/Models/Category.cs
@@ -9,7 +9,7 @@ public class Category
     public TransactionType Typ { get; set; } = TransactionType.Ausgabe;
 
     /// <summary>
-    /// Optionaler Schlüssel für vom System angelegte Kategorien (z.B. Finanzuebersicht.Core.Constants.SystemCategoryKeys.Lebensmittel).
+    /// Optionaler Schlüssel für vom System angelegte Kategorien (z.B. Finanzuebersicht.Constants.SystemCategoryKeys.Lebensmittel).
     /// Wird zur Laufzeit in die übersetzte Bezeichnung aufgelöst.
     /// Null bei nutzerdefinierten Kategorien – diese verwenden immer Name direkt.
     /// </summary>

--- a/Finanzuebersicht.Core/Services/BackupArchiveData.cs
+++ b/Finanzuebersicht.Core/Services/BackupArchiveData.cs
@@ -1,4 +1,4 @@
-namespace Finanzuebersicht.Core.Services;
+namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Rohdaten eines Backup-Archivs als JSON-Strings pro Datei.

--- a/Finanzuebersicht.Core/Services/BackupMetadata.cs
+++ b/Finanzuebersicht.Core/Services/BackupMetadata.cs
@@ -1,7 +1,7 @@
 using System;
 using System.Collections.Generic;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     /// <summary>
     /// Metadaten eines Backups für Versionierung und Validierung.

--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -9,7 +9,7 @@ using Microsoft.Extensions.Logging;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Models;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     /// <summary>
     /// Implementierung des Backup- und Restore-Services mit Versionierung und Validierung.
@@ -19,7 +19,7 @@ namespace Finanzuebersicht.Core.Services
         private readonly IDataService _dataService;
         private readonly SettingsService _settingsService;
         private readonly ILogger<BackupService>? _logger;
-        private readonly Finanzuebersicht.Core.Services.IClock _clock;
+        private readonly Finanzuebersicht.Services.IClock _clock;
         private readonly DataMigrationService _migrationService;
 
         private static readonly JsonSerializerOptions BackupJsonOptions = new()
@@ -31,13 +31,13 @@ namespace Finanzuebersicht.Core.Services
         private const string BackupMetadataFileName = "backup.metadata.json";
         private const int CurrentSchemaVersion = 2;
 
-        public BackupService(IDataService dataService, SettingsService settingsService, DataMigrationService migrationService, ILogger<BackupService>? logger = null, Finanzuebersicht.Core.Services.IClock? clock = null)
+        public BackupService(IDataService dataService, SettingsService settingsService, DataMigrationService migrationService, ILogger<BackupService>? logger = null, Finanzuebersicht.Services.IClock? clock = null)
         {
             _dataService = dataService ?? throw new ArgumentNullException(nameof(dataService));
             _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
             _migrationService = migrationService ?? throw new ArgumentNullException(nameof(migrationService));
             _logger = logger;
-            _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+            _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
         }
 
         /// <summary>

--- a/Finanzuebersicht.Core/Services/CategorizationService.cs
+++ b/Finanzuebersicht.Core/Services/CategorizationService.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Finanzuebersicht.Models;
 
-namespace Finanzuebersicht.Core.Services;
+namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Orchestrates transaction categorization using pluggable strategies.
@@ -34,7 +34,7 @@ public class CategorizationService(
         ArgumentNullException.ThrowIfNull(availableCategories);
 
         var categories = availableCategories.ToList();
-        var uncategorizedCategory = categories.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Core.Constants.SystemCategoryKeys.Unkategorisiert)
+        var uncategorizedCategory = categories.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert)
             ?? categories.FirstOrDefault(c => c.Name == "Unkategorisiert");
 
         // Execute strategies in priority order

--- a/Finanzuebersicht.Core/Services/DataMigrationService.cs
+++ b/Finanzuebersicht.Core/Services/DataMigrationService.cs
@@ -1,4 +1,4 @@
-namespace Finanzuebersicht.Core.Services;
+namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Verkettet Migrations-Schritte um ein Backup beliebiger Version

--- a/Finanzuebersicht.Core/Services/DkbCsvParser.cs
+++ b/Finanzuebersicht.Core/Services/DkbCsvParser.cs
@@ -5,17 +5,17 @@ using System.Collections.Generic;
 using System.Linq;
 using Microsoft.Extensions.Logging;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     public class DkbCsvParser : IStatementParser
     {
         private readonly ILogger<DkbCsvParser>? _logger;
-        private readonly Finanzuebersicht.Core.Services.IClock _clock;
+        private readonly Finanzuebersicht.Services.IClock _clock;
 
-        public DkbCsvParser(ILogger<DkbCsvParser>? logger = null, Finanzuebersicht.Core.Services.IClock? clock = null)
+        public DkbCsvParser(ILogger<DkbCsvParser>? logger = null, Finanzuebersicht.Services.IClock? clock = null)
         {
             _logger = logger;
-            _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+            _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
         }
 
         public IEnumerable<TransactionDto> Parse(Stream csvStream)

--- a/Finanzuebersicht.Core/Services/FileLogger.cs
+++ b/Finanzuebersicht.Core/Services/FileLogger.cs
@@ -1,7 +1,7 @@
 using System;
 using System.IO;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     public static class FileLogger
     {
@@ -16,7 +16,7 @@ namespace Finanzuebersicht.Core.Services
                 lock (_lock)
                 {
                     Directory.CreateDirectory(LogDir);
-                    var ts = Finanzuebersicht.Core.Services.SystemClock.Instance.UtcNow.ToString("o");
+                    var ts = Finanzuebersicht.Services.SystemClock.Instance.UtcNow.ToString("o");
                     var line = $"[{ts}] {tag}: {message}";
                     if (ex != null)
                         line += Environment.NewLine + ex.ToString();

--- a/Finanzuebersicht.Core/Services/HistoricalCategorizationStrategy.cs
+++ b/Finanzuebersicht.Core/Services/HistoricalCategorizationStrategy.cs
@@ -7,7 +7,7 @@ using Microsoft.Extensions.Logging;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
 
-namespace Finanzuebersicht.Core.Services;
+namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Categorizes transactions based on historical categorization patterns.

--- a/Finanzuebersicht.Core/Services/IBackupService.cs
+++ b/Finanzuebersicht.Core/Services/IBackupService.cs
@@ -2,7 +2,7 @@ using System.Collections.Generic;
 using System.IO;
 using System.Threading.Tasks;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     /// <summary>
     /// Service für Backup-, Restore- und Export-Operationen.

--- a/Finanzuebersicht.Core/Services/ICategorizationStrategy.cs
+++ b/Finanzuebersicht.Core/Services/ICategorizationStrategy.cs
@@ -1,6 +1,6 @@
 using Finanzuebersicht.Models;
 
-namespace Finanzuebersicht.Core.Services;
+namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Plugin interface for transaction categorization strategies.

--- a/Finanzuebersicht.Core/Services/IClock.cs
+++ b/Finanzuebersicht.Core/Services/IClock.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     public interface IClock
     {

--- a/Finanzuebersicht.Core/Services/IDataMigrator.cs
+++ b/Finanzuebersicht.Core/Services/IDataMigrator.cs
@@ -1,4 +1,4 @@
-namespace Finanzuebersicht.Core.Services;
+namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Migriert Backup-Daten von einer Schema-Version zur nächsten.

--- a/Finanzuebersicht.Core/Services/IStatementParser.cs
+++ b/Finanzuebersicht.Core/Services/IStatementParser.cs
@@ -1,7 +1,7 @@
 using System.Collections.Generic;
 using System.IO;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     public interface IStatementParser
     {

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -10,7 +10,7 @@ using Microsoft.Extensions.Logging;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     public class ImportService(
         IEnumerable<IStatementParser> parsers,
@@ -166,7 +166,7 @@ namespace Finanzuebersicht.Core.Services
                                     try
                                     {
                                         var categories = await _categoryRepository.GetCategoriesAsync().ConfigureAwait(false);
-                                        var unclassifiedCategory = categories?.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Core.Constants.SystemCategoryKeys.Unkategorisiert || c.Name == "Unkategorisiert");
+                                        var unclassifiedCategory = categories?.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert || c.Name == "Unkategorisiert");
                                         if (unclassifiedCategory == null)
                                         {
                                             unclassifiedCategory = new Finanzuebersicht.Models.Category
@@ -175,7 +175,7 @@ namespace Finanzuebersicht.Core.Services
                                                 Icon = "❓",
                                                 Color = "#A2845E",
                                                 Typ = Finanzuebersicht.Models.TransactionType.Ausgabe,
-                                                SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Unkategorisiert
+                                                SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert
                                             };
                                             await _categoryRepository.SaveCategoryAsync(unclassifiedCategory).ConfigureAwait(false);
                                             try { FileLogger.Append("ImportService", "created default 'Unkategorisiert' category"); } catch { }

--- a/Finanzuebersicht.Core/Services/InitializationService.cs
+++ b/Finanzuebersicht.Core/Services/InitializationService.cs
@@ -13,13 +13,13 @@ public class InitializationService(ICategoryRepository categoryRepository)
 
         var standardKategorien = new List<Category>
         {
-            new() { Name = "Lebensmittel", Icon = "🛒", Color = "#34C759", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Lebensmittel },
-            new() { Name = "Transport", Icon = "🚗", Color = "#007AFF", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Transport },
-            new() { Name = "Wohnen", Icon = "🏠", Color = "#FF9500", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Wohnen },
-            new() { Name = "Unterhaltung", Icon = "🎬", Color = "#AF52DE", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Unterhaltung },
-            new() { Name = "Gesundheit", Icon = "💊", Color = "#FF2D55", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Gesundheit },
-            new() { Name = "Gehalt", Icon = "💼", Color = "#34C759", Typ = TransactionType.Einnahme, SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Gehalt },
-            new() { Name = "Sonstiges", Icon = "📦", Color = "#A2845E", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges },
+            new() { Name = "Lebensmittel", Icon = "🛒", Color = "#34C759", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Lebensmittel },
+            new() { Name = "Transport", Icon = "🚗", Color = "#007AFF", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Transport },
+            new() { Name = "Wohnen", Icon = "🏠", Color = "#FF9500", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Wohnen },
+            new() { Name = "Unterhaltung", Icon = "🎬", Color = "#AF52DE", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unterhaltung },
+            new() { Name = "Gesundheit", Icon = "💊", Color = "#FF2D55", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Gesundheit },
+            new() { Name = "Gehalt", Icon = "💼", Color = "#34C759", Typ = TransactionType.Einnahme, SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Gehalt },
+            new() { Name = "Sonstiges", Icon = "📦", Color = "#A2845E", Typ = TransactionType.Ausgabe, SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges },
         };
 
         foreach (var kategorie in standardKategorien)

--- a/Finanzuebersicht.Core/Services/KeywordCategorizationStrategy.cs
+++ b/Finanzuebersicht.Core/Services/KeywordCategorizationStrategy.cs
@@ -8,7 +8,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Logging;
 using Finanzuebersicht.Models;
 
-namespace Finanzuebersicht.Core.Services;
+namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Categorizes transactions using regex pattern matching on payee/reference fields.

--- a/Finanzuebersicht.Core/Services/Migrations/V1ToV2Migrator.cs
+++ b/Finanzuebersicht.Core/Services/Migrations/V1ToV2Migrator.cs
@@ -1,4 +1,6 @@
-namespace Finanzuebersicht.Core.Services.Migrations;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Services.Migrations;
 
 /// <summary>
 /// Migriert v1-Backups auf v2: ergänzt fehlende budgets.json und sparziele.json

--- a/Finanzuebersicht.Core/Services/Migrations/V1ToV2Migrator.cs
+++ b/Finanzuebersicht.Core/Services/Migrations/V1ToV2Migrator.cs
@@ -1,5 +1,3 @@
-using Finanzuebersicht.Services;
-
 namespace Finanzuebersicht.Services.Migrations;
 
 /// <summary>

--- a/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
+++ b/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
@@ -5,11 +5,11 @@ namespace Finanzuebersicht.Services;
 public class RecurringGenerationService(
     IRecurringTransactionRepository recurringRepository,
     ITransactionRepository transactionRepository,
-    Finanzuebersicht.Core.Services.IClock? clock = null) : IRecurringGenerationService
+    Finanzuebersicht.Services.IClock? clock = null) : IRecurringGenerationService
 {
     private readonly IRecurringTransactionRepository _recurringRepository = recurringRepository;
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
-    private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+    private readonly Finanzuebersicht.Services.IClock _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
     private const int MaxInstancesPerRun = 500;
 
     public async Task GeneratePendingRecurringTransactionsAsync()

--- a/Finanzuebersicht.Core/Services/SystemClock.cs
+++ b/Finanzuebersicht.Core/Services/SystemClock.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     public class SystemClock : IClock
     {

--- a/Finanzuebersicht.Core/Services/TransactionDto.cs
+++ b/Finanzuebersicht.Core/Services/TransactionDto.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Finanzuebersicht.Core.Services
+namespace Finanzuebersicht.Services
 {
     public class TransactionDto
     {

--- a/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -53,7 +53,7 @@ public static class InfrastructureServiceCollectionExtensions
                 sp.GetRequiredService<RecurringStore>(),
                 sp.GetRequiredService<BudgetStore>(),
                 sp.GetRequiredService<SparZielStore>(),
-                sp.GetRequiredService<Finanzuebersicht.Core.Services.IClock>()));
+                sp.GetRequiredService<Finanzuebersicht.Services.IClock>()));
 
         // Expose the LocalDataService instance via the repository interfaces it implements
         services.AddSingleton<ICategoryRepository>(sp => sp.GetRequiredService<LocalDataService>());

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -1,5 +1,4 @@
 using Finanzuebersicht.Models;
-using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.Services;
 

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -1,5 +1,5 @@
 using Finanzuebersicht.Models;
-using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.Services;
 

--- a/Finanzuebersicht.Infrastructure/Services/TransactionStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/TransactionStore.cs
@@ -1,6 +1,6 @@
 using System.Linq;
 using Finanzuebersicht.Models;
-using Finanzuebersicht.Core.Constants;
+using Finanzuebersicht.Constants;
 using Microsoft.Extensions.Logging;
 
 namespace Finanzuebersicht.Services;

--- a/Finanzuebersicht.Tests/Application/UseCases/DeleteCategoryUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/DeleteCategoryUseCaseTests.cs
@@ -16,7 +16,7 @@ public class DeleteCategoryUseCaseTests
         categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
             new() { Id = "cat-delete", Name = "Zu löschen" },
-            new() { Id = "cat-default", Name = "Sonstiges", SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges }
+            new() { Id = "cat-default", Name = "Sonstiges", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges }
         });
         transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue).Returns(new List<Transaction>
         {
@@ -61,7 +61,7 @@ public class DeleteCategoryUseCaseTests
         await sut.ExecuteAsync("cat-delete");
 
         await categoryRepository.Received(1).SaveCategoryAsync(
-            Arg.Is<Category>(c => c.SystemKey == Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges));
+            Arg.Is<Category>(c => c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges));
         await transactionRepository.Received(1).SaveTransactionAsync(Arg.Any<Transaction>());
         await categoryRepository.Received(1).DeleteCategoryAsync("cat-delete");
     }

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadTransactionDetailDataUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadTransactionDetailDataUseCaseTests.cs
@@ -34,7 +34,7 @@ public class LoadTransactionDetailDataUseCaseTests
         categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
             new() { Id = "cat-1", Name = "Lebensmittel" },
-            new() { Id = "cat-2", Name = "Sonstiges", SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges }
+            new() { Id = "cat-2", Name = "Sonstiges", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges }
         });
 
         var sut = new LoadTransactionDetailDataUseCase(categoryRepository);

--- a/Finanzuebersicht.Tests/Core/Services/RecurringGenerationServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/RecurringGenerationServiceTests.cs
@@ -7,7 +7,7 @@ using Finanzuebersicht.Services;
 using Xunit;
 using NSubstitute;
 
-namespace Finanzuebersicht.Tests.Core.Services;
+namespace Finanzuebersicht.Tests.Services;
 
 public class RecurringGenerationServiceTests
 {

--- a/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceEdgeCaseTests.cs
+++ b/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceEdgeCaseTests.cs
@@ -16,7 +16,7 @@ public class LocalDataServiceEdgeCaseTests : IDisposable
 
         var settings = new SettingsService(Path.Combine(_tempDir, "settings.json"));
         settings.Set("DataPath", _tempDir);
-        _service = new LocalDataService(settings, new Finanzuebersicht.Core.Services.SystemClock());
+        _service = new LocalDataService(settings, new Finanzuebersicht.Services.SystemClock());
     }
 
     public void Dispose()

--- a/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceTests.cs
+++ b/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceTests.cs
@@ -16,7 +16,7 @@ public class LocalDataServiceTests : IDisposable
 
         var settings = new SettingsService(Path.Combine(_testDir, "settings.json"));
         settings.Set("DataPath", _testDir);
-        _service = new LocalDataService(settings, new Finanzuebersicht.Core.Services.SystemClock());
+        _service = new LocalDataService(settings, new Finanzuebersicht.Services.SystemClock());
     }
 
     public void Dispose()

--- a/Finanzuebersicht.Tests/Infrastructure/Services/YearAggregationTests.cs
+++ b/Finanzuebersicht.Tests/Infrastructure/Services/YearAggregationTests.cs
@@ -42,7 +42,7 @@ namespace Finanzuebersicht.Tests.Services
             // Use SettingsService to point LocalDataService to temp dir
             var settings = new SettingsService(Path.Combine(_tempDir, "settings.json"));
             settings.Set("DataPath", _tempDir);
-            var ds = new LocalDataService(settings, new Finanzuebersicht.Core.Services.SystemClock());
+            var ds = new LocalDataService(settings, new Finanzuebersicht.Services.SystemClock());
 
             // Act
             var summary = await ds.GetYearSummaryAsync(2025);

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -1,8 +1,7 @@
 using Xunit;
-using Finanzuebersicht.Core.Services;
-using Finanzuebersicht.Core.Services.Migrations;
-using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
+using Finanzuebersicht.Services.Migrations;
+using Finanzuebersicht.Models;
 using System.IO.Compression;
 using System.Text.Json;
 

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -1,8 +1,7 @@
 using Xunit;
-using Finanzuebersicht.Core.Services;
-using Finanzuebersicht.Core.Services.Migrations;
-using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
+using Finanzuebersicht.Services.Migrations;
+using Finanzuebersicht.Models;
 using System.IO.Compression;
 using System.Text.Json;
 

--- a/Finanzuebersicht.Tests/Services/CategorizationTests.cs
+++ b/Finanzuebersicht.Tests/Services/CategorizationTests.cs
@@ -6,9 +6,8 @@ using System.Threading.Tasks;
 using NSubstitute;
 using Xunit;
 using Microsoft.Extensions.Logging;
-using Finanzuebersicht.Core.Services;
-using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
+using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Tests.Services
 {
@@ -23,8 +22,8 @@ namespace Finanzuebersicht.Tests.Services
             var categories = new List<Category>
             {
                 new Category { Id = "1", Name = "Groceries" },
-                new Category { Id = "2", Name = "Transport", SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Transport },
-                new Category { Id = "3", Name = "Unkategorisiert", SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Unkategorisiert }
+                new Category { Id = "2", Name = "Transport", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Transport },
+                new Category { Id = "3", Name = "Unkategorisiert", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert }
             };
 
             var dto = new TransactionDto { Zahlungsempfaenger = "REWE Supermarket" };
@@ -59,7 +58,7 @@ namespace Finanzuebersicht.Tests.Services
             var categories = new List<Category>
             {
                 new Category { Id = "1", Name = "Groceries" },
-                new Category { Id = "2", Name = "Unkategorisiert", SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Unkategorisiert }
+                new Category { Id = "2", Name = "Unkategorisiert", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert }
             };
 
             var dto = new TransactionDto { Zahlungsempfaenger = "Unknown Store" };
@@ -88,7 +87,7 @@ namespace Finanzuebersicht.Tests.Services
             var categories = new List<Category>
             {
                 new Category { Id = "1", Name = "Transport" },
-                new Category { Id = "2", Name = "Unkategorisiert", SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Unkategorisiert }
+                new Category { Id = "2", Name = "Unkategorisiert", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert }
             };
 
             var dto = new TransactionDto { Zahlungsempfaenger = "DB Bahn" };
@@ -252,7 +251,7 @@ namespace Finanzuebersicht.Tests.Services
             var categories = new List<Category>
             {
                 category,
-                new Category { Id = "2", Name = "Unkategorisiert", SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Unkategorisiert }
+                new Category { Id = "2", Name = "Unkategorisiert", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert }
             };
 
             var dto = new TransactionDto { Zahlungsempfaenger = "REWE" };

--- a/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
@@ -1,7 +1,6 @@
 using Xunit;
-using Finanzuebersicht.Core.Services;
-using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
+using Finanzuebersicht.Models;
 using Finanzuebersicht.Application.UseCases.Categories;
 
 namespace Finanzuebersicht.Tests.Services
@@ -33,7 +32,7 @@ namespace Finanzuebersicht.Tests.Services
                 Icon = "📦",
                 Color = "#A2845E",
                 Typ = TransactionType.Ausgabe,
-                SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges
+                SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges
             };
 
             await dataService.SaveCategoryAsync(groceriesCategory);
@@ -106,7 +105,7 @@ namespace Finanzuebersicht.Tests.Services
                 Icon = "📦",
                 Color = "#A2845E",
                 Typ = TransactionType.Ausgabe,
-                SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges
+                SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges
             };
 
             await dataService.SaveCategoryAsync(utilitiesCategory);
@@ -178,7 +177,7 @@ namespace Finanzuebersicht.Tests.Services
 
             // Assert - fallback was created
             var categories = await dataService.GetCategoriesAsync();
-            var fallback = categories.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges);
+            var fallback = categories.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges);
             
             Assert.NotNull(fallback);
             
@@ -212,7 +211,7 @@ namespace Finanzuebersicht.Tests.Services
                 Icon = "📦",
                 Color = "#A2845E",
                 Typ = TransactionType.Ausgabe,
-                SystemKey = Finanzuebersicht.Core.Constants.SystemCategoryKeys.Sonstiges
+                SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges
             };
 
             await dataService.SaveCategoryAsync(entertainmentCategory);

--- a/Finanzuebersicht.Tests/Services/DataMigrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataMigrationTests.cs
@@ -1,5 +1,5 @@
-using Finanzuebersicht.Core.Services;
-using Finanzuebersicht.Core.Services.Migrations;
+using Finanzuebersicht.Services;
+using Finanzuebersicht.Services.Migrations;
 
 namespace Finanzuebersicht.Tests.Services;
 

--- a/Finanzuebersicht.Tests/Services/DkbCsvParserTests.cs
+++ b/Finanzuebersicht.Tests/Services/DkbCsvParserTests.cs
@@ -2,7 +2,7 @@ using System.IO;
 using System.Linq;
 using System.Text;
 using Xunit;
-using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.Tests.Services
 {

--- a/Finanzuebersicht.Tests/Services/ImportServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/ImportServiceTests.cs
@@ -1,7 +1,6 @@
-using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 using Finanzuebersicht.Models;
 using Microsoft.Extensions.Logging;
-using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.Tests.Services
 {

--- a/Finanzuebersicht.Tests/TestHelpers/FixedClock.cs
+++ b/Finanzuebersicht.Tests/TestHelpers/FixedClock.cs
@@ -1,5 +1,5 @@
 using System;
-using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.Tests.TestHelpers
 {

--- a/Finanzuebersicht/Charts/BarChartDrawable.cs
+++ b/Finanzuebersicht/Charts/BarChartDrawable.cs
@@ -48,7 +48,7 @@ public class BarChartDrawable : IDrawable
     }
 
     public IReadOnlyList<MonthSummary> Months { get; set; } = [];
-    public int CurrentMonth { get; set; } = Finanzuebersicht.Core.Services.SystemClock.Instance.Today.Month;
+    public int CurrentMonth { get; set; } = Finanzuebersicht.Services.SystemClock.Instance.Today.Month;
 
     /// <summary>Monat (1–12) für den Forecast-Balken, 0 = kein Forecast.</summary>
     public int ForecastMonth { get; set; }

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -9,7 +9,7 @@ using Finanzuebersicht.Services;
 using Finanzuebersicht.ViewModels;
 using Finanzuebersicht.Views;
 using Microsoft.Extensions.Logging;
-using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht;
 
@@ -38,7 +38,7 @@ public static class MauiProgram
 		// Services
 		builder.Services.AddSingleton<SettingsService>();
 		// Clock for testable current time
-		builder.Services.AddSingleton<Finanzuebersicht.Core.Services.IClock, Finanzuebersicht.Core.Services.SystemClock>();
+		builder.Services.AddSingleton<Finanzuebersicht.Services.IClock, Finanzuebersicht.Services.SystemClock>();
 		builder.Services.AddInfrastructureServices();
 		builder.Services.AddSingleton<IRecurringGenerationService, RecurringGenerationService>();
 		builder.Services.AddSingleton<IReportingService, ReportingService>();
@@ -46,7 +46,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IForecastService, ForecastService>();
 		builder.Services.AddSingleton<ITransactionValidationService, TransactionValidationService>();
 		builder.Services.AddSingleton<IBackupService, BackupService>();
-		builder.Services.AddSingleton<IDataMigrator, Finanzuebersicht.Core.Services.Migrations.V1ToV2Migrator>();
+		builder.Services.AddSingleton<IDataMigrator, Finanzuebersicht.Services.Migrations.V1ToV2Migrator>();
 		builder.Services.AddSingleton<DataMigrationService>(sp =>
 			new DataMigrationService(sp.GetServices<IDataMigrator>()));
 		// Import/parsers

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -9,7 +9,6 @@ using Finanzuebersicht.Services;
 using Finanzuebersicht.ViewModels;
 using Finanzuebersicht.Views;
 using Microsoft.Extensions.Logging;
-using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht;
 
@@ -51,7 +50,7 @@ public static class MauiProgram
 			new DataMigrationService(sp.GetServices<IDataMigrator>()));
 		// Import/parsers
 		// register parser explicitly using DI extension to avoid ambiguous CommunityToolkit overloads
-			Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<IStatementParser, DkbCsvParser>(builder.Services);
+		Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<IStatementParser, DkbCsvParser>(builder.Services);
 		builder.Services.AddSingleton<ImportService>();
 		// Categorization strategies
 		Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<ICategorizationStrategy, KeywordCategorizationStrategy>(builder.Services);

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -4,7 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
-using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 namespace Finanzuebersicht.ViewModels;
 public partial class DashboardViewModel : MonthNavigationViewModel
 {

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -4,7 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
-using Finanzuebersicht.Services;
+
 namespace Finanzuebersicht.ViewModels;
 public partial class DashboardViewModel : MonthNavigationViewModel
 {

--- a/Finanzuebersicht/ViewModels/MonthNavigationViewModel.cs
+++ b/Finanzuebersicht/ViewModels/MonthNavigationViewModel.cs
@@ -14,9 +14,9 @@ public abstract partial class MonthNavigationViewModel : ObservableObject
 
     public DateTime AktuellerMonat { get; private set; }
 
-    protected MonthNavigationViewModel(Finanzuebersicht.Core.Services.IClock? clock = null)
+    protected MonthNavigationViewModel(Finanzuebersicht.Services.IClock? clock = null)
     {
-        var c = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+        var c = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
         AktuellerMonat = new(c.Today.Year, c.Today.Month, 1);
         UpdateMonatAnzeige();
     }

--- a/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
@@ -12,20 +12,20 @@ namespace Finanzuebersicht.ViewModels;
 public partial class RecurringInstanceShiftViewModel(
     ShiftRecurringInstanceUseCase shiftRecurringInstanceUseCase,
     INavigationService navigationService,
-    Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject
+    Finanzuebersicht.Services.IClock? clock = null) : ObservableObject
 {
     private readonly ShiftRecurringInstanceUseCase _shiftRecurringInstanceUseCase = shiftRecurringInstanceUseCase;
     private readonly INavigationService _navigationService = navigationService;
-    private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+    private readonly Finanzuebersicht.Services.IClock _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
 
     [ObservableProperty]
     private string recurringId = string.Empty;
 
     [ObservableProperty]
-    private DateTime instanceDate = Finanzuebersicht.Core.Services.SystemClock.Instance.Today;
+    private DateTime instanceDate = Finanzuebersicht.Services.SystemClock.Instance.Today;
 
     [ObservableProperty]
-    private DateTime newDate = Finanzuebersicht.Core.Services.SystemClock.Instance.Today;
+    private DateTime newDate = Finanzuebersicht.Services.SystemClock.Instance.Today;
 
     [ObservableProperty]
     private string? note;

--- a/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -23,7 +23,7 @@ public partial class RecurringTransactionDetailViewModel(
     IDialogService dialogService,
     ILocalizationService localizationService,
     ILogger<RecurringTransactionDetailViewModel>? logger = null,
-    Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject
+    Finanzuebersicht.Services.IClock? clock = null) : ObservableObject
 {
     private readonly SaveRecurringTransactionDetailUseCase _saveRecurringTransactionDetailUseCase = saveRecurringTransactionDetailUseCase;
     private readonly LoadRecurringTransactionDetailDataUseCase _loadRecurringTransactionDetailDataUseCase = loadRecurringTransactionDetailDataUseCase;
@@ -35,7 +35,7 @@ public partial class RecurringTransactionDetailViewModel(
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILocalizationService _loc = localizationService;
     private readonly ILogger<RecurringTransactionDetailViewModel>? _logger = logger;
-    private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+    private readonly Finanzuebersicht.Services.IClock _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
 
     [ObservableProperty]
     private string betragText = string.Empty;
@@ -50,7 +50,7 @@ public partial class RecurringTransactionDetailViewModel(
     private TransactionType typ = TransactionType.Ausgabe;
 
     [ObservableProperty]
-    private DateTime startdatum = Finanzuebersicht.Core.Services.SystemClock.Instance.Today;
+    private DateTime startdatum = Finanzuebersicht.Services.SystemClock.Instance.Today;
 
     [ObservableProperty]
     private DateTime? enddatum;
@@ -59,7 +59,7 @@ public partial class RecurringTransactionDetailViewModel(
     private bool hatEnddatum;
 
     [ObservableProperty]
-    private DateTime enddatumWert = Finanzuebersicht.Core.Services.SystemClock.Instance.Today.AddYears(1);
+    private DateTime enddatumWert = Finanzuebersicht.Services.SystemClock.Instance.Today.AddYears(1);
 
     [ObservableProperty]
     private bool aktiv = true;

--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -4,7 +4,6 @@ using Microsoft.Extensions.Logging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Services;
-using Finanzuebersicht.Services;
 using Finanzuebersicht.Resources.Strings;
 
 namespace Finanzuebersicht.ViewModels;

--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -3,7 +3,7 @@ using System.Diagnostics;
 using Microsoft.Extensions.Logging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
-using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Resources.Strings;
 
@@ -17,7 +17,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly ILocalizationService _loc;
     private readonly IDialogService _dialogService;
     private readonly IBackupService? _backupService;
-    private readonly Finanzuebersicht.Core.Services.IClock _clock;
+    private readonly Finanzuebersicht.Services.IClock _clock;
 
 
     [ObservableProperty]
@@ -44,7 +44,7 @@ public partial class SettingsViewModel : ObservableObject
         IDialogService dialogService,
         IBackupService? backupService = null,
         ILogger<SettingsViewModel>? logger = null,
-        Finanzuebersicht.Core.Services.IClock? clock = null)
+        Finanzuebersicht.Services.IClock? clock = null)
     {
         _settings = settings;
         _themeService = themeService;
@@ -52,7 +52,7 @@ public partial class SettingsViewModel : ObservableObject
         _loc = localizationService;
         _dialogService = dialogService;
         _backupService = backupService;
-        _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+        _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
 
         // Version aus Assembly-Metadaten lesen (von Nerdbank.GitVersioning gesetzt)
         var asm = Assembly.GetExecutingAssembly();

--- a/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
@@ -18,7 +18,7 @@ public partial class TransactionDetailViewModel(
     INavigationService navigationService,
     IDialogService dialogService,
     ILogger<TransactionDetailViewModel>? logger = null,
-    Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject
+    Finanzuebersicht.Services.IClock? clock = null) : ObservableObject
 {
     private readonly SaveTransactionDetailUseCase _saveTransactionDetailUseCase = saveTransactionDetailUseCase;
     private readonly LoadTransactionDetailDataUseCase _loadTransactionDetailDataUseCase = loadTransactionDetailDataUseCase;
@@ -28,7 +28,7 @@ public partial class TransactionDetailViewModel(
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILogger<TransactionDetailViewModel>? _logger = logger;
-    private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+    private readonly Finanzuebersicht.Services.IClock _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
 
     [ObservableProperty]
     private string betragText = string.Empty;
@@ -40,7 +40,7 @@ public partial class TransactionDetailViewModel(
     private string verwendungszweck = string.Empty;
 
     [ObservableProperty]
-    private DateTime datum = Finanzuebersicht.Core.Services.SystemClock.Instance.Today;
+    private DateTime datum = Finanzuebersicht.Services.SystemClock.Instance.Today;
 
     [ObservableProperty]
     private Category? selectedKategorie;

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -8,7 +8,7 @@ using Finanzuebersicht.Views;
 using Microsoft.Maui.Storage;
 using System.Linq;
 using Microsoft.Extensions.Logging;
-using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.ViewModels;
 
@@ -76,7 +76,7 @@ public partial class TransactionsViewModel(
         catch (Exception ex)
         {
             _logger?.LogError(ex, "DeleteTransaktion failed for transaction {Id}", transaktion.Id);
-            try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsViewModel", $"DeleteTransaktion failed for {transaktion.Id}", ex); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsViewModel", $"DeleteTransaktion failed for {transaktion.Id}", ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_Titel),
                 _loc.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
@@ -90,7 +90,7 @@ public partial class TransactionsViewModel(
         try
         {
             _logger?.LogDebug("GoToDetail called for transaction {Id}", transaktion?.Id ?? "(new)");
-            try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsViewModel", $"GoToDetail called for {transaktion?.Id ?? "(new)"}"); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsViewModel", $"GoToDetail called for {transaktion?.Id ?? "(new)"}"); } catch { }
 
             var parameter = new Dictionary<string, object>();
             if (transaktion != null)
@@ -101,7 +101,7 @@ public partial class TransactionsViewModel(
             if (_navigationService == null)
             {
                 _logger?.LogError("GoToDetail: navigation service is null");
-                try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsViewModel", "navigation service is null"); } catch { }
+                try { Finanzuebersicht.Services.FileLogger.Append("TransactionsViewModel", "navigation service is null"); } catch { }
                 return;
             }
 
@@ -110,7 +110,7 @@ public partial class TransactionsViewModel(
         catch (Exception ex)
         {
             _logger?.LogError(ex, "GoToDetail failed");
-            try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsViewModel", "GoToDetail failed", ex); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsViewModel", "GoToDetail failed", ex); } catch { }
         }
     }
 
@@ -131,7 +131,7 @@ public partial class TransactionsViewModel(
             else
             {
                 _logger?.LogError("ImportCsv: DialogService is null while handling missing ImportService");
-                try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsViewModel", "ImportCsv: DialogService is null while handling missing ImportService"); } catch { }
+                try { Finanzuebersicht.Services.FileLogger.Append("TransactionsViewModel", "ImportCsv: DialogService is null while handling missing ImportService"); } catch { }
             }
 
             return;
@@ -157,7 +157,7 @@ public partial class TransactionsViewModel(
             else
             {
                 _logger?.LogError("ImportCsv: DialogService is null after successful import");
-                try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsViewModel", "ImportCsv: DialogService is null after successful import"); } catch { }
+                try { Finanzuebersicht.Services.FileLogger.Append("TransactionsViewModel", "ImportCsv: DialogService is null after successful import"); } catch { }
             }
 
             await LoadTransaktionen();

--- a/Finanzuebersicht/ViewModels/YearOverviewViewModel.cs
+++ b/Finanzuebersicht/ViewModels/YearOverviewViewModel.cs
@@ -6,6 +6,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.ViewModels
 {
@@ -14,11 +15,11 @@ namespace Finanzuebersicht.ViewModels
         private readonly LoadDashboardYearUseCase _loadDashboardYearUseCase;
         private readonly ILogger<YearOverviewViewModel>? _logger;
 
-        public YearOverviewViewModel(LoadDashboardYearUseCase loadDashboardYearUseCase, Microsoft.Extensions.Logging.ILogger<YearOverviewViewModel>? logger = null, Finanzuebersicht.Core.Services.IClock? clock = null)
+        public YearOverviewViewModel(LoadDashboardYearUseCase loadDashboardYearUseCase, Microsoft.Extensions.Logging.ILogger<YearOverviewViewModel>? logger = null, IClock? clock = null)
         {
             _loadDashboardYearUseCase = loadDashboardYearUseCase;
             _logger = logger;
-            var c = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+            var c = clock ?? SystemClock.Instance;
             Year = c.Now.Year;
             Categories = new ObservableCollection<CategorySummary>();
         }

--- a/Finanzuebersicht/Views/TransactionsPage.xaml.cs
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml.cs
@@ -13,14 +13,14 @@ public partial class TransactionsPage : ContentPage
         if (viewModel == null)
         {
             logger?.LogError("TransactionsPage: injected TransactionsViewModel is null. DI may have failed.");
-            try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsPage", "injected TransactionsViewModel is null"); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsPage", "injected TransactionsViewModel is null"); } catch { }
             // avoid creating types from other layers here — leave BindingContext empty to prevent further NREs
             BindingContext = new object();
         }
         else
         {
             logger?.LogDebug("TransactionsPage: TransactionsViewModel injected successfully");
-            try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsPage", "TransactionsViewModel injected successfully"); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsPage", "TransactionsViewModel injected successfully"); } catch { }
             BindingContext = viewModel;
         }
     }
@@ -38,7 +38,7 @@ public partial class TransactionsPage : ContentPage
         try
         {
             var selected = e.CurrentSelection?.FirstOrDefault() as Finanzuebersicht.Models.Transaction;
-            try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsPage", $"OnSelectionChanged selected={(selected?.Id ?? "(null)")}"); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsPage", $"OnSelectionChanged selected={(selected?.Id ?? "(null)")}"); } catch { }
 
             if (BindingContext is TransactionsViewModel vm)
             {
@@ -52,7 +52,7 @@ public partial class TransactionsPage : ContentPage
         }
         catch (Exception ex)
         {
-            try { Finanzuebersicht.Core.Services.FileLogger.Append("TransactionsPage", "OnSelectionChanged failed", ex); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsPage", "OnSelectionChanged failed", ex); } catch { }
         }
     }
 }


### PR DESCRIPTION
## Änderung

Bereinigt alle inkonsistenten Namespaces im Projekt. Die bestehende Konvention `RootNamespace=Finanzuebersicht` wird nun konsequent eingehalten – der Projektname-Bestandteil `Core` gehört **nicht** in den Namespace.

## Was wurde geändert

| Alt | Neu |
|-----|-----|
| `Finanzuebersicht.Core.Services` | `Finanzuebersicht.Services` |
| `Finanzuebersicht.Core.Services.Migrations` | `Finanzuebersicht.Services.Migrations` |
| `Finanzuebersicht.Core.Constants` | `Finanzuebersicht.Constants` |

- 17 Namespace-Deklarationen in `Finanzuebersicht.Core/Services/` korrigiert
- Alle `using`-Direktiven und voll qualifizierten Referenzen aktualisiert
- Duplizierten `using`-Eintrag in `BackupServiceTests.cs` entfernt
- Abweichenden Test-Namespace in `RecurringGenerationServiceTests.cs` korrigiert

## Betroffene Bereiche
- `Finanzuebersicht.Core/Services/` (17 Dateien)
- `Finanzuebersicht.Core/Constants/`
- `Finanzuebersicht.Infrastructure/Services/`
- `Finanzuebersicht/ViewModels/`, `Charts/`, `Views/`
- `Finanzuebersicht.Tests/`

Nur Compile-Time-Änderung, kein Laufzeitverhalten betroffen. Alle 143 Tests bestehen.

Closes #103