### PR TITLE
✨ feat(ui): Fällige Daueraufträge Widget im Dashboard (#113)

### DIFF
--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/GetDueRecurringWithHintsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/GetDueRecurringWithHintsUseCase.cs
@@ -67,7 +67,7 @@ public class GetDueRecurringWithHintsUseCase
         var reference = referenceDate.Date;
         var start = recurring.Startdatum.Date;
 
-        if (reference < start)
+        if (reference < start.AddDays(-recurring.ReminderDaysBefore))
         {
             return false;
         }

--- a/Finanzuebersicht.Infrastructure/Finanzuebersicht.Infrastructure.csproj
+++ b/Finanzuebersicht.Infrastructure/Finanzuebersicht.Infrastructure.csproj
@@ -12,7 +12,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.7" />
   </ItemGroup>
 
 </Project>

--- a/Finanzuebersicht.Tests/Application/UseCases/RecurringTransactions/GetDueRecurringWithHintsUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/RecurringTransactions/GetDueRecurringWithHintsUseCaseTests.cs
@@ -1,0 +1,126 @@
+using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
+using NSubstitute;
+
+namespace Finanzuebersicht.Tests.Application.UseCases.RecurringTransactions;
+
+public class GetDueRecurringWithHintsUseCaseTests
+{
+    private static GetDueRecurringWithHintsUseCase CreateSut(params RecurringTransaction[] transactions)
+    {
+        var repo = Substitute.For<IRecurringTransactionRepository>();
+        repo.GetRecurringTransactionsAsync().Returns(transactions.ToList());
+        return new GetDueRecurringWithHintsUseCase(repo);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsHint_WhenStartDateIsInFutureButWithinReminderWindow()
+    {
+        var today = new DateTime(2026, 4, 21);
+        var startDate = new DateTime(2026, 4, 23); // 2 days in the future
+        var recurring = new RecurringTransaction
+        {
+            Id = "r-1",
+            Aktiv = true,
+            Startdatum = startDate,
+            Interval = RecurrenceInterval.Monthly,
+            IntervalFactor = 1,
+            ReminderDaysBefore = 2
+        };
+        var sut = CreateSut(recurring);
+
+        var result = await sut.ExecuteAsync(today);
+
+        Assert.Single(result);
+        Assert.NotNull(result[0].Hint);
+        Assert.Contains("2", result[0].Hint); // "Fällig in 2 Tagen"
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNoHint_WhenStartDateIsInFutureAndOutsideReminderWindow()
+    {
+        var today = new DateTime(2026, 4, 21);
+        var startDate = new DateTime(2026, 4, 25); // 4 days in the future
+        var recurring = new RecurringTransaction
+        {
+            Id = "r-1",
+            Aktiv = true,
+            Startdatum = startDate,
+            Interval = RecurrenceInterval.Monthly,
+            IntervalFactor = 1,
+            ReminderDaysBefore = 2
+        };
+        var sut = CreateSut(recurring);
+
+        var result = await sut.ExecuteAsync(today);
+
+        // Filtered out: start date is beyond the reminder window
+        Assert.Empty(result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsHint_WhenDueToday()
+    {
+        var today = new DateTime(2026, 4, 21);
+        var recurring = new RecurringTransaction
+        {
+            Id = "r-1",
+            Aktiv = true,
+            Startdatum = today,
+            Interval = RecurrenceInterval.Monthly,
+            IntervalFactor = 1,
+            ReminderDaysBefore = 0
+        };
+        var sut = CreateSut(recurring);
+
+        var result = await sut.ExecuteAsync(today);
+
+        Assert.Single(result);
+        Assert.Equal("Heute fällig", result[0].Hint);
+        Assert.True(result[0].IsDue);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsHint_WhenLetzteAusfuehrungSetAndNextInstanceWithinReminderWindow()
+    {
+        var today = new DateTime(2026, 4, 21);
+        var recurring = new RecurringTransaction
+        {
+            Id = "r-1",
+            Aktiv = true,
+            Startdatum = new DateTime(2026, 1, 1),
+            Interval = RecurrenceInterval.Weekly,
+            IntervalFactor = 1,
+            ReminderDaysBefore = 7,
+            LetzteAusfuehrung = new DateTime(2026, 4, 19) // next = 2026-04-26, 5 days away
+        };
+        var sut = CreateSut(recurring);
+
+        var result = await sut.ExecuteAsync(today);
+
+        Assert.Single(result);
+        Assert.NotNull(result[0].Hint);
+        Assert.Contains("5", result[0].Hint); // "Fällig in 5 Tagen"
+        Assert.False(result[0].IsDue);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ExcludesInactiveTransactions()
+    {
+        var today = new DateTime(2026, 4, 21);
+        var recurring = new RecurringTransaction
+        {
+            Id = "r-1",
+            Aktiv = false,
+            Startdatum = today,
+            Interval = RecurrenceInterval.Monthly,
+            IntervalFactor = 1
+        };
+        var sut = CreateSut(recurring);
+
+        var result = await sut.ExecuteAsync(today);
+
+        Assert.Empty(result);
+    }
+}

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -192,6 +192,7 @@ Bitte starte die App neu.</value></data>
   <data name="Lbl_Fortschritt" xml:space="preserve"><value>Fortschritt</value></data>
   <data name="Lbl_Forecast" xml:space="preserve"><value>Prognose</value></data>
   <data name="Lbl_ForecastNaechsterMonat" xml:space="preserve"><value>Erwarteter nächster Monat (Ø 3M)</value></data>
+  <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} Dauerauftrag/Aufträge bald fällig</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>von {0}</value></data>
   <data name="Lbl_Von" xml:space="preserve"><value>von</value></data>
   <data name="Lbl_UeberBudget" xml:space="preserve"><value>über Budget</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -192,7 +192,8 @@ Bitte starte die App neu.</value></data>
   <data name="Lbl_Fortschritt" xml:space="preserve"><value>Fortschritt</value></data>
   <data name="Lbl_Forecast" xml:space="preserve"><value>Prognose</value></data>
   <data name="Lbl_ForecastNaechsterMonat" xml:space="preserve"><value>Erwarteter nächster Monat (Ø 3M)</value></data>
-  <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} Dauerauftrag/Aufträge bald fällig</value></data>
+  <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} Daueraufträge bald fällig</value></data>
+  <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} Dauerauftrag bald fällig</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>von {0}</value></data>
   <data name="Lbl_Von" xml:space="preserve"><value>von</value></data>
   <data name="Lbl_UeberBudget" xml:space="preserve"><value>über Budget</value></data>
@@ -212,6 +213,7 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Neuen Dauerauftrag hinzufügen</value></data>
   <data name="A11y_BudgetBalken" xml:space="preserve"><value>Budget-Fortschrittsbalken für Kategorie</value></data>
   <data name="A11y_SparZielBalken" xml:space="preserve"><value>Sparziel-Fortschrittsbalken</value></data>
+  <data name="A11y_DauerauftraegeBannerHint" xml:space="preserve"><value>Öffnet den Tab Daueraufträge</value></data>
   <data name="A11y_HintBetrag" xml:space="preserve"><value>Betrag eingeben, z. B. 12,50</value></data>
   <data name="A11y_HintTitel" xml:space="preserve"><value>Kurze Beschreibung der Transaktion</value></data>
   <data name="A11y_HintBudget" xml:space="preserve"><value>Leer lassen für kein Budgetlimit</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -192,6 +192,7 @@ Please restart the app.</value></data>
   <data name="Lbl_Fortschritt" xml:space="preserve"><value>Progress</value></data>
   <data name="Lbl_Forecast" xml:space="preserve"><value>Forecast</value></data>
   <data name="Lbl_ForecastNaechsterMonat" xml:space="preserve"><value>Expected next month (Ø 3M)</value></data>
+  <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} recurring transaction(s) due soon</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>of {0}</value></data>
   <data name="Lbl_Von" xml:space="preserve"><value>of</value></data>
   <data name="Lbl_UeberBudget" xml:space="preserve"><value>over budget</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -192,7 +192,8 @@ Please restart the app.</value></data>
   <data name="Lbl_Fortschritt" xml:space="preserve"><value>Progress</value></data>
   <data name="Lbl_Forecast" xml:space="preserve"><value>Forecast</value></data>
   <data name="Lbl_ForecastNaechsterMonat" xml:space="preserve"><value>Expected next month (Ø 3M)</value></data>
-  <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} recurring transaction(s) due soon</value></data>
+  <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} recurring transactions due soon</value></data>
+  <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} recurring transaction due soon</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>of {0}</value></data>
   <data name="Lbl_Von" xml:space="preserve"><value>of</value></data>
   <data name="Lbl_UeberBudget" xml:space="preserve"><value>over budget</value></data>
