### PR TITLE
🐛 fix: v1.3 Quick Fixes – HasYearData, Jahresnavigation, Fehlerbehandlung, Bestätigungsdialog

### DIFF
--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -90,6 +90,7 @@
   <data name="Err_KategorieErforderlich" xml:space="preserve"><value>Kategorie ist erforderlich</value></data>
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Fehler beim Speichern: {0}</value></data>
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Löschen: {0}</value></data>
+  <data name="Err_LadenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Laden: {0}</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Ordner konnte nicht gewählt werden: {0}</value></data>
   <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>Die Suche konnte nicht abgeschlossen werden.</value></data>
 
@@ -100,6 +101,8 @@
   <data name="Dlg_DauerauftragLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
   <data name="Dlg_TransaktionLoeschen" xml:space="preserve"><value>Transaktion löschen</value></data>
   <data name="Dlg_TransaktionLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
+  <data name="Dlg_SparZielLoeschen" xml:space="preserve"><value>Sparziel löschen</value></data>
+  <data name="Dlg_SparZielLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
 
   <!-- Settings Messages -->
   <data name="Stn_UngueltigerOrdner" xml:space="preserve"><value>Ungültiger Ordner</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -90,6 +90,7 @@
   <data name="Err_KategorieErforderlich" xml:space="preserve"><value>Category is required</value></data>
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Error saving: {0}</value></data>
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Error deleting: {0}</value></data>
+  <data name="Err_LadenFehlgeschlagen" xml:space="preserve"><value>Error loading data: {0}</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Folder could not be selected: {0}</value></data>
   <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>The search could not be completed.</value></data>
 
@@ -100,6 +101,8 @@
   <data name="Dlg_DauerauftragLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
   <data name="Dlg_TransaktionLoeschen" xml:space="preserve"><value>Delete Transaction</value></data>
   <data name="Dlg_TransaktionLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
+  <data name="Dlg_SparZielLoeschen" xml:space="preserve"><value>Delete Savings Goal</value></data>
+  <data name="Dlg_SparZielLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
 
   <!-- Settings Messages -->
   <data name="Stn_UngueltigerOrdner" xml:space="preserve"><value>Invalid Folder</value></data>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -90,6 +90,7 @@ public static class ResourceKeys
     public const string Err_KategorieErforderlich = nameof(Err_KategorieErforderlich);
     public const string Err_SpeichernFehlgeschlagen = nameof(Err_SpeichernFehlgeschlagen);
     public const string Err_LoeschenFehlgeschlagen = nameof(Err_LoeschenFehlgeschlagen);
+    public const string Err_LadenFehlgeschlagen = nameof(Err_LadenFehlgeschlagen);
     public const string Err_OrdnerNichtWaehlbar = nameof(Err_OrdnerNichtWaehlbar);
     public const string Err_SucheFehlgeschlagen = nameof(Err_SucheFehlgeschlagen);
 
@@ -100,6 +101,8 @@ public static class ResourceKeys
     public const string Dlg_DauerauftragLoeschenFrage = nameof(Dlg_DauerauftragLoeschenFrage);
     public const string Dlg_TransaktionLoeschen = nameof(Dlg_TransaktionLoeschen);
     public const string Dlg_TransaktionLoeschenFrage = nameof(Dlg_TransaktionLoeschenFrage);
+    public const string Dlg_SparZielLoeschen = nameof(Dlg_SparZielLoeschen);
+    public const string Dlg_SparZielLoeschenFrage = nameof(Dlg_SparZielLoeschenFrage);
 
     // Settings Messages
     public const string Stn_UngueltigerOrdner = nameof(Stn_UngueltigerOrdner);

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -79,9 +79,11 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private decimal jahrGesamtAusgaben;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private ObservableCollection<CategorySummary> jahrKategorien = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private List<MonthSummary> jahrMonate = [];
 
     // --- Allgemein ---
@@ -178,7 +180,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
             if (all.Count > 0)
                 _minJahr = all.Min(t => t.Datum.Year);
         }
-        catch { /* Fallback auf initialen Wert */ }
+        catch (Exception ex)
+        {
+            try { Finanzuebersicht.Services.FileLogger.Append("DashboardViewModel", "EnsureMinJahrLoadedAsync failed", ex); } catch { }
+        }
         PreviousYearCommand.NotifyCanExecuteChanged();
     }
 

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -97,7 +97,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     public bool HasMonthData => KategorieAusgaben.Count > 0 || KategorieEinnahmen.Count > 0;
 
-    public bool HasYearData => JahrGesamtAusgaben > 0;
+    public bool HasYearData => JahrMonate.Count > 0 || JahrKategorien.Count > 0;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasDueItems))]
@@ -110,7 +110,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         ? _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig_Singular, DueRecurringCount)
         : _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig, DueRecurringCount);
 
+    private readonly ITransactionRepository _transactionRepository;
     private int _aktuellesJahr;
+    private int _minJahr;
+    private bool _minJahrLoaded;
 
     public DashboardViewModel(
         LoadDashboardMonthUseCase loadDashboardMonthUseCase,
@@ -121,10 +124,12 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         IReportingService reportingService,
         ILocalizationService localizationService,
         INavigationService navigationService,
+        ITransactionRepository transactionRepository,
         IClock? clock = null) : base(clock)
     {
         _clock = clock ?? SystemClock.Instance;
         _aktuellesJahr = _clock.Today.Year;
+        _minJahr = _clock.Today.Year - 10;
         _loadDashboardMonthUseCase = loadDashboardMonthUseCase;
         _loadDashboardYearUseCase = loadDashboardYearUseCase;
         _loadForecastUseCase = loadForecastUseCase;
@@ -133,6 +138,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _reportingService = reportingService;
         _loc = localizationService;
         _navigationService = navigationService;
+        _transactionRepository = transactionRepository;
         UpdateJahrAnzeige();
     }
 
