### PR TITLE
✨ feat: Suche & Filter für Transaktionen (#114)

### DIFF
--- a/Finanzuebersicht.Application/UseCases/Transactions/SearchTransactionsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SearchTransactionsUseCase.cs
@@ -1,0 +1,73 @@
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public enum TransactionTypeFilter { Alle, Einnahme, Ausgabe }
+
+public record SearchTransactionsQuery(
+    string SearchText = "",
+    string? KategorieId = null,
+    TransactionTypeFilter Typ = TransactionTypeFilter.Alle,
+    DateTime? VonDatum = null,
+    DateTime? BisDatum = null
+);
+
+public class SearchTransactionsResult
+{
+    public List<TransactionGroup> Gruppen { get; set; } = [];
+    public Dictionary<string, string> IconMap { get; set; } = [];
+    public int TotalCount { get; set; }
+}
+
+public class SearchTransactionsUseCase(
+    ITransactionRepository transactionRepository,
+    ICategoryRepository categoryRepository)
+{
+    private readonly ITransactionRepository _transactionRepository = transactionRepository;
+    private readonly ICategoryRepository _categoryRepository = categoryRepository;
+
+    public async Task<SearchTransactionsResult> ExecuteAsync(SearchTransactionsQuery query)
+    {
+        var von = query.VonDatum ?? DateTime.MinValue;
+        var bis = query.BisDatum ?? DateTime.MaxValue;
+
+        var alle = await _transactionRepository.GetTransactionsAsync(von, bis);
+
+        var gefiltert = alle.AsEnumerable();
+
+        if (!string.IsNullOrWhiteSpace(query.SearchText))
+        {
+            var text = query.SearchText.Trim();
+            gefiltert = gefiltert.Where(t =>
+                t.Titel.Contains(text, StringComparison.OrdinalIgnoreCase) ||
+                t.Verwendungszweck.Contains(text, StringComparison.OrdinalIgnoreCase));
+        }
+
+        if (query.KategorieId != null)
+            gefiltert = gefiltert.Where(t => t.KategorieId == query.KategorieId);
+
+        if (query.Typ == TransactionTypeFilter.Einnahme)
+            gefiltert = gefiltert.Where(t => t.Typ == TransactionType.Einnahme);
+        else if (query.Typ == TransactionTypeFilter.Ausgabe)
+            gefiltert = gefiltert.Where(t => t.Typ == TransactionType.Ausgabe);
+
+        var liste = gefiltert.OrderByDescending(t => t.Datum).ToList();
+
+        var gruppen = liste
+            .GroupBy(t => new DateTime(t.Datum.Year, t.Datum.Month, 1))
+            .OrderByDescending(g => g.Key)
+            .Select(g => new TransactionGroup(g.Key, g.OrderByDescending(t => t.Datum), isMonthGroup: true))
+            .ToList();
+
+        var categories = await _categoryRepository.GetCategoriesAsync();
+        var iconMap = categories.ToDictionary(c => c.Id, c => c.Icon ?? "📁");
+
+        return new SearchTransactionsResult
+        {
+            Gruppen = gruppen,
+            IconMap = iconMap,
+            TotalCount = liste.Count
+        };
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Transactions/SearchTransactionsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SearchTransactionsUseCase.cs
@@ -32,6 +32,9 @@ public class SearchTransactionsUseCase(
         var von = query.VonDatum ?? DateTime.MinValue;
         var bis = query.BisDatum ?? DateTime.MaxValue;
 
+        if (von > bis)
+            (von, bis) = (bis, von);
+
         var alle = await _transactionRepository.GetTransactionsAsync(von, bis);
 
         var gefiltert = alle.AsEnumerable();

--- a/Finanzuebersicht.Core/Models/KategorieFilterItem.cs
+++ b/Finanzuebersicht.Core/Models/KategorieFilterItem.cs
@@ -1,0 +1,3 @@
+namespace Finanzuebersicht.Models;
+
+public record KategorieFilterItem(string? Id, string DisplayName);

--- a/Finanzuebersicht.Core/Models/TransactionGroup.cs
+++ b/Finanzuebersicht.Core/Models/TransactionGroup.cs
@@ -1,7 +1,9 @@
 namespace Finanzuebersicht.Models;
 
-public class TransactionGroup(DateTime datum, IEnumerable<Transaction> transaktionen) : List<Transaction>(transaktionen)
+public class TransactionGroup(DateTime datum, IEnumerable<Transaction> transaktionen, bool isMonthGroup = false) : List<Transaction>(transaktionen)
 {
     public DateTime Datum { get; } = datum;
-    public string DatumFormatiert { get; } = datum.ToString("dd. MMMM yyyy", System.Globalization.CultureInfo.GetCultureInfo("de-DE"));
+    public string DatumFormatiert { get; } = isMonthGroup
+        ? datum.ToString("MMMM yyyy", System.Globalization.CultureInfo.GetCultureInfo("de-DE"))
+        : datum.ToString("dd. MMMM yyyy", System.Globalization.CultureInfo.GetCultureInfo("de-DE"));
 }

--- a/Finanzuebersicht.Tests/Application/UseCases/Transactions/SearchTransactionsUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/Transactions/SearchTransactionsUseCaseTests.cs
@@ -1,0 +1,237 @@
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
+using NSubstitute;
+
+namespace Finanzuebersicht.Tests.Application.UseCases.Transactions;
+
+public class SearchTransactionsUseCaseTests
+{
+    private static SearchTransactionsUseCase CreateSut(
+        IEnumerable<Transaction>? transactions = null,
+        IEnumerable<Category>? categories = null)
+    {
+        var allTransactions = (transactions ?? []).ToList();
+        var transactionRepo = Substitute.For<ITransactionRepository>();
+        transactionRepo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(callInfo =>
+            {
+                var von = (DateTime)callInfo[0];
+                var bis = (DateTime)callInfo[1];
+                return allTransactions.Where(t => t.Datum >= von && t.Datum <= bis).ToList();
+            });
+
+        var categoryRepo = Substitute.For<ICategoryRepository>();
+        categoryRepo.GetCategoriesAsync()
+            .Returns((categories ?? []).ToList());
+
+        return new SearchTransactionsUseCase(transactionRepo, categoryRepo);
+    }
+
+    private static Transaction MakeTransaction(
+        string id, string titel, string verwendungszweck = "",
+        string? kategorieId = null, TransactionType typ = TransactionType.Ausgabe,
+        DateTime? datum = null)
+    {
+        return new Transaction
+        {
+            Id = id,
+            Titel = titel,
+            Verwendungszweck = verwendungszweck,
+            KategorieId = kategorieId,
+            Typ = typ,
+            Betrag = 10m,
+            Datum = datum ?? new DateTime(2026, 1, 15)
+        };
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SearchText_MatchesTitel()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Supermarkt", "Lebensmittel"),
+            MakeTransaction("2", "Netflix", "Streaming")
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(SearchText: "super"));
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal("Supermarkt", result.Gruppen[0].First().Titel);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SearchText_MatchesVerwendungszweck()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Supermarkt", "Lebensmittel einkaufen"),
+            MakeTransaction("2", "Netflix", "Streaming")
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(SearchText: "lebensmittel"));
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal("Supermarkt", result.Gruppen[0].First().Titel);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_SearchText_IsCaseInsensitive()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "NETFLIX", "STREAMING SERVICE")
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(SearchText: "netflix"));
+
+        Assert.Equal(1, result.TotalCount);
+
+        var result2 = await sut.ExecuteAsync(new SearchTransactionsQuery(SearchText: "NETFLIX"));
+
+        Assert.Equal(1, result2.TotalCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilterNachKategorie_OnlyReturnsMatchingCategory()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Supermarkt", kategorieId: "kat-1"),
+            MakeTransaction("2", "Netflix", kategorieId: "kat-2"),
+            MakeTransaction("3", "Gehalt", kategorieId: "kat-1", typ: TransactionType.Einnahme)
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(KategorieId: "kat-1"));
+
+        Assert.Equal(2, result.TotalCount);
+        Assert.All(result.Gruppen.SelectMany(g => g), t => Assert.Equal("kat-1", t.KategorieId));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilterNachTyp_Einnahme_OnlyReturnsEinnahmen()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Supermarkt", typ: TransactionType.Ausgabe),
+            MakeTransaction("2", "Gehalt", typ: TransactionType.Einnahme),
+            MakeTransaction("3", "Freiberuflich", typ: TransactionType.Einnahme)
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(Typ: TransactionTypeFilter.Einnahme));
+
+        Assert.Equal(2, result.TotalCount);
+        Assert.All(result.Gruppen.SelectMany(g => g), t => Assert.Equal(TransactionType.Einnahme, t.Typ));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilterNachTyp_Ausgabe_OnlyReturnsAusgaben()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Supermarkt", typ: TransactionType.Ausgabe),
+            MakeTransaction("2", "Gehalt", typ: TransactionType.Einnahme)
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(Typ: TransactionTypeFilter.Ausgabe));
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal(TransactionType.Ausgabe, result.Gruppen[0].First().Typ);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilterNachDatumsbereich_ReturnsOnlyTransactionsInRange()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Januar", datum: new DateTime(2026, 1, 15)),
+            MakeTransaction("2", "März", datum: new DateTime(2026, 3, 10)),
+            MakeTransaction("3", "Juni", datum: new DateTime(2026, 6, 1))
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(
+            VonDatum: new DateTime(2026, 2, 1),
+            BisDatum: new DateTime(2026, 4, 30)));
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.Equal("März", result.Gruppen[0].First().Titel);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilterKombiniert_AppliesAllFilters()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Supermarkt", kategorieId: "kat-1", typ: TransactionType.Ausgabe,
+                datum: new DateTime(2026, 3, 5)),
+            MakeTransaction("2", "Gehalt", kategorieId: "kat-2", typ: TransactionType.Einnahme,
+                datum: new DateTime(2026, 3, 1)),
+            MakeTransaction("3", "Online Shop", verwendungszweck: "Supermarkt Lieferung",
+                kategorieId: "kat-1", typ: TransactionType.Ausgabe, datum: new DateTime(2026, 3, 20))
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(
+            SearchText: "supermarkt",
+            KategorieId: "kat-1",
+            Typ: TransactionTypeFilter.Ausgabe,
+            VonDatum: new DateTime(2026, 3, 1),
+            BisDatum: new DateTime(2026, 3, 31)));
+
+        Assert.Equal(2, result.TotalCount);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_NoResults_ReturnsEmptyGroups()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Supermarkt")
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(SearchText: "gibtsNicht123"));
+
+        Assert.Equal(0, result.TotalCount);
+        Assert.Empty(result.Gruppen);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_GroupsByMonth_SortedDescending()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Januar", datum: new DateTime(2026, 1, 10)),
+            MakeTransaction("2", "März", datum: new DateTime(2026, 3, 5)),
+            MakeTransaction("3", "Februar", datum: new DateTime(2026, 2, 20))
+        };
+        var sut = CreateSut(transactions);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery());
+
+        Assert.Equal(3, result.Gruppen.Count);
+        Assert.Equal(new DateTime(2026, 3, 1), result.Gruppen[0].Datum);
+        Assert.Equal(new DateTime(2026, 2, 1), result.Gruppen[1].Datum);
+        Assert.Equal(new DateTime(2026, 1, 1), result.Gruppen[2].Datum);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_IconMap_ContainsCategoryIcons()
+    {
+        var transactions = new[] { MakeTransaction("1", "Test", kategorieId: "kat-1") };
+        var categories = new[] { new Category { Id = "kat-1", Name = "Lebensmittel", Icon = "🛒" } };
+        var sut = CreateSut(transactions, categories);
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery());
+
+        Assert.True(result.IconMap.ContainsKey("kat-1"));
+        Assert.Equal("🛒", result.IconMap["kat-1"]);
+    }
+}

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -75,6 +75,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<LoadTransactionDetailDataUseCase>();
 		builder.Services.AddTransient<DeleteTransactionUseCase>();
 		builder.Services.AddTransient<LoadTransactionsMonthUseCase>();