@@ -212,6 +213,7 @@ Please restart the app.</value></data>
   <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Add new recurring transaction</value></data>
   <data name="A11y_BudgetBalken" xml:space="preserve"><value>Category budget progress</value></data>
   <data name="A11y_SparZielBalken" xml:space="preserve"><value>Savings goal progress</value></data>
+  <data name="A11y_DauerauftraegeBannerHint" xml:space="preserve"><value>Opens the recurring transactions tab</value></data>
   <data name="A11y_HintBetrag" xml:space="preserve"><value>Enter amount, e.g. 12.50</value></data>
   <data name="A11y_HintTitel" xml:space="preserve"><value>Short description of the transaction</value></data>
   <data name="A11y_HintBudget" xml:space="preserve"><value>Leave empty for no budget limit</value></data>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -187,6 +187,7 @@ public static class ResourceKeys
     public const string Lbl_Fortschritt = nameof(Lbl_Fortschritt);
     public const string Lbl_Forecast = nameof(Lbl_Forecast);
     public const string Lbl_ForecastNaechsterMonat = nameof(Lbl_ForecastNaechsterMonat);
+    public const string Lbl_DauerauftraegeFaellig = nameof(Lbl_DauerauftraegeFaellig);
     public const string Lbl_BudgetVon = nameof(Lbl_BudgetVon);
     public const string Lbl_Von = nameof(Lbl_Von);
     public const string Lbl_UeberBudget = nameof(Lbl_UeberBudget);

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -188,6 +188,7 @@ public static class ResourceKeys
     public const string Lbl_Forecast = nameof(Lbl_Forecast);
     public const string Lbl_ForecastNaechsterMonat = nameof(Lbl_ForecastNaechsterMonat);
     public const string Lbl_DauerauftraegeFaellig = nameof(Lbl_DauerauftraegeFaellig);
