### PR TITLE
🐛 fix(service): log warnings when RecurringGenerationService hits limits

### DIFF
--- a/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
+++ b/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
@@ -1,15 +1,18 @@
 using Finanzuebersicht.Models;
+using Microsoft.Extensions.Logging;
 
 namespace Finanzuebersicht.Services;
 
 public class RecurringGenerationService(
     IRecurringTransactionRepository recurringRepository,
     ITransactionRepository transactionRepository,
-    Finanzuebersicht.Services.IClock? clock = null) : IRecurringGenerationService
+    Finanzuebersicht.Services.IClock? clock = null,
+    ILogger<RecurringGenerationService>? logger = null) : IRecurringGenerationService
 {
     private readonly IRecurringTransactionRepository _recurringRepository = recurringRepository;
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
     private readonly Finanzuebersicht.Services.IClock _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
+    private readonly ILogger<RecurringGenerationService>? _logger = logger;
     private const int MaxInstancesPerRun = 500;
 
     public async Task GeneratePendingRecurringTransactionsAsync()
@@ -21,6 +24,15 @@ public class RecurringGenerationService(
         {
             if (recurring.Enddatum.HasValue && recurring.Enddatum.Value < today)
                 continue;
+
+            // Guard against corrupted future LetzteAusfuehrung
+            if (recurring.LetzteAusfuehrung.HasValue && recurring.LetzteAusfuehrung.Value.Date > today)
+            {
+                _logger?.LogWarning(
+                    "RecurringTransaction {Id} ('{Titel}') has LetzteAusfuehrung {Date} in the future. Skipping.",
+                    recurring.Id, recurring.Titel, recurring.LetzteAusfuehrung.Value.Date);
+                continue;
+            }
 
             var generatedCount = 0;
 
@@ -68,6 +80,15 @@ public class RecurringGenerationService(
                 // mark this instance as last executed (use the template instance date)
                 recurring.LetzteAusfuehrung = candidate;
                 candidate = GetNextInstance(recurring, candidate);
+            }
+
+            // Warn if the limit was hit and instances are still pending
+            if (generatedCount == MaxInstancesPerRun && candidate <= today)
+            {
+                _logger?.LogWarning(
+                    "RecurringTransaction {Id} ('{Titel}') hit the {Limit}-instance limit. " +
+                    "Oldest pending instance: {PendingDate}. Remaining instances will be generated on next run.",
+                    recurring.Id, recurring.Titel, MaxInstancesPerRun, candidate.Date);
             }
 
             await _recurringRepository.SaveRecurringTransactionAsync(recurring);

--- a/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
+++ b/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
@@ -31,6 +31,7 @@ public class RecurringGenerationService(
                 _logger?.LogWarning(
                     "RecurringTransaction {Id} ('{Titel}') has LetzteAusfuehrung {Date} in the future. Skipping.",
                     recurring.Id, recurring.Titel, recurring.LetzteAusfuehrung.Value.Date);
+                try { FileLogger.Append("RecurringGeneration", $"Skipped '{recurring.Titel}' ({recurring.Id}): LetzteAusfuehrung {recurring.LetzteAusfuehrung.Value.Date:yyyy-MM-dd} is in the future."); } catch { }
                 continue;
             }
 
@@ -89,6 +90,7 @@ public class RecurringGenerationService(
                     "RecurringTransaction {Id} ('{Titel}') hit the {Limit}-instance limit. " +
                     "Oldest pending instance: {PendingDate}. Remaining instances will be generated on next run.",
                     recurring.Id, recurring.Titel, MaxInstancesPerRun, candidate.Date);
+                try { FileLogger.Append("RecurringGeneration", $"Limit of {MaxInstancesPerRun} hit for '{recurring.Titel}' ({recurring.Id}). Oldest pending: {candidate.Date:yyyy-MM-dd}."); } catch { }
             }
 
             await _recurringRepository.SaveRecurringTransactionAsync(recurring);

--- a/Finanzuebersicht.Tests/Core/Services/RecurringGenerationServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/RecurringGenerationServiceTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Services;
+using Finanzuebersicht.Tests.TestHelpers;
 using Xunit;
 using NSubstitute;
 
@@ -171,5 +172,71 @@ public class RecurringGenerationServiceTests
         Assert.Contains(saved, t => t.Datum.Date == shifted.Date && t.DauerauftragId == recurring.Id);
         await recurringRepository.Received(1).SaveRecurringTransactionAsync(Arg.Is<RecurringTransaction>(r => r.LetzteAusfuehrung.HasValue));
     }
-}
 
