### PR TITLE
🐛 fix(viewmodel): add error handling and validation feedback for silent failures

### DIFF
--- a/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
@@ -47,15 +47,18 @@ public partial class RecurringInstanceShiftViewModel(
         try
         {
             await _shiftRecurringInstanceUseCase.ExecuteAsync(RecurringId, InstanceDate.Date, NewDate.Date, Note);
-            await _navigationService.GoBackAsync();
         }
         catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"Error while shifting recurring instance: {ex}");
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen),
                 _loc.GetString(ResourceKeys.Btn_OK));
+            return;
         }
+
+        await _navigationService.GoBackAsync();
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
@@ -1,6 +1,7 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Resources.Strings;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Models;
 using System.Globalization;
@@ -12,10 +13,14 @@ namespace Finanzuebersicht.ViewModels;
 public partial class RecurringInstanceShiftViewModel(
     ShiftRecurringInstanceUseCase shiftRecurringInstanceUseCase,
     INavigationService navigationService,
+    IDialogService dialogService,
+    ILocalizationService localizationService,
     Finanzuebersicht.Services.IClock? clock = null) : ObservableObject
 {
     private readonly ShiftRecurringInstanceUseCase _shiftRecurringInstanceUseCase = shiftRecurringInstanceUseCase;
     private readonly INavigationService _navigationService = navigationService;
+    private readonly IDialogService _dialogService = dialogService;
+    private readonly ILocalizationService _loc = localizationService;
     private readonly Finanzuebersicht.Services.IClock _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
 
     [ObservableProperty]
@@ -39,8 +44,18 @@ public partial class RecurringInstanceShiftViewModel(
     private async Task Save()
     {
         if (string.IsNullOrEmpty(RecurringId)) return;
-        await _shiftRecurringInstanceUseCase.ExecuteAsync(RecurringId, InstanceDate.Date, NewDate.Date, Note);
-        await _navigationService.GoBackAsync();
+        try
+        {
+            await _shiftRecurringInstanceUseCase.ExecuteAsync(RecurringId, InstanceDate.Date, NewDate.Date, Note);
+            await _navigationService.GoBackAsync();
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -123,16 +123,19 @@ public partial class SparZieleViewModel : ObservableObject
             };
 
             await _saveUseCase.ExecuteAsync(ziel);
-            ShowAddForm = false;
-            await LoadSparZieleCommand.ExecuteAsync(null);
         }
         catch (Exception ex)
         {
+            System.Diagnostics.Debug.WriteLine($"SaveNewSparZiel failed: {ex}");
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen),
                 _loc.GetString(ResourceKeys.Btn_OK));
+            return;
         }
+
+        ShowAddForm = false;
+        await LoadSparZieleCommand.ExecuteAsync(null);
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -3,6 +3,8 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.SparZiele;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Resources.Strings;
+using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.ViewModels;
 
@@ -11,6 +13,8 @@ public partial class SparZieleViewModel : ObservableObject
     private readonly LoadSparZieleUseCase _loadUseCase;
     private readonly SaveSparZielUseCase _saveUseCase;
     private readonly DeleteSparZielUseCase _deleteUseCase;
+    private readonly IDialogService _dialogService;
+    private readonly ILocalizationService _loc;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsEmpty))]
@@ -42,11 +46,15 @@ public partial class SparZieleViewModel : ObservableObject
     public SparZieleViewModel(
         LoadSparZieleUseCase loadUseCase,
         SaveSparZielUseCase saveUseCase,
-        DeleteSparZielUseCase deleteUseCase)
+        DeleteSparZielUseCase deleteUseCase,
+        IDialogService dialogService,
+        ILocalizationService localizationService)
     {
         _loadUseCase = loadUseCase;
         _saveUseCase = saveUseCase;
         _deleteUseCase = deleteUseCase;
+        _dialogService = dialogService;
+        _loc = localizationService;
     }
 
     [RelayCommand]
@@ -78,20 +86,53 @@ public partial class SparZieleViewModel : ObservableObject
     [RelayCommand]
     private async Task SaveNewSparZiel()
     {
-        if (string.IsNullOrWhiteSpace(NeuerTitel) || NeuesZielBetrag <= 0) return;
-
-        var ziel = new SparZiel
+        if (string.IsNullOrWhiteSpace(NeuerTitel))
         {
-            Titel = NeuerTitel,
-            Icon = NeuerIcon,
-            ZielBetrag = NeuesZielBetrag,
-            AktuellerBetrag = NeuerAktuellerBetrag,
-            Faelligkeitsdatum = NeueFaelligkeit
-        };
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_TitelErforderlich),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+        if (NeuesZielBetrag <= 0)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_BetragGroesserNull),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+        if (NeuerAktuellerBetrag < 0)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
 
-        await _saveUseCase.ExecuteAsync(ziel);
-        ShowAddForm = false;
-        await LoadSparZieleCommand.ExecuteAsync(null);
+        try
+        {
+            var ziel = new SparZiel
+            {
+                Titel = NeuerTitel,
+                Icon = string.IsNullOrWhiteSpace(NeuerIcon) ? "🎯" : NeuerIcon,
+                ZielBetrag = NeuesZielBetrag,
+                AktuellerBetrag = NeuerAktuellerBetrag,
+                Faelligkeitsdatum = NeueFaelligkeit
+            };
+
+            await _saveUseCase.ExecuteAsync(ziel);
+            ShowAddForm = false;
+            await LoadSparZieleCommand.ExecuteAsync(null);
+        }
+        catch (Exception ex)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 
     [RelayCommand]


### PR DESCRIPTION
Fixes silent failures in `SparZieleViewModel` and `RecurringInstanceShiftViewModel`.

### SparZieleViewModel
- Validation split into einzelne Checks mit spezifischen Dialogen (Titel fehlt, Betrag ≤ 0, Betrag negativ)
- `NeuerIcon` leerer String wird auf `🎯` gefallbackt
- `try/catch` um UseCase-Aufruf

### RecurringInstanceShiftViewModel
- `try/catch` um ShiftUseCase-Aufruf
- Fehler wird per Alert angezeigt

Closes #109