+		builder.Services.AddTransient<SearchTransactionsUseCase>();
 		builder.Services.AddTransient<SaveRecurringTransactionDetailUseCase>();
 		builder.Services.AddTransient<SaveTransactionDetailUseCase>();
 		builder.Services.AddSingleton<InitializationService>();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -78,6 +78,7 @@
   <data name="Empty_KeineKategorien" xml:space="preserve"><value>Keine Kategorien vorhanden</value></data>
   <data name="Empty_KeineDauerauftraege" xml:space="preserve"><value>Keine Daueraufträge vorhanden</value></data>
   <data name="Empty_KeineTransaktionen" xml:space="preserve"><value>Keine Transaktionen in diesem Monat</value></data>
+  <data name="Empty_KeineSuchergebnisse" xml:space="preserve"><value>Keine Transaktionen gefunden</value></data>
   <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>Keine Daten für diesen Zeitraum</value></data>
   <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>Keine Daten für dieses Jahr</value></data>
 
@@ -174,6 +175,7 @@ Bitte starte die App neu.</value></data>
   <data name="Msg_BackupRestoreTitle" xml:space="preserve"><value>Sicherung &amp; Wiederherstellung</value></data>
   <data name="Msg_BackupRestoreDesc" xml:space="preserve"><value>Erstelle Sicherungen deiner Daten und stelle sie bei Bedarf wieder her.</value></data>
   <data name="Btn_Import" xml:space="preserve"><value>Import</value></data>
