### PR TITLE
💄 style(ui): Dashboard empty states + year navigation bounds (#111, #112)

### DIFF
--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -78,6 +78,8 @@
   <data name="Empty_KeineKategorien" xml:space="preserve"><value>Keine Kategorien vorhanden</value></data>
   <data name="Empty_KeineDauerauftraege" xml:space="preserve"><value>Keine Daueraufträge vorhanden</value></data>
   <data name="Empty_KeineTransaktionen" xml:space="preserve"><value>Keine Transaktionen in diesem Monat</value></data>
+  <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>Keine Daten für diesen Zeitraum</value></data>
+  <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>Keine Daten für dieses Jahr</value></data>
 
   <!-- Error Messages -->
   <data name="Err_Titel" xml:space="preserve"><value>Fehler</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -78,6 +78,8 @@
   <data name="Empty_KeineKategorien" xml:space="preserve"><value>No categories available</value></data>
   <data name="Empty_KeineDauerauftraege" xml:space="preserve"><value>No recurring transactions available</value></data>
   <data name="Empty_KeineTransaktionen" xml:space="preserve"><value>No transactions this month</value></data>
+  <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>No data for this period</value></data>
+  <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>No data for this year</value></data>
 
   <!-- Error Messages -->
   <data name="Err_Titel" xml:space="preserve"><value>Error</value></data>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -78,6 +78,8 @@ public static class ResourceKeys
     public const string Empty_KeineKategorien = nameof(Empty_KeineKategorien);
     public const string Empty_KeineDauerauftraege = nameof(Empty_KeineDauerauftraege);
     public const string Empty_KeineTransaktionen = nameof(Empty_KeineTransaktionen);
+    public const string Empty_KeineDashboardDaten = nameof(Empty_KeineDashboardDaten);
+    public const string Empty_KeineJahresDaten = nameof(Empty_KeineJahresDaten);
 
     // Error Messages
     public const string Err_Titel = nameof(Err_Titel);

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -69,14 +69,13 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private string jahrAnzeige = string.Empty;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private decimal jahrGesamtAusgaben;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private ObservableCollection<CategorySummary> jahrKategorien = [];
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private List<MonthSummary> jahrMonate = [];
 
     // --- Allgemein ---
@@ -92,7 +91,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     public bool HasMonthData => KategorieAusgaben.Count > 0 || KategorieEinnahmen.Count > 0;
 
-    public bool HasYearData => JahrMonate.Count > 0 || JahrKategorien.Count > 0;
+    public bool HasYearData => JahrGesamtAusgaben > 0;
 
     private int _aktuellesJahr;
 

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -27,9 +27,11 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private decimal bilanz;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasMonthData))]
     private ObservableCollection<CategorySummary> kategorieAusgaben = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasMonthData))]
     private ObservableCollection<CategorySummary> kategorieEinnahmen = [];
 
     [ObservableProperty]
@@ -70,9 +72,11 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private decimal jahrGesamtAusgaben;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private ObservableCollection<CategorySummary> jahrKategorien = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private List<MonthSummary> jahrMonate = [];
 
     // --- Allgemein ---
@@ -85,6 +89,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private bool isMonthView = true;
 
     public bool IsYearView => !IsMonthView;
+
+    public bool HasMonthData => KategorieAusgaben.Count > 0 || KategorieEinnahmen.Count > 0;
+
+    public bool HasYearData => JahrMonate.Count > 0 || JahrKategorien.Count > 0;
 
     private int _aktuellesJahr;
 
@@ -231,7 +239,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         await LoadDashboard();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanGoNextYear))]
     private async Task NextYear()
     {
         _aktuellesJahr++;
@@ -239,7 +247,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         await LoadDashboard();
     }
 
-    [RelayCommand]
+    [RelayCommand(CanExecute = nameof(CanGoPreviousYear))]
     private async Task PreviousYear()
     {
         _aktuellesJahr--;
@@ -247,8 +255,14 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         await LoadDashboard();
     }
 
+    private bool CanGoNextYear() => _aktuellesJahr < _clock.Today.Year;
+
+    private bool CanGoPreviousYear() => _aktuellesJahr > _clock.Today.Year - 30;
+
     private void UpdateJahrAnzeige()
     {
         JahrAnzeige = _aktuellesJahr.ToString();
+        NextYearCommand.NotifyCanExecuteChanged();
+        PreviousYearCommand.NotifyCanExecuteChanged();
     }
 }

--- a/Finanzuebersicht/ViewModels/YearOverviewViewModel.cs
+++ b/Finanzuebersicht/ViewModels/YearOverviewViewModel.cs
@@ -31,7 +31,10 @@ namespace Finanzuebersicht.ViewModels
         private decimal yearTotal;
 
         [ObservableProperty]
+        [NotifyPropertyChangedFor(nameof(HasData))]
         private ObservableCollection<CategorySummary> categories;
+
+        public bool HasData => Categories.Count > 0;
 
         [RelayCommand]
         private async Task LoadAsync()

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -279,11 +279,11 @@
                   <Label Text="{loc:Translate Lbl_AusgabenProMonat}" FontSize="18" FontAttributes="Bold"
                       Margin="0,8,0,0"
                       SemanticProperties.HeadingLevel="Level2"
