### PR TITLE
🔧 chore(config): bump version to 1.1

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.0",
+  "version": "1.1",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Milestone **v1.1 – Qualität & Performance** ist abgeschlossen.

Bumpt `version.json` von `1.0` auf `1.1`.

Nach dem Merge: Tag `v1.1.0` setzen um den Release-Workflow auszulösen.