### PR TITLE
🐛 fix(viewmodel): Fehlender ex.Message Parameter in SaveNewSparZiel

### DIFF
--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -130,7 +130,7 @@ public partial class SparZieleViewModel : ObservableObject
             try { Finanzuebersicht.Services.FileLogger.Append("SparZieleViewModel", nameof(SaveNewSparZiel), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
             return;
         }


### PR DESCRIPTION
## Problem\nCode Review der v1.3 Änderungen hat ergeben: `Err_SpeichernFehlgeschlagen` wurde in `SaveNewSparZiel` ohne `ex.Message` aufgerufen → Nutzer sah `"Error saving: {0}"` statt der echten Fehlermeldung.\n\n## Fix\nFehlendes `ex.Message` Argument ergänzt – konsistent mit `UpdateBetrag` und `DeleteSparZiel` im selben ViewModel.\n\n✅ 161/161 Tests · ✅ Build 0 Fehler