### PR TITLE
🐛 fix(service): CSV-Export via FileSaver statt temporärem Ordner (#136)

### DIFF
--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -448,7 +448,7 @@ public partial class SettingsViewModel : ObservableObject
 
         try
         {
-            var csvStream = await _backupService.ExportAsCSVAsync();
+            await using var csvStream = await _backupService.ExportAsCSVAsync();
             csvStream.Seek(0, System.IO.SeekOrigin.Begin);
 
             var fileName = $"Finanzuebersicht_Export_{_clock.Now:yyyy-MM-dd}.csv";
@@ -460,6 +460,14 @@ public partial class SettingsViewModel : ObservableObject
                 await _dialogService.ShowAlertAsync(
                     _loc.GetString(ResourceKeys.Msg_CSVExportedTitle),
                     string.Format(_loc.GetString(ResourceKeys.Msg_CSVExportedBody), result.FilePath),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+            }
+            else if (result.Exception is not null and not OperationCanceledException)
+            {
+                _logger?.LogError(result.Exception, "ExportAsCSV SaveAsync failed");
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_CSVExportFailedTitle),
+                    string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), result.Exception.Message),
                     _loc.GetString(ResourceKeys.Btn_OK));
             }
         }

--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -449,22 +449,23 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             var csvStream = await _backupService.ExportAsCSVAsync();
-            var csvData = new byte[csvStream.Length];
             csvStream.Seek(0, System.IO.SeekOrigin.Begin);
-            csvStream.Read(csvData, 0, csvData.Length);
 
-            var fileName = $"Finanzuebersicht_{_clock.Now:yyyyMMdd_HHmmss}.csv";
-            var filePath = Path.Combine(Path.GetTempPath(), fileName);
+            var fileName = $"Finanzuebersicht_Export_{_clock.Now:yyyy-MM-dd}.csv";
+            var result = await CommunityToolkit.Maui.Storage.FileSaver.Default
+                .SaveAsync(fileName, csvStream, CancellationToken.None);
 
-            File.WriteAllBytes(filePath, csvData);
-
-            await _dialogService.ShowAlertAsync(
-                _loc.GetString(ResourceKeys.Msg_CSVExportedTitle),
-                string.Format(_loc.GetString(ResourceKeys.Msg_CSVExportedBody), filePath),
-                _loc.GetString(ResourceKeys.Btn_OK));
+            if (result.IsSuccessful)
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_CSVExportedTitle),
+                    string.Format(_loc.GetString(ResourceKeys.Msg_CSVExportedBody), result.FilePath),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+            }
         }
         catch (Exception ex)
         {
+            _logger?.LogError(ex, "ExportAsCSV failed");
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Msg_CSVExportFailedTitle),
                 string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), ex.Message),


### PR DESCRIPTION
## Closes
Closes #136

## Problem
`ExportAsCSV()` schrieb die Datei in `Path.GetTempPath()` – auf macOS (Sandbox) für den Nutzer nicht auffindbar und kann vom OS gelöscht werden.

## Lösung
Nutzt jetzt `CommunityToolkit.Maui.Storage.FileSaver.Default.SaveAsync()` für den nativen Save-Dialog.

## Changes
- Benutzer wählt Speicherort selbst via nativen macOS/iOS Save-Dialog
- Bei Abbruch: stille Rückkehr (kein Dialog)
- Dateiname: `Finanzuebersicht_Export_YYYY-MM-DD.csv`
- Fehler werden via `ILogger` strukturiert geloggt
- Kein neues NuGet-Paket notwendig – `CommunityToolkit.Maui` war bereits referenziert und via `UseMauiCommunityToolkit()` registriert

## Test
✅ 161/161 Tests grün  
✅ Build erfolgreich (net10.0-maccatalyst, 0 Warnungen)