+    public const string Lbl_DauerauftraegeFaellig_Singular = nameof(Lbl_DauerauftraegeFaellig_Singular);
     public const string Lbl_BudgetVon = nameof(Lbl_BudgetVon);
     public const string Lbl_Von = nameof(Lbl_Von);
     public const string Lbl_UeberBudget = nameof(Lbl_UeberBudget);
@@ -209,6 +210,7 @@ public static class ResourceKeys
     public const string A11y_DauerauftragHinzufuegen = nameof(A11y_DauerauftragHinzufuegen);
     public const string A11y_BudgetBalken = nameof(A11y_BudgetBalken);
     public const string A11y_SparZielBalken = nameof(A11y_SparZielBalken);
+    public const string A11y_DauerauftraegeBannerHint = nameof(A11y_DauerauftraegeBannerHint);
     public const string A11y_HintBetrag = nameof(A11y_HintBetrag);
     public const string A11y_HintTitel = nameof(A11y_HintTitel);
     public const string A11y_HintBudget = nameof(A11y_HintBudget);

--- a/Finanzuebersicht/Resources/Styles/Colors.xaml
+++ b/Finanzuebersicht/Resources/Styles/Colors.xaml
@@ -13,6 +13,13 @@
     <Color x:Key="Warning">#FF9500</Color>
     <Color x:Key="WarningDark">#FF9F0A</Color>
 
+    <!-- Reminder Banner (fällige Daueraufträge) -->
+    <Color x:Key="ReminderBannerBorder">#FFD60A</Color>
+    <Color x:Key="ReminderBannerBackground">#FFFBE6</Color>
+    <Color x:Key="ReminderBannerBackgroundDark">#3A3200</Color>
+    <Color x:Key="ReminderBannerText">#7D6000</Color>
+    <Color x:Key="ReminderBannerTextDark">#FFD60A</Color>
+
     <!-- Hintergrund -->
     <Color x:Key="PageBackground">#F2F2F7</Color>
     <Color x:Key="PageBackgroundDark">#1C1C1E</Color>

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -1,8 +1,11 @@
 using System.Collections.ObjectModel;