+  <data name="Btn_FilterZuruecksetzen" xml:space="preserve"><value>Filter zurücksetzen</value></data>
   <data name="Title_ShiftInstance" xml:space="preserve"><value>Instanz verschieben</value></data>
   <data name="Btn_Hinzufuegen" xml:space="preserve"><value>+</value></data>
   <data name="Btn_Prev" xml:space="preserve"><value>‹</value></data>
@@ -191,6 +193,13 @@ Bitte starte die App neu.</value></data>
   <data name="Lbl_Faelligkeit" xml:space="preserve"><value>Fälligkeit</value></data>
   <data name="Lbl_Fortschritt" xml:space="preserve"><value>Fortschritt</value></data>
   <data name="Lbl_Forecast" xml:space="preserve"><value>Prognose</value></data>
+  <data name="Lbl_ForecastNaechsterMonat" xml:space="preserve"><value>Erwarteter nächster Monat (Ø 3M)</value></data>
+  <data name="Lbl_SuchergebnisseAnzahl" xml:space="preserve"><value>{0} Ergebnis(se)</value></data>
+  <data name="Lbl_AlleKategorien" xml:space="preserve"><value>Alle Kategorien</value></data>
+  <data name="Lbl_AlleTypen" xml:space="preserve"><value>Alle Typen</value></data>
+  <data name="Lbl_VonDatum" xml:space="preserve"><value>Von</value></data>
+  <data name="Lbl_BisDatum" xml:space="preserve"><value>Bis</value></data>
+  <data name="Hint_SucheTransaktionen" xml:space="preserve"><value>Transaktionen suchen…</value></data>
   <data name="Lbl_ForecastNaechsterMonat" xml:space="preserve"><value>Erwarteter nächster Monat (Ø 3M)</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} Daueraufträge bald fällig</value></data>
   <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} Dauerauftrag bald fällig</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -200,7 +200,7 @@ Bitte starte die App neu.</value></data>
   <data name="Lbl_VonDatum" xml:space="preserve"><value>Von</value></data>
   <data name="Lbl_BisDatum" xml:space="preserve"><value>Bis</value></data>
   <data name="Hint_SucheTransaktionen" xml:space="preserve"><value>Transaktionen suchen…</value></data>
-  <data name="Lbl_ForecastNaechsterMonat" xml:space="preserve"><value>Erwarteter nächster Monat (Ø 3M)</value></data>
+  <data name="A11y_FilterUmschalten" xml:space="preserve"><value>Filter umschalten</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} Daueraufträge bald fällig</value></data>
   <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} Dauerauftrag bald fällig</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>von {0}</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -78,6 +78,7 @@
   <data name="Empty_KeineKategorien" xml:space="preserve"><value>No categories available</value></data>
   <data name="Empty_KeineDauerauftraege" xml:space="preserve"><value>No recurring transactions available</value></data>
   <data name="Empty_KeineTransaktionen" xml:space="preserve"><value>No transactions this month</value></data>
+  <data name="Empty_KeineSuchergebnisse" xml:space="preserve"><value>No transactions found</value></data>
   <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>No data for this period</value></data>
   <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>No data for this year</value></data>
 
@@ -174,6 +175,7 @@ Please restart the app.</value></data>
   <data name="Msg_BackupRestoreTitle" xml:space="preserve"><value>Backup &amp; Restore</value></data>
   <data name="Msg_BackupRestoreDesc" xml:space="preserve"><value>Create backups of your data and restore when needed.</value></data>
   <data name="Btn_Import" xml:space="preserve"><value>Import</value></data>
+  <data name="Btn_FilterZuruecksetzen" xml:space="preserve"><value>Clear filter</value></data>
   <data name="Title_ShiftInstance" xml:space="preserve"><value>Shift instance</value></data>
   <data name="Btn_Hinzufuegen" xml:space="preserve"><value>+</value></data>
   <data name="Btn_Prev" xml:space="preserve"><value>‹</value></data>
@@ -192,6 +194,12 @@ Please restart the app.</value></data>
   <data name="Lbl_Fortschritt" xml:space="preserve"><value>Progress</value></data>
   <data name="Lbl_Forecast" xml:space="preserve"><value>Forecast</value></data>
   <data name="Lbl_ForecastNaechsterMonat" xml:space="preserve"><value>Expected next month (Ø 3M)</value></data>
+  <data name="Lbl_SuchergebnisseAnzahl" xml:space="preserve"><value>{0} result(s)</value></data>
+  <data name="Lbl_AlleKategorien" xml:space="preserve"><value>All categories</value></data>
+  <data name="Lbl_AlleTypen" xml:space="preserve"><value>All types</value></data>
+  <data name="Lbl_VonDatum" xml:space="preserve"><value>From</value></data>
+  <data name="Lbl_BisDatum" xml:space="preserve"><value>To</value></data>
+  <data name="Hint_SucheTransaktionen" xml:space="preserve"><value>Search transactions…</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} recurring transactions due soon</value></data>
   <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} recurring transaction due soon</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>of {0}</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -200,6 +200,7 @@ Please restart the app.</value></data>
   <data name="Lbl_VonDatum" xml:space="preserve"><value>From</value></data>
   <data name="Lbl_BisDatum" xml:space="preserve"><value>To</value></data>
   <data name="Hint_SucheTransaktionen" xml:space="preserve"><value>Search transactions…</value></data>
+  <data name="A11y_FilterUmschalten" xml:space="preserve"><value>Toggle filters</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} recurring transactions due soon</value></data>
   <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} recurring transaction due soon</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>of {0}</value></data>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -195,6 +195,7 @@ public static class ResourceKeys
     public const string Lbl_VonDatum = nameof(Lbl_VonDatum);
     public const string Lbl_BisDatum = nameof(Lbl_BisDatum);
     public const string Hint_SucheTransaktionen = nameof(Hint_SucheTransaktionen);
+    public const string A11y_FilterUmschalten = nameof(A11y_FilterUmschalten);
     public const string Lbl_DauerauftraegeFaellig = nameof(Lbl_DauerauftraegeFaellig);
     public const string Lbl_DauerauftraegeFaellig_Singular = nameof(Lbl_DauerauftraegeFaellig_Singular);
     public const string Lbl_BudgetVon = nameof(Lbl_BudgetVon);

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -78,6 +78,7 @@ public static class ResourceKeys
     public const string Empty_KeineKategorien = nameof(Empty_KeineKategorien);
     public const string Empty_KeineDauerauftraege = nameof(Empty_KeineDauerauftraege);
     public const string Empty_KeineTransaktionen = nameof(Empty_KeineTransaktionen);
+    public const string Empty_KeineSuchergebnisse = nameof(Empty_KeineSuchergebnisse);
     public const string Empty_KeineDashboardDaten = nameof(Empty_KeineDashboardDaten);
     public const string Empty_KeineJahresDaten = nameof(Empty_KeineJahresDaten);
 
