### PR TITLE
🔧 chore(config): introduce develop branch, make pre-release manual only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,9 +2,9 @@ name: CI
 
 on:
   push:
-    branches: [ main, "release/v*" ]
+    branches: [ main, develop, "release/v*" ]
   pull_request:
-    branches: [ main ]
+    branches: [ main, develop ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -1,9 +1,12 @@
 name: Pre-Release
 
 on:
-  push:
-    branches: [ main ]
   workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Pre-release tag (e.g. v1.2.0-beta.1)'
+        required: true
+        type: string
 
 permissions:
   contents: write
@@ -13,29 +16,12 @@ jobs:
     name: Resolve version
     runs-on: ubuntu-latest
     outputs:
-      semver: ${{ steps.version.outputs.semver }}
       tag: ${{ steps.version.outputs.tag }}
     steps:
-      - uses: actions/checkout@v6
-        with:
-          fetch-depth: 0
-
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v5
-        with:
-          dotnet-version: '10.0.100'
-
-      - name: Resolve prerelease tag
+      - name: Set tag from input
         id: version
         shell: bash
-        run: |
-          dotnet tool install -g nbgv
-          echo "$HOME/.dotnet/tools" >> "$GITHUB_PATH"
-          VERSION_FULL=$(nbgv get-version -v SemVer2)
-          VERSION_NO_META=${VERSION_FULL%%+*}
-          TAG="v${VERSION_NO_META}-beta.${GITHUB_RUN_NUMBER}"
-          echo "semver=${VERSION_NO_META}" >> "$GITHUB_OUTPUT"
-          echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
+        run: echo "tag=${{ github.event.inputs.tag }}" >> "$GITHUB_OUTPUT"
 
   build-maccatalyst:
     name: Build macOS (Mac Catalyst)

--- a/README.md
+++ b/README.md
@@ -105,19 +105,19 @@ Full MAUI build (macCatalyst)
 
 - Quick checks (unit tests, linters) werden bei Push auf Branches ausgeführt (ubuntu runner) — das spart macOS-Runner-Minuten.
 - Der vollständige MAUI macCatalyst-Build läuft für Pull Requests gegen `main` und für `main`-Pushes. Dadurch werden macOS-Ressourcen nur bei echten Integrationsprüfungen verwendet.
-- **Pre-Release:** Bei jedem Push auf `main` wird automatisch ein Beta-Release mit Artifacts erstellt.
+- **Pre-Release:** Manuell via Actions → "Pre-Release" → Run workflow mit gewünschtem Tag (z.B. `v1.2.0-beta.1`).
 - **Release:** Bei Tag-Push (`v*`) oder manuellem Trigger werden Build-Artifacts (macOS + Windows) an das GitHub Release gehängt.
 - Um einen vollständigen MAUI-Build für einen PR explizit anzustoßen, füge das Label `run-maui` zur PR hinzu oder starte den Workflow manuell über Actions → "CI - Split quick and full" → Run workflow.
 
 ## Mitmachen
 
-Bitte arbeite auf Feature-Branches und eröffne Pull Requests gegen `main`:
+Arbeite auf Feature-Branches und öffne Pull Requests gegen **`develop`**:
 
 ```bash
 git checkout -b feature/mein-feature
 ```
 
-`main` ist geschützt; PRs werden geprüft bevor gemerged wird.
+Wenn ein Milestone fertig ist, wird `develop` per PR in `main` gemerged. `main` ist geschützt und immer release-ready.
 
 ## Lizenz
 

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -108,9 +108,17 @@ Finanzuebersicht.Tests/            ← xUnit tests (net10.0)
 
 ### Git-Workflow
 
-- **Branch:** Arbeite auf `feature/*`, `fix/*` oder `chore/*`, nicht auf `main`
+- **Branch:** Arbeite auf `feature/*`, `fix/*` oder `chore/*` – Basis ist immer `develop`
 - **Commit:** Gitmoji + Conventional Commits (siehe [.github/copilot-instructions.md](../.github/copilot-instructions.md))
-- **PR:** Erstelle Pull Request gegen `main`; `main` ist geschützt
+- **PR:** Erstelle Pull Request gegen `develop`; `main` ist geschützt und nur für Releases
+
+**Branch-Strategie:**
+
+```
+feature/* → develop  (PR, für laufende Entwicklung)
+develop   → main     (PR, wenn ein Milestone abgeschlossen ist)
+main      → v1.x-Tag (löst release.yml aus)
+```
 
 Beispiel-Commit:
 
@@ -172,11 +180,10 @@ nbgv set-version <new-version>
 
 ## 11. CI/CD
 
-- **Quick Checks:** Unit Tests auf Ubuntu (schnell, günstig) — bei jedem Branch-Push
+- **Quick Checks:** Unit Tests auf Ubuntu (schnell, günstig) — bei jedem Push auf `develop`, `main`, `feature/*` und PRs
 - **Full MAUI Build:** Nur für PRs gegen `main` und `main`-Pushes (macOS-Runner)
-- **Pre-Release:** Bei jedem `main`-Push → automatisches Beta-Release mit Artifacts (macOS + Windows)
+- **Pre-Release:** Manuell über Actions → "Pre-Release" → Run workflow (Tag z.B. `v1.2.0-beta.1`)
 - **Release:** Bei Tag-Push `v*` oder manuellem Trigger → Artifacts werden an GitHub Release angehängt
-- **Explizit triggern:** Label `run-maui` zur PR hinzufügen oder manuell via Actions starten
 
 ## 12. Fragen & Mitwirken
 


### PR DESCRIPTION
Bringt die CI/CD-Änderungen auf `main` damit der Pre-Release-Fix sofort greift.

### Änderungen
- `prerelease.yml`: Trigger von `push: main` auf `workflow_dispatch` umgestellt – Pre-Releases nur noch manuell mit explizitem Tag (z.B. `v1.2.0-beta.1`)
- `ci.yml`: Tests laufen jetzt auch auf PRs gegen `develop`

### Neuer Workflow für v1.2
```
feature/* → develop  (PR)
develop   → main     (PR, wenn Milestone fertig)
main      → v1.x-Tag (löst release.yml aus)
```