### PR TITLE
✨ feat: Dashboard Empty State + einheitliches Error-Logging (#133, #135)

### DIFF
--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -81,6 +81,8 @@
   <data name="Empty_KeineSuchergebnisse" xml:space="preserve"><value>Keine Transaktionen gefunden</value></data>
   <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>Keine Daten für diesen Zeitraum</value></data>
   <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>Keine Daten für dieses Jahr</value></data>
+  <data name="Empty_NochKeineTransaktionen" xml:space="preserve"><value>Noch keine Transaktionen vorhanden</value></data>
+  <data name="Btn_ZuTransaktionen" xml:space="preserve"><value>Erste Transaktion hinzufügen</value></data>
 
   <!-- Error Messages -->
   <data name="Err_Titel" xml:space="preserve"><value>Fehler</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -81,6 +81,8 @@
   <data name="Empty_KeineSuchergebnisse" xml:space="preserve"><value>No transactions found</value></data>
   <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>No data for this period</value></data>
   <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>No data for this year</value></data>
+  <data name="Empty_NochKeineTransaktionen" xml:space="preserve"><value>No transactions yet</value></data>
+  <data name="Btn_ZuTransaktionen" xml:space="preserve"><value>Add First Transaction</value></data>
 
   <!-- Error Messages -->
   <data name="Err_Titel" xml:space="preserve"><value>Error</value></data>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -81,6 +81,8 @@ public static class ResourceKeys
     public const string Empty_KeineSuchergebnisse = nameof(Empty_KeineSuchergebnisse);
     public const string Empty_KeineDashboardDaten = nameof(Empty_KeineDashboardDaten);
     public const string Empty_KeineJahresDaten = nameof(Empty_KeineJahresDaten);
+    public const string Empty_NochKeineTransaktionen = nameof(Empty_NochKeineTransaktionen);
+    public const string Btn_ZuTransaktionen = nameof(Btn_ZuTransaktionen);
 
     // Error Messages
     public const string Err_Titel = nameof(Err_Titel);

--- a/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
@@ -39,6 +39,14 @@ public partial class CategoriesViewModel(
             var liste = await _loadCategoriesUseCase.ExecuteAsync();
             Kategorien = new ObservableCollection<Category>(liste);
         }
+        catch (Exception ex)
+        {
+            try { Finanzuebersicht.Services.FileLogger.Append("CategoriesViewModel", nameof(LoadKategorien), ex); } catch { }
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LadenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
         finally
         {
             IsLoading = false;
@@ -54,8 +62,19 @@ public partial class CategoriesViewModel(
             _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
         if (!confirm) return;
 
-        await _deleteCategoryUseCase.ExecuteAsync(kategorie.Id);
-        Kategorien.Remove(kategorie);
+        try
+        {
+            await _deleteCategoryUseCase.ExecuteAsync(kategorie.Id);
+            Kategorien.Remove(kategorie);
+        }
+        catch (Exception ex)
+        {
+            try { Finanzuebersicht.Services.FileLogger.Append("CategoriesViewModel", nameof(DeleteKategorie), ex); } catch { }
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
@@ -84,7 +84,7 @@ public partial class CategoryDetailViewModel(
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[CategoryDetailViewModel] LoadBudgetAsync failed: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("CategoryDetailViewModel", "LoadBudgetAsync", ex); } catch { }
         }
     }
 

--- a/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
@@ -84,7 +84,7 @@ public partial class CategoryDetailViewModel(
         }
         catch (Exception ex)
         {
-            try { Finanzuebersicht.Services.FileLogger.Append("CategoryDetailViewModel", "LoadBudgetAsync", ex); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("CategoryDetailViewModel", nameof(LoadBudgetAsync), ex); } catch { }
         }
     }
 

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -184,7 +184,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     private async Task EnsureMinJahrLoadedAsync()
     {
-        if (_minJahrLoaded) return;
+        if (_minJahrLoaded && HasAnyDataLoaded) return;
         _minJahrLoaded = true;
         try
         {

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -93,6 +93,8 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsYearView))]
+    [NotifyPropertyChangedFor(nameof(ShowMonthView))]
+    [NotifyPropertyChangedFor(nameof(ShowYearView))]
     private bool isMonthView = true;
 
     public bool IsYearView => !IsMonthView;
@@ -100,6 +102,16 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     public bool HasMonthData => KategorieAusgaben.Count > 0 || KategorieEinnahmen.Count > 0;
 
     public bool HasYearData => JahrMonate.Count > 0 || JahrKategorien.Count > 0;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasAnyData))]