@@ -167,6 +168,7 @@ public static class ResourceKeys
     public const string Msg_BackupRestoreTitle = nameof(Msg_BackupRestoreTitle);
     public const string Msg_BackupRestoreDesc = nameof(Msg_BackupRestoreDesc);
     public const string Btn_Import = nameof(Btn_Import);
+    public const string Btn_FilterZuruecksetzen = nameof(Btn_FilterZuruecksetzen);
     public const string Title_ShiftInstance = nameof(Title_ShiftInstance);
 
     // Additional common buttons / app info
@@ -187,6 +189,12 @@ public static class ResourceKeys
     public const string Lbl_Fortschritt = nameof(Lbl_Fortschritt);
     public const string Lbl_Forecast = nameof(Lbl_Forecast);
     public const string Lbl_ForecastNaechsterMonat = nameof(Lbl_ForecastNaechsterMonat);
+    public const string Lbl_SuchergebnisseAnzahl = nameof(Lbl_SuchergebnisseAnzahl);
+    public const string Lbl_AlleKategorien = nameof(Lbl_AlleKategorien);
+    public const string Lbl_AlleTypen = nameof(Lbl_AlleTypen);
+    public const string Lbl_VonDatum = nameof(Lbl_VonDatum);
+    public const string Lbl_BisDatum = nameof(Lbl_BisDatum);
+    public const string Hint_SucheTransaktionen = nameof(Hint_SucheTransaktionen);
     public const string Lbl_DauerauftraegeFaellig = nameof(Lbl_DauerauftraegeFaellig);
     public const string Lbl_DauerauftraegeFaellig_Singular = nameof(Lbl_DauerauftraegeFaellig_Singular);
     public const string Lbl_BudgetVon = nameof(Lbl_BudgetVon);

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -34,6 +34,7 @@ public partial class TransactionsViewModel(
     private readonly ILogger<TransactionsViewModel> _logger = logger;
 
     private CancellationTokenSource? _searchDebounce;
+    private int _searchVersion;
 
     // --- Monatsansicht ---
 
@@ -82,6 +83,8 @@ public partial class TransactionsViewModel(
     private ObservableCollection<TransactionGroup> searchErgebnisGruppen = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSearchResults))]
+    [NotifyPropertyChangedFor(nameof(SearchCountText))]
     private int totalSearchCount;
 
     [ObservableProperty]