+    [Fact]
+    public async Task FutureLetzteAusfuehrung_SkipsRecurringAndDoesNotSave()
+    {
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var clock = new FixedClock(new DateTime(2024, 6, 1));
+
+        var recurring = new RecurringTransaction
+        {
+            Id = Guid.NewGuid().ToString(),
+            Titel = "Future Guard",
+            Betrag = 50m,
+            Typ = TransactionType.Ausgabe,
+            Startdatum = new DateTime(2024, 1, 1),
+            LetzteAusfuehrung = new DateTime(2024, 12, 31), // in the future relative to clock
+            Aktiv = true,
+            KategorieId = "cat-1",
+            Interval = RecurrenceInterval.Monthly,
+            IntervalFactor = 1
+        };
+
+        recurringRepository.GetRecurringTransactionsAsync().Returns(new List<RecurringTransaction> { recurring });
+
+        var service = new RecurringGenerationService(recurringRepository, transactionRepository, clock);
+        await service.GeneratePendingRecurringTransactionsAsync();
+
+        await transactionRepository.DidNotReceive().SaveTransactionAsync(Arg.Any<Transaction>());
+        await recurringRepository.DidNotReceive().SaveRecurringTransactionAsync(Arg.Any<RecurringTransaction>());
+    }
+
+    [Fact]
+    public async Task MaxInstancesPerRun_StopsAtLimitAndSavesState()
+    {
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        // Start far enough back that more than 500 daily instances would be pending
+        var clock = new FixedClock(new DateTime(2024, 6, 1));
+        var start = new DateTime(2022, 1, 1); // ~880 days ago → 880 daily instances pending
+
+        var recurring = new RecurringTransaction
+        {
+            Id = Guid.NewGuid().ToString(),
+            Titel = "Daily Limit Test",
+            Betrag = 1m,
+            Typ = TransactionType.Ausgabe,
+            Startdatum = start,
+            Aktiv = true,
+            KategorieId = "cat-1",
+            Interval = RecurrenceInterval.Daily,
+            IntervalFactor = 1
+        };
+
+        recurringRepository.GetRecurringTransactionsAsync().Returns(new List<RecurringTransaction> { recurring });
+
+        var saved = new List<Transaction>();
+        transactionRepository.When(x => x.SaveTransactionAsync(Arg.Any<Transaction>()))
+            .Do(call => saved.Add(call.Arg<Transaction>()));
+
+        var service = new RecurringGenerationService(recurringRepository, transactionRepository, clock);
+        await service.GeneratePendingRecurringTransactionsAsync();
+
+        Assert.Equal(500, saved.Count);
+        // LetzteAusfuehrung must be updated to the last generated instance
+        await recurringRepository.Received(1).SaveRecurringTransactionAsync(
+            Arg.Is<RecurringTransaction>(r => r.LetzteAusfuehrung.HasValue));
+    }
+}


### PR DESCRIPTION
Adds logging guards to `RecurringGenerationService` for two edge cases:

1. **500-Limit erreicht** – loggt eine `Warning` mit ID, Titel und ältestem ausstehendem Datum, damit die Lücke im Log nachvollziehbar ist
2. **LetzteAusfuehrung in der Zukunft** – loggt eine `Warning` und überspringt den Dauerauftrag (Data-Integrity-Guard)

Kein Verhaltensänderung für Normalbetrieb.

Closes #110