@@ -145,6 +151,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         IsLoading = true;
         try
         {
+            await EnsureMinJahrLoadedAsync();
             if (IsMonthView)
             {
                 await LadeMonatAsync();
@@ -159,6 +166,20 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         {
             IsLoading = false;
         }
+    }
+
+    private async Task EnsureMinJahrLoadedAsync()
+    {
+        if (_minJahrLoaded) return;
+        _minJahrLoaded = true;
+        try
+        {
+            var all = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+            if (all.Count > 0)
+                _minJahr = all.Min(t => t.Datum.Year);
+        }
+        catch { /* Fallback auf initialen Wert */ }
+        PreviousYearCommand.NotifyCanExecuteChanged();
     }
 
     private async Task LadeMonatAsync()
@@ -278,9 +299,9 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         await LoadDashboard();
     }
 
-    private bool CanGoNextYear() => _aktuellesJahr < _clock.Today.Year;
+    private bool CanGoNextYear() => _aktuellesJahr < _clock.Today.Year + 1;
 
-    private bool CanGoPreviousYear() => _aktuellesJahr > _clock.Today.Year - 30;
+    private bool CanGoPreviousYear() => _aktuellesJahr > _minJahr;
 
     private void UpdateJahrAnzeige()
     {

--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -142,14 +142,43 @@ public partial class SparZieleViewModel : ObservableObject
     [RelayCommand]
     private async Task UpdateBetrag(SparZiel ziel)
     {
-        await _saveUseCase.ExecuteAsync(ziel);
-        await LoadSparZieleCommand.ExecuteAsync(null);
+        try
+        {
+            await _saveUseCase.ExecuteAsync(ziel);
+            await LoadSparZieleCommand.ExecuteAsync(null);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"UpdateBetrag failed: {ex}");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 
     [RelayCommand]
     private async Task DeleteSparZiel(string id)
     {
-        await _deleteUseCase.ExecuteAsync(id);
-        await LoadSparZieleCommand.ExecuteAsync(null);
+        var titel = SparZiele.FirstOrDefault(z => z.SparZiel.Id == id)?.SparZiel.Titel ?? id;
+        var confirm = await _dialogService.ShowConfirmationAsync(
+            _loc.GetString(ResourceKeys.Dlg_SparZielLoeschen),
+            _loc.GetString(ResourceKeys.Dlg_SparZielLoeschenFrage, titel),
+            _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
+        if (!confirm) return;
+
+        try
+        {
+            await _deleteUseCase.ExecuteAsync(id);
+            await LoadSparZieleCommand.ExecuteAsync(null);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"DeleteSparZiel failed: {ex}");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 }

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -297,6 +297,14 @@ public partial class TransactionsViewModel(
             if (AvailableKategorien.Count == 0)
                 await LoadKategorienAsync();
         }
+        catch (Exception ex)
+        {
+            LogError(nameof(LoadTransaktionen), ex);
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LadenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
         finally
         {
             IsLoading = false;

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -46,7 +46,7 @@
                                TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                         <Label Grid.Column="1" Text="›" FontSize="20" FontAttributes="Bold"
                                VerticalTextAlignment="Center"
-                               SemanticProperties.Description=""
+                               AutomationProperties.IsInAccessibleTree="False"
                                TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                     </Grid>
                 </Border>

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -46,7 +46,7 @@
                                TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                         <Label Grid.Column="1" Text="›" FontSize="20" FontAttributes="Bold"
                                VerticalTextAlignment="Center"
-                               AutomationProperties.IsInAccessibleTree="False"
+                               SemanticProperties.Description=""
                                TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                     </Grid>
                 </Border>

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -67,8 +67,7 @@
                     Padding="0"
                     WidthRequest="44" HeightRequest="44"
                     VerticalOptions="Center"
-                    SemanticProperties.Description="{loc:Translate A11y_FilterUmschalten}"
-                    AutomationProperties.Name="{loc:Translate A11y_FilterUmschalten}">
+                    SemanticProperties.Description="{loc:Translate A11y_FilterUmschalten}">
                 <Button.Triggers>
                     <DataTrigger TargetType="Button" Binding="{Binding IsFilterActive}" Value="True">
                         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />


### PR DESCRIPTION
## Closes

Closes #128, #129, #130, #131, #132, #134

## Changes

| Issue | Fix |
|-------|-----|
| #128 | `HasYearData` basiert auf Datenmenge statt Ausgaben-Betrag |
| #129 | Jahresnavigation: +1 Jahr erlaubt, Min-Jahr aus Transaktionsdaten |
| #130 | `SparZieleViewModel`: try-catch in `UpdateBetrag` + `DeleteSparZiel` |
| #131 | `DeleteSparZiel` mit Bestätigungsdialog vor dem Löschen |
| #132 | `LoadTransaktionen` mit catch + Fehlerdialog für den Nutzer |
| #134 | `AutomationProperties` durch `SemanticProperties` ersetzt |

## Test

✅ 161/161 Tests grün  
✅ Build erfolgreich (net10.0-maccatalyst)