@@ -99,6 +102,13 @@ public partial class TransactionsViewModel(
     public bool HasSearchResults => SearchErgebnisGruppen.Count > 0;
 
     public string SearchCountText => _loc.GetString(ResourceKeys.Lbl_SuchergebnisseAnzahl, TotalSearchCount);
+
+    public string[] TypFilterItems =>
+    [
+        _loc.GetString(ResourceKeys.Lbl_AlleTypen),
+        _loc.GetString(ResourceKeys.Lbl_Einnahmen),
+        _loc.GetString(ResourceKeys.Lbl_Ausgaben)
+    ];
 
     // --- Picker-Hilfsfelder ---
 
@@ -171,15 +181,16 @@ public partial class TransactionsViewModel(
         _searchDebounce?.Cancel();
         _searchDebounce = new CancellationTokenSource();
         var token = _searchDebounce.Token;
+        var version = Interlocked.Increment(ref _searchVersion);
         Task.Run(async () =>
         {
             await Task.Delay(300, token);
             if (!token.IsCancellationRequested)
-                await MainThread.InvokeOnMainThreadAsync(ExecuteSearchAsync);
+                await MainThread.InvokeOnMainThreadAsync(() => ExecuteSearchAsync(version));
         }, token);
     }
 
-    private async Task ExecuteSearchAsync()
+    private async Task ExecuteSearchAsync(int version = -1)
     {
         if (!IsSearchActive)
         {
@@ -197,13 +208,15 @@ public partial class TransactionsViewModel(
                 VonDatum: VonDatum,
                 BisDatum: BisDatum);
             var result = await _searchTransactionsUseCase.ExecuteAsync(query);
+            if (version >= 0 && version != _searchVersion) return;
             SearchErgebnisGruppen = new ObservableCollection<TransactionGroup>(result.Gruppen);
             TotalSearchCount = result.TotalCount;
             Converters.KategorieIdToIconConverter.SetCache(result.IconMap);
         }
         finally
         {
-            IsLoading = false;
+            if (version < 0 || version == _searchVersion)
+                IsLoading = false;
         }
     }
 

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -3,31 +3,39 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Resources.Strings;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Views;
 using Microsoft.Maui.Storage;
 using System.Linq;
 using Microsoft.Extensions.Logging;
-using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.ViewModels;
 
 public partial class TransactionsViewModel(
     DeleteTransactionUseCase deleteTransactionUseCase,
     LoadTransactionsMonthUseCase loadTransactionsMonthUseCase,
+    SearchTransactionsUseCase searchTransactionsUseCase,
     INavigationService navigationService,
     ImportService importService,
     IDialogService dialogService,
     ILocalizationService localizationService,
+    ICategoryRepository categoryRepository,
     ILogger<TransactionsViewModel> logger) : MonthNavigationViewModel
 {
     private readonly DeleteTransactionUseCase _deleteTransactionUseCase = deleteTransactionUseCase;
     private readonly LoadTransactionsMonthUseCase _loadTransactionsMonthUseCase = loadTransactionsMonthUseCase;
+    private readonly SearchTransactionsUseCase _searchTransactionsUseCase = searchTransactionsUseCase;
     private readonly INavigationService _navigationService = navigationService;
     private readonly ImportService _importService = importService;
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILocalizationService _loc = localizationService;
+    private readonly ICategoryRepository _categoryRepository = categoryRepository;
     private readonly ILogger<TransactionsViewModel> _logger = logger;
+
+    private CancellationTokenSource? _searchDebounce;
+
+    // --- Monatsansicht ---
 
     [ObservableProperty]
     private ObservableCollection<TransactionGroup> transaktionsGruppen = [];
@@ -35,7 +43,205 @@ public partial class TransactionsViewModel(
     [ObservableProperty]
     private bool isLoading;
 
+    // --- Suche & Filter ---
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsSearchActive))]
+    [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    private string searchText = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFilterActive))]
+    [NotifyPropertyChangedFor(nameof(IsSearchActive))]
+    [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    private string? selectedKategorieId = null;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFilterActive))]
+    [NotifyPropertyChangedFor(nameof(IsSearchActive))]
+    [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    private TransactionTypeFilter selectedTypFilter = TransactionTypeFilter.Alle;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFilterActive))]
+    [NotifyPropertyChangedFor(nameof(IsSearchActive))]
+    [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    private DateTime? vonDatum = null;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFilterActive))]
+    [NotifyPropertyChangedFor(nameof(IsSearchActive))]
+    [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    private DateTime? bisDatum = null;
+
+    [ObservableProperty]
+    private bool isFilterPanelOpen;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSearchResults))]
+    private ObservableCollection<TransactionGroup> searchErgebnisGruppen = [];
+
+    [ObservableProperty]
+    private int totalSearchCount;
+
+    [ObservableProperty]
+    private ObservableCollection<KategorieFilterItem> availableKategorien = [];
+
+    public bool IsFilterActive =>
+        SelectedKategorieId != null ||
+        SelectedTypFilter != TransactionTypeFilter.Alle ||
+        IsDateFilterEnabled;
+
+    public bool IsSearchActive => !string.IsNullOrWhiteSpace(SearchText) || IsFilterActive;
+
+    public bool IsMonthMode => !IsSearchActive;
+
+    public bool HasSearchResults => SearchErgebnisGruppen.Count > 0;
+
+    public string SearchCountText => _loc.GetString(ResourceKeys.Lbl_SuchergebnisseAnzahl, TotalSearchCount);
+
+    // --- Picker-Hilfsfelder ---
+
+    [ObservableProperty]
+    private KategorieFilterItem? selectedKategorieFilterItem;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsFilterActive))]
+    [NotifyPropertyChangedFor(nameof(IsSearchActive))]
+    [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    private bool isDateFilterEnabled;
+
+    [ObservableProperty]
+    private DateTime vonDatumPicker = new DateTime(DateTime.Today.Year, 1, 1);
+
+    [ObservableProperty]
+    private DateTime bisDatumPicker = DateTime.Today;
+
+    // Typ-Filter als Index (0=Alle, 1=Einnahmen, 2=Ausgaben) für Picker
+    private int _selectedTypIndex;
+    public int SelectedTypIndex
+    {
+        get => _selectedTypIndex;
+        set
+        {
+            if (SetProperty(ref _selectedTypIndex, value))
+            {
+                SelectedTypFilter = value switch
+                {
+                    1 => TransactionTypeFilter.Einnahme,
+                    2 => TransactionTypeFilter.Ausgabe,
+                    _ => TransactionTypeFilter.Alle
+                };
+            }
+        }
+    }
+
+    partial void OnSelectedKategorieFilterItemChanged(KategorieFilterItem? value)
+    {
+        SelectedKategorieId = value?.Id;
+    }
+
+    partial void OnIsDateFilterEnabledChanged(bool value)
+    {
+        VonDatum = value ? VonDatumPicker : null;
+        BisDatum = value ? BisDatumPicker : null;
+        TriggerSearchDebounced();
+    }
+
+    partial void OnVonDatumPickerChanged(DateTime value)
+    {
+        if (IsDateFilterEnabled) VonDatum = value;
+    }
+
+    partial void OnBisDatumPickerChanged(DateTime value)
+    {
+        if (IsDateFilterEnabled) BisDatum = value;
+    }
+
     protected override async Task OnMonthChangedAsync() => await LoadTransaktionen();
+
+    partial void OnSearchTextChanged(string value) => TriggerSearchDebounced();
+    partial void OnSelectedKategorieIdChanged(string? value) => TriggerSearchDebounced();
+    partial void OnSelectedTypFilterChanged(TransactionTypeFilter value) => TriggerSearchDebounced();
+    partial void OnVonDatumChanged(DateTime? value) => TriggerSearchDebounced();
+    partial void OnBisDatumChanged(DateTime? value) => TriggerSearchDebounced();
+
+    private void TriggerSearchDebounced()
+    {
+        _searchDebounce?.Cancel();
+        _searchDebounce = new CancellationTokenSource();
+        var token = _searchDebounce.Token;
+        Task.Run(async () =>
+        {
+            await Task.Delay(300, token);
+            if (!token.IsCancellationRequested)
+                await MainThread.InvokeOnMainThreadAsync(ExecuteSearchAsync);
+        }, token);
+    }
+
+    private async Task ExecuteSearchAsync()
+    {
+        if (!IsSearchActive)
+        {
+            SearchErgebnisGruppen = [];
+            TotalSearchCount = 0;
+            return;
+        }
+        IsLoading = true;
+        try
+        {
+            var query = new SearchTransactionsQuery(
+                SearchText: SearchText.Trim(),
+                KategorieId: SelectedKategorieId,
+                Typ: SelectedTypFilter,
+                VonDatum: VonDatum,
+                BisDatum: BisDatum);
+            var result = await _searchTransactionsUseCase.ExecuteAsync(query);
+            SearchErgebnisGruppen = new ObservableCollection<TransactionGroup>(result.Gruppen);
+            TotalSearchCount = result.TotalCount;
+            Converters.KategorieIdToIconConverter.SetCache(result.IconMap);
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private void ToggleFilterPanel() => IsFilterPanelOpen = !IsFilterPanelOpen;
+
+    [RelayCommand]
+    private async Task ClearSearch()
+    {
+        _searchDebounce?.Cancel();
+        SearchText = string.Empty;
+        SelectedKategorieId = null;
+        SelectedKategorieFilterItem = AvailableKategorien.FirstOrDefault();
+        SelectedTypFilter = TransactionTypeFilter.Alle;
+        SelectedTypIndex = 0;
+        IsDateFilterEnabled = false;
+        VonDatumPicker = new DateTime(DateTime.Today.Year, 1, 1);
+        BisDatumPicker = DateTime.Today;
+        VonDatum = null;
+        BisDatum = null;
+        IsFilterPanelOpen = false;
+        SearchErgebnisGruppen = [];
+        TotalSearchCount = 0;
+        await LoadTransaktionen();
+    }
+
+    private async Task LoadKategorienAsync()
+    {
+        var kategorien = await _categoryRepository.GetCategoriesAsync();
+        var items = new ObservableCollection<KategorieFilterItem>
+        {
+            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKategorien))
+        };
+        foreach (var k in kategorien.OrderBy(k => k.Name))
+            items.Add(new KategorieFilterItem(k.Id, $"{k.Icon} {k.Name}"));
+        AvailableKategorien = items;
+        SelectedKategorieFilterItem = items[0];
+    }
 
     [RelayCommand]
     private async Task LoadTransaktionen()
@@ -52,6 +258,9 @@ public partial class TransactionsViewModel(
             var data = await _loadTransactionsMonthUseCase.ExecuteAsync(AktuellerMonat);
             TransaktionsGruppen = new ObservableCollection<TransactionGroup>(data.Gruppen);
             Converters.KategorieIdToIconConverter.SetCache(data.IconMap);
+
+            if (AvailableKategorien.Count == 0)
+                await LoadKategorienAsync();
         }
         finally
         {

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -3,7 +3,6 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
-             xmlns:appModels="clr-namespace:Finanzuebersicht.Models;assembly=Finanzuebersicht.Core"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.TransactionsPage"
@@ -15,7 +14,6 @@
         <conv:BetragDisplayConverter x:Key="BetragDisplay" />
         <conv:KategorieIdToIconConverter x:Key="KategorieIdToIcon" />
         <conv:InvertBoolConverter x:Key="InvertBool" />
-        <conv:CountToBoolConverter x:Key="CountToBool" />
     </ContentPage.Resources>
 
     <Grid RowDefinitions="Auto, Auto, Auto, *">
@@ -26,19 +24,26 @@
                        Text="{Binding SearchText}"
                        Placeholder="{loc:Translate Hint_SucheTransaktionen}"
                        CancelButtonColor="#007AFF" />
-            <Border Grid.Column="1"
-                    StrokeShape="RoundRectangle 10"
-                    BackgroundColor="{Binding IsFilterActive, Converter={StaticResource InvertBool}, ConverterParameter='{AppThemeBinding Light=#007AFF, Dark=#0A84FF}'}"
-                    Stroke="Transparent"
+            <Button Grid.Column="1"
+                    Text="⚙"
+                    FontSize="20"
+                    Command="{Binding ToggleFilterPanelCommand}"
+                    BackgroundColor="Transparent"
+                    TextColor="{AppThemeBinding Light=#007AFF, Dark=#0A84FF}"
+                    BorderWidth="0"
+                    CornerRadius="10"
+                    Padding="0"
                     WidthRequest="44" HeightRequest="44"
-                    VerticalOptions="Center">
-                <Border.GestureRecognizers>
-                    <TapGestureRecognizer Command="{Binding ToggleFilterPanelCommand}" />
-                </Border.GestureRecognizers>
-                <Label Text="⚙" FontSize="20"
-                       HorizontalOptions="Center" VerticalOptions="Center"
-                       TextColor="{AppThemeBinding Light=#007AFF, Dark=#0A84FF}" />
-            </Border>
+                    VerticalOptions="Center"
+                    SemanticProperties.Description="{loc:Translate A11y_FilterUmschalten}"
+                    AutomationProperties.Name="{loc:Translate A11y_FilterUmschalten}">
+                <Button.Triggers>
+                    <DataTrigger TargetType="Button" Binding="{Binding IsFilterActive}" Value="True">
+                        <Setter Property="BackgroundColor" Value="{AppThemeBinding Light=#007AFF, Dark=#0A84FF}" />
+                        <Setter Property="TextColor" Value="White" />
+                    </DataTrigger>
+                </Button.Triggers>
+            </Button>
         </Grid>
 
         <!-- Row 1: Monatsnavigation (nur im Monatsmodus sichtbar) -->
@@ -85,14 +90,9 @@
                     <Label Grid.Column="0" Text="{loc:Translate Lbl_AlleTypen}"
                            FontSize="13" TextColor="Gray" VerticalTextAlignment="Center" />
                     <Picker Grid.Column="1"
+                            ItemsSource="{Binding TypFilterItems}"
                             SelectedIndex="{Binding SelectedTypIndex}"
-                            FontSize="14">
-                        <Picker.Items>
-                            <x:String>Alle</x:String>
-                            <x:String>Einnahmen</x:String>
-                            <x:String>Ausgaben</x:String>
-                        </Picker.Items>
-                    </Picker>
+                            FontSize="14" />
                 </Grid>
 
                 <!-- Datum-Filter aktivieren -->

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
+             xmlns:appModels="clr-namespace:Finanzuebersicht.Models;assembly=Finanzuebersicht.Core"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.TransactionsPage"
@@ -13,14 +14,38 @@
         <conv:TransactionTypToColorConverter x:Key="TypToColor" />
         <conv:BetragDisplayConverter x:Key="BetragDisplay" />
         <conv:KategorieIdToIconConverter x:Key="KategorieIdToIcon" />
+        <conv:InvertBoolConverter x:Key="InvertBool" />
+        <conv:CountToBoolConverter x:Key="CountToBool" />
     </ContentPage.Resources>
 
-    <Grid RowDefinitions="Auto, *">
+    <Grid RowDefinitions="Auto, Auto, Auto, *">
 
-        <!-- Monatsnavigation -->
-        <Grid Grid.Row="0" ColumnDefinitions="Auto, *, Auto"
-              Padding="16,12">
-                <Button Grid.Column="0" Text="{loc:Translate Btn_Prev}" FontSize="28"
+        <!-- Row 0: Suchleiste + Filter-Button -->
+        <Grid Grid.Row="0" ColumnDefinitions="*, Auto" Padding="12,8,12,4" ColumnSpacing="8">
+            <SearchBar Grid.Column="0"
+                       Text="{Binding SearchText}"
+                       Placeholder="{loc:Translate Hint_SucheTransaktionen}"
+                       CancelButtonColor="#007AFF" />
+            <Border Grid.Column="1"
+                    StrokeShape="RoundRectangle 10"
+                    BackgroundColor="{Binding IsFilterActive, Converter={StaticResource InvertBool}, ConverterParameter='{AppThemeBinding Light=#007AFF, Dark=#0A84FF}'}"
+                    Stroke="Transparent"
+                    WidthRequest="44" HeightRequest="44"
+                    VerticalOptions="Center">
+                <Border.GestureRecognizers>
+                    <TapGestureRecognizer Command="{Binding ToggleFilterPanelCommand}" />
+                </Border.GestureRecognizers>
+                <Label Text="⚙" FontSize="20"
+                       HorizontalOptions="Center" VerticalOptions="Center"
+                       TextColor="{AppThemeBinding Light=#007AFF, Dark=#0A84FF}" />
+            </Border>
+        </Grid>
+
+        <!-- Row 1: Monatsnavigation (nur im Monatsmodus sichtbar) -->
+        <Grid Grid.Row="1" ColumnDefinitions="Auto, *, Auto"
+              Padding="16,4"
+              IsVisible="{Binding IsMonthMode}">
+            <Button Grid.Column="0" Text="{loc:Translate Btn_Prev}" FontSize="28"
                     BackgroundColor="Transparent" TextColor="#007AFF"
                     Command="{Binding PreviousMonthCommand}"
                     SemanticProperties.Description="{loc:Translate A11y_VorherigerMonat}"
@@ -28,96 +53,214 @@
             <Label Grid.Column="1" Text="{Binding MonatAnzeige}"
                    FontSize="18" FontAttributes="Bold"
                    HorizontalTextAlignment="Center" VerticalTextAlignment="Center" />
-                <Button Grid.Column="2" Text="{loc:Translate Btn_Next}" FontSize="28"
+            <Button Grid.Column="2" Text="{loc:Translate Btn_Next}" FontSize="28"
                     BackgroundColor="Transparent" TextColor="#007AFF"
                     Command="{Binding NextMonthCommand}"
                     SemanticProperties.Description="{loc:Translate A11y_NaechsterMonat}"
                     WidthRequest="44" />
         </Grid>
 
-        <!-- Transaktionsliste -->
-        <RefreshView Grid.Row="1"
-                     Command="{Binding LoadTransaktionenCommand}"
-                     IsRefreshing="{Binding IsLoading}">
-            <CollectionView ItemsSource="{Binding TransaktionsGruppen}"
-                            IsGrouped="True"
-                            SelectionMode="None">
+        <!-- Row 2: Filter-Panel (collapsible) -->
+        <Border Grid.Row="2"
+                StrokeShape="RoundRectangle 0"
+                Stroke="Transparent"
+                BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
+                Padding="12,8"
+                IsVisible="{Binding IsFilterPanelOpen}">
+            <VerticalStackLayout Spacing="10">
 
-                <CollectionView.EmptyView>
-                    <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
-                        <Label Text="{loc:Translate Empty_KeineTransaktionen}"
-                               FontSize="16" HorizontalTextAlignment="Center" TextColor="Gray" />
-                    </VerticalStackLayout>
-                </CollectionView.EmptyView>
+                <!-- Kategorie-Filter -->
+                <Grid ColumnDefinitions="80, *" ColumnSpacing="8">
+                    <Label Grid.Column="0" Text="{loc:Translate Lbl_AlleKategorien}"
+                           FontSize="13" TextColor="Gray" VerticalTextAlignment="Center" />
+                    <Picker Grid.Column="1"
+                            ItemsSource="{Binding AvailableKategorien}"
+                            ItemDisplayBinding="{Binding DisplayName}"
+                            SelectedItem="{Binding SelectedKategorieFilterItem}"
+                            FontSize="14" />
+                </Grid>
 
-                <CollectionView.GroupHeaderTemplate>
-                    <DataTemplate x:DataType="models:TransactionGroup">
-                        <Label Text="{Binding DatumFormatiert}"
-                               FontSize="14" TextColor="Gray"
-                               Padding="16,12,16,4" />
-                    </DataTemplate>
-                </CollectionView.GroupHeaderTemplate>
+                <!-- Typ-Filter -->
+                <Grid ColumnDefinitions="80, *" ColumnSpacing="8">
+                    <Label Grid.Column="0" Text="{loc:Translate Lbl_AlleTypen}"
+                           FontSize="13" TextColor="Gray" VerticalTextAlignment="Center" />
+                    <Picker Grid.Column="1"
+                            SelectedIndex="{Binding SelectedTypIndex}"
+                            FontSize="14">
+                        <Picker.Items>
+                            <x:String>Alle</x:String>
+                            <x:String>Einnahmen</x:String>
+                            <x:String>Ausgaben</x:String>
+                        </Picker.Items>
+                    </Picker>
+                </Grid>
 
-                <CollectionView.ItemTemplate>
-                    <DataTemplate x:DataType="models:Transaction">
-                        <SwipeView>
-                            <SwipeView.RightItems>
-                                <SwipeItems>
-                                    <SwipeItem Text="{loc:Translate Btn_Loeschen}"
-                                               BackgroundColor="#FF3B30"
-                                               Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=DeleteTransaktionCommand}"
-                                               CommandParameter="{Binding .}" />
-                                </SwipeItems>
-                            </SwipeView.RightItems>
+                <!-- Datum-Filter aktivieren -->
+                <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                    <Label Grid.Column="0" Text="{loc:Translate Lbl_VonDatum}"
+                           FontSize="13" TextColor="Gray" VerticalTextAlignment="Center" />
+                    <Switch Grid.Column="1" IsToggled="{Binding IsDateFilterEnabled}" />
+                </Grid>
 
+                <!-- Datum Von/Bis (nur wenn aktiviert) -->
+                <Grid ColumnDefinitions="80, *, 40, *" ColumnSpacing="8"
+                      IsVisible="{Binding IsDateFilterEnabled}">
+                    <Label Grid.Column="0" Text="{loc:Translate Lbl_VonDatum}"
+                           FontSize="13" TextColor="Gray" VerticalTextAlignment="Center" />
+                    <DatePicker Grid.Column="1"
+                                Date="{Binding VonDatumPicker}"
+                                Format="dd.MM.yyyy" FontSize="14" />
+                    <Label Grid.Column="2" Text="{loc:Translate Lbl_BisDatum}"
+                           FontSize="13" TextColor="Gray" VerticalTextAlignment="Center" />
+                    <DatePicker Grid.Column="3"
+                                Date="{Binding BisDatumPicker}"
+                                Format="dd.MM.yyyy" FontSize="14" />
+                </Grid>
+
+                <!-- Filter zurücksetzen -->
+                <Button Text="{loc:Translate Btn_FilterZuruecksetzen}"
+                        FontSize="13" TextColor="#FF3B30"
+                        BackgroundColor="Transparent"
+                        HorizontalOptions="Start"
+                        IsVisible="{Binding IsFilterActive}"
+                        Command="{Binding ClearSearchCommand}" />
+            </VerticalStackLayout>
+        </Border>
+
+        <!-- Row 3: Content -->
+        <Grid Grid.Row="3">
+
+            <!-- Monatsansicht (normal) -->
+            <RefreshView Command="{Binding LoadTransaktionenCommand}"
+                         IsRefreshing="{Binding IsLoading}"
+                         IsVisible="{Binding IsMonthMode}">
+                <CollectionView ItemsSource="{Binding TransaktionsGruppen}"
+                                IsGrouped="True"
+                                SelectionMode="None">
+                    <CollectionView.EmptyView>
+                        <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
+                            <Label Text="{loc:Translate Empty_KeineTransaktionen}"
+                                   FontSize="16" HorizontalTextAlignment="Center" TextColor="Gray" />
+                        </VerticalStackLayout>
+                    </CollectionView.EmptyView>
+                    <CollectionView.GroupHeaderTemplate>
+                        <DataTemplate x:DataType="models:TransactionGroup">
+                            <Label Text="{Binding DatumFormatiert}"
+                                   FontSize="14" TextColor="Gray"
+                                   Padding="16,12,16,4" />
+                        </DataTemplate>
+                    </CollectionView.GroupHeaderTemplate>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:Transaction">
+                            <SwipeView>
+                                <SwipeView.RightItems>
+                                    <SwipeItems>
+                                        <SwipeItem Text="{loc:Translate Btn_Loeschen}"
+                                                   BackgroundColor="#FF3B30"
+                                                   Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=DeleteTransaktionCommand}"
+                                                   CommandParameter="{Binding .}" />
+                                    </SwipeItems>
+                                </SwipeView.RightItems>
+                                <Grid ColumnDefinitions="44, *, Auto" Padding="16,10" ColumnSpacing="12">
+                                    <Grid.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=GoToDetailCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    </Grid.GestureRecognizers>
+                                    <Border Grid.Column="0"
+                                            BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#3A3A3C}"
+                                            StrokeShape="RoundRectangle 10" Stroke="Transparent"
+                                            WidthRequest="40" HeightRequest="40"
+                                            HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Label Text="{Binding KategorieId, Converter={StaticResource KategorieIdToIcon}}" FontSize="18"
+                                               HorizontalOptions="Center" VerticalOptions="Center" />
+                                    </Border>
+                                    <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
+                                        <Label Text="{Binding Titel}" FontSize="16" FontAttributes="Bold"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Text="{Binding Verwendungszweck}" FontSize="12" TextColor="Gray"
+                                               LineBreakMode="TailTruncation" />
+                                    </VerticalStackLayout>
+                                    <Label Grid.Column="2"
+                                           Text="{Binding ., Converter={StaticResource BetragDisplay}}"
+                                           TextColor="{Binding Typ, Converter={StaticResource TypToColor}}"
+                                           FontSize="16" FontAttributes="Bold"
+                                           VerticalTextAlignment="Center" />
+                                </Grid>
+                            </SwipeView>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </RefreshView>
+
+            <!-- Suchergebnisse -->
+            <VerticalStackLayout IsVisible="{Binding IsSearchActive}" Spacing="0">
+
+                <!-- Ergebnis-Anzahl -->
+                <Label Padding="16,8,16,4"
+                       FontSize="13" TextColor="Gray"
+                       IsVisible="{Binding HasSearchResults}"
+                       Text="{Binding SearchCountText}" />
+
+                <!-- Keine Ergebnisse -->
+                <Label Text="{loc:Translate Empty_KeineSuchergebnisse}"
+                       FontSize="16" HorizontalTextAlignment="Center" TextColor="Gray"
+                       Margin="0,40,0,0"
+                       IsVisible="{Binding HasSearchResults, Converter={StaticResource InvertBool}}" />
+
+                <CollectionView ItemsSource="{Binding SearchErgebnisGruppen}"
+                                IsGrouped="True"
+                                SelectionMode="None"
+                                IsVisible="{Binding HasSearchResults}">
+                    <CollectionView.GroupHeaderTemplate>
+                        <DataTemplate x:DataType="models:TransactionGroup">
+                            <Label Text="{Binding DatumFormatiert}"
+                                   FontSize="14" TextColor="Gray" FontAttributes="Bold"
+                                   Padding="16,12,16,4" />
+                        </DataTemplate>
+                    </CollectionView.GroupHeaderTemplate>
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:Transaction">
                             <Grid ColumnDefinitions="44, *, Auto" Padding="16,10" ColumnSpacing="12">
                                 <Grid.GestureRecognizers>
                                     <TapGestureRecognizer
                                         Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=GoToDetailCommand}"
                                         CommandParameter="{Binding .}" />
                                 </Grid.GestureRecognizers>
