### PR TITLE
🐛 fix(viewmodel): fix debounce race, search error handling and culture

### DIFF
--- a/Finanzuebersicht.Core/Models/TransactionGroup.cs
+++ b/Finanzuebersicht.Core/Models/TransactionGroup.cs
@@ -4,6 +4,6 @@ public class TransactionGroup(DateTime datum, IEnumerable<Transaction> transakti
 {
     public DateTime Datum { get; } = datum;
     public string DatumFormatiert { get; } = isMonthGroup
-        ? datum.ToString("MMMM yyyy", System.Globalization.CultureInfo.GetCultureInfo("de-DE"))
-        : datum.ToString("dd. MMMM yyyy", System.Globalization.CultureInfo.GetCultureInfo("de-DE"));
+        ? datum.ToString("MMMM yyyy", System.Globalization.CultureInfo.CurrentCulture)
+        : datum.ToString("dd. MMMM yyyy", System.Globalization.CultureInfo.CurrentCulture);
 }

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -43,7 +43,6 @@
   <data name="Lbl_AusgabenNachKategorie" xml:space="preserve"><value>Ausgaben nach Kategorie</value></data>
   <data name="Lbl_EinnahmenNachKategorie" xml:space="preserve"><value>Einnahmen nach Kategorie</value></data>
   <data name="Lbl_Jahresausgaben" xml:space="preserve"><value>Jahresausgaben</value></data>
-  <data name="Lbl_JahressummeColon" xml:space="preserve"><value>Jahresbetrag:</value></data>
   <data name="Lbl_AusgabenProMonat" xml:space="preserve"><value>Ausgaben pro Monat</value></data>
   <data name="Lbl_Darstellung" xml:space="preserve"><value>Darstellung</value></data>
   <data name="Lbl_Speicherort" xml:space="preserve"><value>Speicherort</value></data>
@@ -92,6 +91,7 @@
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Fehler beim Speichern: {0}</value></data>
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Löschen: {0}</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Ordner konnte nicht gewählt werden: {0}</value></data>
+  <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>Die Suche konnte nicht abgeschlossen werden.</value></data>
 
   <!-- Confirmation Dialogs -->
   <data name="Dlg_KategorieLoeschen" xml:space="preserve"><value>Kategorie löschen</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -43,7 +43,6 @@
   <data name="Lbl_AusgabenNachKategorie" xml:space="preserve"><value>Expenses by Category</value></data>
   <data name="Lbl_EinnahmenNachKategorie" xml:space="preserve"><value>Income by Category</value></data>
   <data name="Lbl_Jahresausgaben" xml:space="preserve"><value>Annual Expenses</value></data>
-  <data name="Lbl_JahressummeColon" xml:space="preserve"><value>Annual Total:</value></data>
   <data name="Lbl_AusgabenProMonat" xml:space="preserve"><value>Expenses per Month</value></data>
   <data name="Lbl_Darstellung" xml:space="preserve"><value>Appearance</value></data>
   <data name="Lbl_Speicherort" xml:space="preserve"><value>Data Storage</value></data>
@@ -92,6 +91,7 @@
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Error saving: {0}</value></data>
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Error deleting: {0}</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Folder could not be selected: {0}</value></data>
+  <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>The search could not be completed.</value></data>
 
   <!-- Confirmation Dialogs -->
   <data name="Dlg_KategorieLoeschen" xml:space="preserve"><value>Delete Category</value></data>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -43,7 +43,6 @@ public static class ResourceKeys
     public const string Lbl_AusgabenNachKategorie = nameof(Lbl_AusgabenNachKategorie);
     public const string Lbl_EinnahmenNachKategorie = nameof(Lbl_EinnahmenNachKategorie);
     public const string Lbl_Jahresausgaben = nameof(Lbl_Jahresausgaben);
-    public const string Lbl_JahressummeColon = nameof(Lbl_JahressummeColon);
     public const string Lbl_AusgabenProMonat = nameof(Lbl_AusgabenProMonat);
     public const string Lbl_Darstellung = nameof(Lbl_Darstellung);
     public const string Lbl_Speicherort = nameof(Lbl_Speicherort);
@@ -92,6 +91,7 @@ public static class ResourceKeys
     public const string Err_SpeichernFehlgeschlagen = nameof(Err_SpeichernFehlgeschlagen);
     public const string Err_LoeschenFehlgeschlagen = nameof(Err_LoeschenFehlgeschlagen);
     public const string Err_OrdnerNichtWaehlbar = nameof(Err_OrdnerNichtWaehlbar);
+    public const string Err_SucheFehlgeschlagen = nameof(Err_SucheFehlgeschlagen);
 
     // Confirmation Dialogs
     public const string Dlg_KategorieLoeschen = nameof(Dlg_KategorieLoeschen);

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -187,16 +187,22 @@ public partial class TransactionsViewModel(
 
     private void TriggerSearchDebounced()
     {
-        _searchDebounce?.Cancel();
+        var oldCts = _searchDebounce;
         _searchDebounce = new CancellationTokenSource();
+        oldCts?.Cancel();
+        oldCts?.Dispose();
         var token = _searchDebounce.Token;
         var version = Interlocked.Increment(ref _searchVersion);
-        Task.Run(async () =>
+        _ = Task.Run(async () =>
         {
-            await Task.Delay(300, token);
-            if (!token.IsCancellationRequested)
-                await MainThread.InvokeOnMainThreadAsync(() => ExecuteSearchAsync(version));
-        }, token);
+            try
+            {
+                await Task.Delay(300, token);
+                if (!token.IsCancellationRequested)
+                    await MainThread.InvokeOnMainThreadAsync(() => ExecuteSearchAsync(version));
+            }
+            catch (TaskCanceledException) { }
+        });
     }
 
     private async Task ExecuteSearchAsync(int version = -1)
@@ -221,6 +227,17 @@ public partial class TransactionsViewModel(
             SearchErgebnisGruppen = new ObservableCollection<TransactionGroup>(result.Gruppen);
             TotalSearchCount = result.TotalCount;
             Converters.KategorieIdToIconConverter.SetCache(result.IconMap);
+        }
+        catch (Exception ex)
+        {
+            LogError(nameof(ExecuteSearchAsync), ex);
+            if (version >= 0 && version != _searchVersion) return;
+            SearchErgebnisGruppen = [];
+            TotalSearchCount = 0;
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SucheFehlgeschlagen),
+                _loc.GetString(ResourceKeys.Btn_OK));
         }
         finally
         {

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -52,8 +52,9 @@
                 </Border>
 
                 <!-- Ansicht-Umschalter -->
-                <Border StrokeShape="RoundRectangle 10" Stroke="#E5E5EA"
-                        BackgroundColor="#F2F2F7" Padding="2">
+                <Border StrokeShape="RoundRectangle 10"
+                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                        BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#2C2C2E}" Padding="2">
                     <Grid ColumnDefinitions="*, *" ColumnSpacing="2">
                         <Border Grid.Column="0" StrokeShape="RoundRectangle 8" Stroke="Transparent"
                                 BackgroundColor="{Binding IsMonthView, Converter={StaticResource ToggleActiveColor}}"


### PR DESCRIPTION
Fixes 5 review comments from PR #125.

### Changes

- **Debounce race** (`TriggerSearchDebounced`): catch `TaskCanceledException`, dispose old `CancellationTokenSource` → no more unobserved exceptions on cancel
- **Search error handling** (`ExecuteSearchAsync`): add try/catch with localized error dialog + reset results → `IsLoading` can no longer get stuck
- **`TransactionGroup.DatumFormatiert`**: use `CultureInfo.CurrentCulture` instead of hardcoded `de-DE`
- **`Lbl_JahressummeColon`**: remove unused key from `ResourceKeys.cs` and both resx files (consumer `YearOverviewPage` was deleted)
- **DashboardPage view toggle**: replace hardcoded `#E5E5EA`/`#F2F2F7` with `AppThemeBinding` for dark mode consistency

Addresses review comments on #125 (skipped #3/#4 as scope-creep for v1.3).