+using System.Linq;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Dashboard;
+using Finanzuebersicht.Application.UseCases.RecurringTransactions;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Resources.Strings;
 using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.ViewModels;
@@ -11,8 +14,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private readonly LoadDashboardMonthUseCase _loadDashboardMonthUseCase;
     private readonly LoadDashboardYearUseCase _loadDashboardYearUseCase;
     private readonly LoadForecastUseCase _loadForecastUseCase;
+    private readonly GetDueRecurringWithHintsUseCase _getDueRecurringUseCase;
     private readonly IBudgetRepository _budgetRepository;
     private readonly IReportingService _reportingService;
+    private readonly ILocalizationService _loc;
     private readonly IClock _clock;
 
     // --- Monatsansicht ---
@@ -93,14 +98,25 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     public bool HasYearData => JahrGesamtAusgaben > 0;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasDueItems))]
+    [NotifyPropertyChangedFor(nameof(DueRecurringText))]
+    private int dueRecurringCount;
+
+    public bool HasDueItems => DueRecurringCount > 0;
+
+    public string DueRecurringText => _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig, DueRecurringCount);
+
     private int _aktuellesJahr;
 
     public DashboardViewModel(
         LoadDashboardMonthUseCase loadDashboardMonthUseCase,
         LoadDashboardYearUseCase loadDashboardYearUseCase,
         LoadForecastUseCase loadForecastUseCase,
+        GetDueRecurringWithHintsUseCase getDueRecurringUseCase,
         IBudgetRepository budgetRepository,
         IReportingService reportingService,
+        ILocalizationService localizationService,
         IClock? clock = null) : base(clock)
     {
         _clock = clock ?? SystemClock.Instance;
@@ -108,8 +124,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _loadDashboardMonthUseCase = loadDashboardMonthUseCase;
         _loadDashboardYearUseCase = loadDashboardYearUseCase;
         _loadForecastUseCase = loadForecastUseCase;
+        _getDueRecurringUseCase = getDueRecurringUseCase;
         _budgetRepository = budgetRepository;
         _reportingService = reportingService;
+        _loc = localizationService;
         UpdateJahrAnzeige();
     }
 
@@ -130,6 +148,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
             {
                 await LadeJahrAsync();
             }
+            await LadeFaelligeDauerauftraegeAsync();
         }
         finally
         {
@@ -263,5 +282,17 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         JahrAnzeige = _aktuellesJahr.ToString();
         NextYearCommand.NotifyCanExecuteChanged();
         PreviousYearCommand.NotifyCanExecuteChanged();
+    }
+
+    private async Task LadeFaelligeDauerauftraegeAsync()
+    {
+        var items = await _getDueRecurringUseCase.ExecuteAsync(_clock.Today);
+        DueRecurringCount = items.Count(i => i.Hint != null);
+    }
+
+    [RelayCommand]
+    private async Task NavigateToDauerauftraege()
+    {
+        await Shell.Current.GoToAsync("//RecurringTransactionsPage");
     }
 }

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -18,6 +18,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private readonly IBudgetRepository _budgetRepository;
     private readonly IReportingService _reportingService;
     private readonly ILocalizationService _loc;
+    private readonly INavigationService _navigationService;
     private readonly IClock _clock;
 
     // --- Monatsansicht ---
@@ -105,7 +106,9 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     public bool HasDueItems => DueRecurringCount > 0;
 
-    public string DueRecurringText => _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig, DueRecurringCount);
+    public string DueRecurringText => DueRecurringCount == 1
+        ? _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig_Singular, DueRecurringCount)
+        : _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig, DueRecurringCount);
 
     private int _aktuellesJahr;
 
@@ -117,6 +120,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         IBudgetRepository budgetRepository,
         IReportingService reportingService,
         ILocalizationService localizationService,