-
                                 <Border Grid.Column="0"
                                         BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#3A3A3C}"
-                                        StrokeShape="RoundRectangle 10"
-                                        Stroke="Transparent"
+                                        StrokeShape="RoundRectangle 10" Stroke="Transparent"
                                         WidthRequest="40" HeightRequest="40"
                                         HorizontalOptions="Center" VerticalOptions="Center">
                                     <Label Text="{Binding KategorieId, Converter={StaticResource KategorieIdToIcon}}" FontSize="18"
                                            HorizontalOptions="Center" VerticalOptions="Center" />
                                 </Border>
-
                                 <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
-                                    <Label Text="{Binding Titel}"
-                                           FontSize="16" FontAttributes="Bold"
+                                    <Label Text="{Binding Titel}" FontSize="16" FontAttributes="Bold"
                                            LineBreakMode="TailTruncation" />
-                                    <Label Text="{Binding Verwendungszweck}"
-                                           FontSize="12" TextColor="Gray"
+                                    <Label Text="{Binding Verwendungszweck}" FontSize="12" TextColor="Gray"
                                            LineBreakMode="TailTruncation" />
                                 </VerticalStackLayout>
-
                                 <Label Grid.Column="2"
                                        Text="{Binding ., Converter={StaticResource BetragDisplay}}"
                                        TextColor="{Binding Typ, Converter={StaticResource TypToColor}}"
                                        FontSize="16" FontAttributes="Bold"
                                        VerticalTextAlignment="Center" />
                             </Grid>