+    [NotifyPropertyChangedFor(nameof(ShowMonthView))]
+    [NotifyPropertyChangedFor(nameof(ShowYearView))]
+    private bool hasAnyDataLoaded;
+
+    public bool HasAnyData => HasAnyDataLoaded;
+    public bool ShowMonthView => HasAnyDataLoaded && IsMonthView;
+    public bool ShowYearView => HasAnyDataLoaded && IsYearView;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasDueItems))]
@@ -178,7 +190,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         {
             var all = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
             if (all.Count > 0)
+            {
                 _minJahr = all.Min(t => t.Datum.Year);
+                HasAnyDataLoaded = true;
+            }
         }
         catch (Exception ex)
         {
@@ -325,5 +340,11 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private async Task NavigateToDauerauftraege()
     {
         await _navigationService.GoToAsync("//RecurringTransactionsPage");
+    }
+
+    [RelayCommand]
+    private async Task NavigateToTransaktionen()
+    {
+        await _navigationService.GoToAsync("//TransactionsPage");
     }
 }

--- a/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
@@ -50,10 +50,10 @@ public partial class RecurringInstanceShiftViewModel(
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error while shifting recurring instance: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("RecurringInstanceShiftViewModel", nameof(Save), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
             return;
         }

--- a/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
@@ -41,6 +41,14 @@ public partial class RecurringTransactionsViewModel(
             var liste = await _loadRecurringTransactionsUseCase.ExecuteAsync();
             Dauerauftraege = new ObservableCollection<RecurringTransaction>(liste);
         }
+        catch (Exception ex)
+        {
+            try { Finanzuebersicht.Services.FileLogger.Append("RecurringTransactionsViewModel", nameof(LoadDauerauftraege), ex); } catch { }
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LadenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
         finally
         {
             IsLoading = false;
@@ -71,6 +79,7 @@ public partial class RecurringTransactionsViewModel(
         }
         catch (Exception ex)
         {
+            try { Finanzuebersicht.Services.FileLogger.Append("RecurringTransactionsViewModel", nameof(DeleteDauerauftrag), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),

--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -127,7 +127,7 @@ public partial class SparZieleViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"SaveNewSparZiel failed: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("SparZieleViewModel", nameof(SaveNewSparZiel), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen),
@@ -149,7 +149,7 @@ public partial class SparZieleViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"UpdateBetrag failed: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("SparZieleViewModel", nameof(UpdateBetrag), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
@@ -174,7 +174,7 @@ public partial class SparZieleViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"DeleteSparZiel failed: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("SparZieleViewModel", nameof(DeleteSparZiel), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -51,10 +51,26 @@
                     </Grid>
                 </Border>
 
+                <!-- Global Empty State – keine Transaktionen vorhanden -->
+                <VerticalStackLayout Spacing="16" HorizontalOptions="Center" Margin="0,40,0,0"
+                                     IsVisible="{Binding HasAnyData, Converter={StaticResource InvertBool}}">
+                    <Label Text="📊" FontSize="56" HorizontalTextAlignment="Center" />
+                    <Label Text="{loc:Translate Empty_NochKeineTransaktionen}"
+                           FontSize="17" TextColor="Gray"
+                           HorizontalTextAlignment="Center" />
+                    <Button Text="{loc:Translate Btn_ZuTransaktionen}"
+                            Command="{Binding NavigateToTransaktionenCommand}"
+                            HorizontalOptions="Center"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            TextColor="White"
+                            CornerRadius="10" Padding="20,10" />
+                </VerticalStackLayout>
+
                 <!-- Ansicht-Umschalter -->
                 <Border StrokeShape="RoundRectangle 10"
                         Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                        BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#2C2C2E}" Padding="2">
+                        BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#2C2C2E}" Padding="2"
+                        IsVisible="{Binding HasAnyData}">
                     <Grid ColumnDefinitions="*, *" ColumnSpacing="2">
                         <Border Grid.Column="0" StrokeShape="RoundRectangle 8" Stroke="Transparent"
                                 BackgroundColor="{Binding IsMonthView, Converter={StaticResource ToggleActiveColor}}"
@@ -80,7 +96,7 @@
                 </Border>
 
                 <!-- Monatsansicht -->
-                <VerticalStackLayout Spacing="16" IsVisible="{Binding IsMonthView}">
+                <VerticalStackLayout Spacing="16" IsVisible="{Binding ShowMonthView}">
 
                 <!-- Monatsnavigation -->
                 <Grid ColumnDefinitions="Auto, *, Auto">
@@ -270,7 +286,7 @@
                 </VerticalStackLayout>
 
                 <!-- Jahresansicht -->
-                <VerticalStackLayout Spacing="16" IsVisible="{Binding IsYearView}">
+                <VerticalStackLayout Spacing="16" IsVisible="{Binding ShowYearView}">
 
                 <!-- Jahresnavigation -->
                 <Grid ColumnDefinitions="Auto, *, Auto">

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -54,7 +54,8 @@
                 <!-- Global Empty State – keine Transaktionen vorhanden -->
                 <VerticalStackLayout Spacing="16" HorizontalOptions="Center" Margin="0,40,0,0"
                                      IsVisible="{Binding HasAnyData, Converter={StaticResource InvertBool}}">
-                    <Label Text="📊" FontSize="56" HorizontalTextAlignment="Center" />
+                    <Label Text="📊" FontSize="56" HorizontalTextAlignment="Center"
+                           AutomationProperties.IsInAccessibleTree="False" />
                     <Label Text="{loc:Translate Empty_NochKeineTransaktionen}"
                            FontSize="17" TextColor="Gray"
                            HorizontalTextAlignment="Center" />


### PR DESCRIPTION
## Closes
Closes #133, #135

## Changes

### #133 – Dashboard Empty State
- Neue Properties `HasAnyData`, `ShowMonthView`, `ShowYearView` in `DashboardViewModel`
- `HasAnyDataLoaded` wird lazy beim ersten `LoadDashboard()` aus Transaktionsdaten gesetzt
- `NavigateToTransaktionenCommand` für Button im Empty State
- **DashboardPage:** Placeholder-UI (📊 + Text + Button) wenn noch keine Transaktionen vorhanden
- Ansicht-Umschalter + Monats-/Jahresansicht nur sichtbar wenn `HasAnyData = true`
- Neue ResourceKeys: `Empty_NochKeineTransaktionen`, `Btn_ZuTransaktionen` (DE + EN)

### #135 – Error-Logging vereinheitlichen
- `RecurringInstanceShiftViewModel`: `Debug.WriteLine` → `FileLogger.Append`; Fehlermeldung enthält jetzt `ex.Message`
- `SparZieleViewModel`: alle 3 `Debug.WriteLine` → `FileLogger.Append`
- `CategoryDetailViewModel`: `Debug.WriteLine` → `FileLogger.Append`
- `CategoriesViewModel`: `catch`-Block in `LoadKategorien` + `DeleteKategorie` mit try-catch abgesichert
- `RecurringTransactionsViewModel`: `catch`-Block in `LoadDauerauftraege`; `DeleteDauerauftrag` mit `FileLogger`

## Test
✅ 161/161 Tests grün  
✅ Build erfolgreich (net10.0-maccatalyst, 0 Warnungen)