+        INavigationService navigationService,
         IClock? clock = null) : base(clock)
     {
         _clock = clock ?? SystemClock.Instance;
@@ -128,6 +132,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _budgetRepository = budgetRepository;
         _reportingService = reportingService;
         _loc = localizationService;
+        _navigationService = navigationService;
         UpdateJahrAnzeige();
     }
 
@@ -293,6 +298,6 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     [RelayCommand]
     private async Task NavigateToDauerauftraege()
     {
-        await Shell.Current.GoToAsync("//RecurringTransactionsPage");
+        await _navigationService.GoToAsync("//RecurringTransactionsPage");
     }
 }

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -28,6 +28,26 @@
         <ScrollView>
             <VerticalStackLayout Spacing="16" Padding="16">
 
+                <!-- Fällige Daueraufträge Widget -->
+                <Border StrokeShape="RoundRectangle 12"
+                        Stroke="{AppThemeBinding Light=#FFD60A, Dark=#FFD60A}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFBE6, Dark=#3A3200}"
+                        Padding="12,10"
+                        IsVisible="{Binding HasDueItems}">
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding NavigateToDauerauftraegeCommand}" />
+                    </Border.GestureRecognizers>
+                    <Grid ColumnDefinitions="*, Auto">
+                        <Label Grid.Column="0"
+                               Text="{Binding DueRecurringText}"
+                               FontSize="14" VerticalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light=#7D6000, Dark=#FFD60A}" />
+                        <Label Grid.Column="1" Text="›" FontSize="20" FontAttributes="Bold"
+                               VerticalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light=#7D6000, Dark=#FFD60A}" />
+                    </Grid>
+                </Border>
+
                 <!-- Ansicht-Umschalter -->
                 <Border StrokeShape="RoundRectangle 10" Stroke="#E5E5EA"
                         BackgroundColor="#F2F2F7" Padding="2">

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -30,10 +30,12 @@
 
                 <!-- Fällige Daueraufträge Widget -->
                 <Border StrokeShape="RoundRectangle 12"
-                        Stroke="{AppThemeBinding Light=#FFD60A, Dark=#FFD60A}"
-                        BackgroundColor="{AppThemeBinding Light=#FFFBE6, Dark=#3A3200}"
+                        Stroke="{StaticResource ReminderBannerBorder}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource ReminderBannerBackground}, Dark={StaticResource ReminderBannerBackgroundDark}}"
                         Padding="12,10"
-                        IsVisible="{Binding HasDueItems}">
+                        IsVisible="{Binding HasDueItems}"
+                        SemanticProperties.Description="{Binding DueRecurringText}"
+                        SemanticProperties.Hint="{loc:Translate A11y_DauerauftraegeBannerHint}">
                     <Border.GestureRecognizers>
                         <TapGestureRecognizer Command="{Binding NavigateToDauerauftraegeCommand}" />
                     </Border.GestureRecognizers>
@@ -41,10 +43,11 @@
                         <Label Grid.Column="0"
                                Text="{Binding DueRecurringText}"
                                FontSize="14" VerticalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light=#7D6000, Dark=#FFD60A}" />
+                               TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                         <Label Grid.Column="1" Text="›" FontSize="20" FontAttributes="Bold"
                                VerticalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light=#7D6000, Dark=#FFD60A}" />
+                               AutomationProperties.IsInAccessibleTree="False"
+                               TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                     </Grid>
                 </Border>
 


### PR DESCRIPTION
## Changes

### Widget: fällige Daueraufträge im Dashboard

- **DashboardPage.xaml**: Gelbes Banner über dem Ansicht-Toggle, nur sichtbar wenn `HasDueItems`; Tap navigiert direkt zum Daueraufträge-Tab
- **DashboardViewModel**: lädt fällige Daueraufträge bei jedem Dashboard-Refresh (`LadeFaelligeDauerauftraegeAsync`)
  - Zählt Items wo `Hint != null` (heute fällig, überfällig, oder innerhalb Reminder-Fenster)
  - `HasDueItems`, `DueRecurringText` (lokalisiert mit Anzahl), `NavigateToDauerauftraegeCommand`
- Neue Strings `Lbl_DauerauftraegeFaellig` (EN + DE)

Closes #113