-                        </SwipeView>
-                    </DataTemplate>
-                </CollectionView.ItemTemplate>
-            </CollectionView>
-        </RefreshView>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </VerticalStackLayout>
 
-        <!-- Buttons: FAB + Import -->
-        <Grid Grid.Row="1" HorizontalOptions="Fill" VerticalOptions="End" Padding="20,0,20,20">
-                <!-- Import Button -->
-                <Button Text="{loc:Translate Btn_Import}" FontSize="14" TextColor="#007AFF"
+        </Grid>
+
+        <!-- FABs (immer sichtbar, über Row 3) -->
+        <Grid Grid.Row="3" HorizontalOptions="Fill" VerticalOptions="End" Padding="20,0,20,20">
+            <Button Text="{loc:Translate Btn_Import}" FontSize="14" TextColor="#007AFF"
                     BackgroundColor="Transparent"
                     HorizontalOptions="Start" VerticalOptions="End"
                     Command="{Binding ImportCsvCommand}" />
-            
-            <!-- FAB -->
-                <Button Text="{loc:Translate Btn_Hinzufuegen}"
+            <Button Text="{loc:Translate Btn_Hinzufuegen}"
                     FontSize="28" TextColor="White"
                     BackgroundColor="#007AFF"
                     CornerRadius="28"