-                      IsVisible="{Binding JahrMonate, Converter={StaticResource CountToBool}}" />
+                      IsVisible="{Binding HasYearData}" />
 
                 <GraphicsView x:Name="YearBarChart"
                               HeightRequest="150"
-                              IsVisible="{Binding JahrMonate, Converter={StaticResource CountToBool}}"
+                              IsVisible="{Binding HasYearData}"
                               Margin="0,4,0,8" />
 
                 <!-- Kategorien im Jahr -->

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -237,6 +237,12 @@
                     </Grid>
                 </Border>
 
+                <!-- Empty State Monatsansicht -->
+                <Label Text="{loc:Translate Empty_KeineDashboardDaten}"
+                       FontSize="15" TextColor="Gray"
+                       HorizontalTextAlignment="Center" Margin="0,24,0,0"
+                       IsVisible="{Binding HasMonthData, Converter={StaticResource InvertBool}}" />
+
                 </VerticalStackLayout>
 
                 <!-- Jahresansicht -->
@@ -317,6 +323,12 @@
                         </DataTemplate>
                     </BindableLayout.ItemTemplate>
                 </VerticalStackLayout>
+
+                <!-- Empty State Jahresansicht -->
+                <Label Text="{loc:Translate Empty_KeineJahresDaten}"
+                       FontSize="15" TextColor="Gray"
+                       HorizontalTextAlignment="Center" Margin="0,24,0,0"
+                       IsVisible="{Binding HasYearData, Converter={StaticResource InvertBool}}" />
 
                 </VerticalStackLayout>
 

--- a/Finanzuebersicht/Views/YearOverviewPage.xaml
+++ b/Finanzuebersicht/Views/YearOverviewPage.xaml
@@ -5,6 +5,7 @@
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             xmlns:models="clr-namespace:Finanzuebersicht.Models"
              x:DataType="vm:YearOverviewViewModel"
              Title="{loc:Translate Title_Jahresansicht}">
     <ContentPage.Resources>
@@ -28,7 +29,7 @@
             <Label Text="{loc:Translate Lbl_KategorienColon}" FontSize="14" FontAttributes="Bold" Margin="0,10,0,0" />
             <CollectionView ItemsSource="{Binding Categories}" SelectionMode="None">
                 <CollectionView.ItemTemplate>
-                    <DataTemplate>
+                    <DataTemplate x:DataType="models:CategorySummary">
                         <Grid ColumnDefinitions="*,Auto,Auto" Padding="12">
                             <Label Text="{Binding CategoryName}" Grid.Column="0" VerticalOptions="Center" />
                             <Label Text="{Binding Total, StringFormat='{0:C}'}" Grid.Column="1" VerticalOptions="Center" HorizontalOptions="End" TextColor="Gray" />

--- a/Finanzuebersicht/Views/YearOverviewPage.xaml
+++ b/Finanzuebersicht/Views/YearOverviewPage.xaml
@@ -3,7 +3,13 @@
              xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
+             xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             x:DataType="vm:YearOverviewViewModel"
              Title="{loc:Translate Title_Jahresansicht}">
+    <ContentPage.Resources>
+        <conv:InvertBoolConverter x:Key="InvertBool" />
+    </ContentPage.Resources>
     <ScrollView>
         <VerticalStackLayout Padding="15" Spacing="15">
             <Label Text="{loc:Translate Title_Jahresansicht}" FontSize="22" FontAttributes="Bold" />
@@ -31,6 +37,12 @@
                     </DataTemplate>
                 </CollectionView.ItemTemplate>
             </CollectionView>
+
+            <!-- Empty State -->
+            <Label Text="{loc:Translate Empty_KeineJahresDaten}"
+                   FontSize="15" TextColor="Gray"
+                   HorizontalTextAlignment="Center" Margin="0,24,0,0"
+                   IsVisible="{Binding HasData, Converter={StaticResource InvertBool}}" />
 
         </VerticalStackLayout>
     </ScrollView>


### PR DESCRIPTION
## Changes

### #111 – Dashboard / YearOverview empty states
- **DashboardPage**: empty state label in month view and year view (shown when no category data available)
- **YearOverviewPage**: empty state label when `Categories` is empty; added `x:DataType` for compiled bindings
- **DashboardViewModel**: `HasMonthData` and `HasYearData` computed properties with `NotifyPropertyChangedFor`
- **YearOverviewViewModel**: `HasData` computed property
- New strings: `Empty_KeineDashboardDaten` + `Empty_KeineJahresDaten` (EN + DE)

### #112 – Year navigation bounds
- `CanGoNextYear()`: disabled when `_aktuellesJahr >= currentYear`
- `CanGoPreviousYear()`: disabled when going back more than 30 years
- `UpdateJahrAnzeige()` calls `NotifyCanExecuteChanged` on both commands → buttons auto-disable

All 145 tests pass.

Closes #111
Closes #112