@@ -127,5 +270,6 @@
                     Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
                     Command="{Binding GoToDetailCommand}" />
         </Grid>
+
     </Grid>
 </ContentPage>


### PR DESCRIPTION
## Änderungen

### SearchTransactionsUseCase
- Neuer UseCase mit `SearchTransactionsQuery` Record
- Filter: Textsuche (Titel + Verwendungszweck, case-insensitive), Kategorie, Typ (Alle/Einnahme/Ausgabe), Datumsbereich Von/Bis
- Ergebnisse gruppiert nach Monat, absteigend sortiert

### TransactionsViewModel
- Erweitert um: `SearchText`, `IsSearchActive`, `IsFilterPanelOpen`, `SelectedKategorieFilterItem`, `SelectedTypIndex`, `IsDateFilterEnabled`, `VonDatumPicker`/`BisDatumPicker`
- 300ms Debounce via CancellationTokenSource
- Commands: `ToggleFilterPanelCommand`, `ClearSearchCommand`
- Monatsnavigation wird im Suchmodus ausgeblendet

### TransactionsPage.xaml
- Neues Layout: SearchBar + Filter-Toggle oben, Monatsnavigation (nur Monatsansicht), collapsibles Filter-Panel, Suchergebnisse gruppiert nach Monat
- Empty State bei leeren Suchergebnissen

### Tests
- 9 neue Tests für `SearchTransactionsUseCase` (161 gesamt)
- Text-, Kategorie-, Typ-, Datums- und Kombinationsfilter abgedeckt

Closes #114