### PR TITLE
🚀 Release v1.3 – Dashboard & Navigation

### DIFF
--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -90,6 +90,7 @@
   <data name="Err_KategorieErforderlich" xml:space="preserve"><value>Kategorie ist erforderlich</value></data>
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Fehler beim Speichern: {0}</value></data>
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Löschen: {0}</value></data>
+  <data name="Err_LadenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Laden: {0}</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Ordner konnte nicht gewählt werden: {0}</value></data>
   <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>Die Suche konnte nicht abgeschlossen werden.</value></data>
 
@@ -100,6 +101,8 @@
   <data name="Dlg_DauerauftragLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
   <data name="Dlg_TransaktionLoeschen" xml:space="preserve"><value>Transaktion löschen</value></data>
   <data name="Dlg_TransaktionLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
+  <data name="Dlg_SparZielLoeschen" xml:space="preserve"><value>Sparziel löschen</value></data>
+  <data name="Dlg_SparZielLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
 
   <!-- Settings Messages -->
   <data name="Stn_UngueltigerOrdner" xml:space="preserve"><value>Ungültiger Ordner</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -81,6 +81,8 @@
   <data name="Empty_KeineSuchergebnisse" xml:space="preserve"><value>Keine Transaktionen gefunden</value></data>
   <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>Keine Daten für diesen Zeitraum</value></data>
   <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>Keine Daten für dieses Jahr</value></data>
+  <data name="Empty_NochKeineTransaktionen" xml:space="preserve"><value>Noch keine Transaktionen vorhanden</value></data>
+  <data name="Btn_ZuTransaktionen" xml:space="preserve"><value>Erste Transaktion hinzufügen</value></data>
 
   <!-- Error Messages -->
   <data name="Err_Titel" xml:space="preserve"><value>Fehler</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -81,6 +81,8 @@
   <data name="Empty_KeineSuchergebnisse" xml:space="preserve"><value>No transactions found</value></data>
   <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>No data for this period</value></data>
   <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>No data for this year</value></data>
+  <data name="Empty_NochKeineTransaktionen" xml:space="preserve"><value>No transactions yet</value></data>
+  <data name="Btn_ZuTransaktionen" xml:space="preserve"><value>Add First Transaction</value></data>
 
   <!-- Error Messages -->
   <data name="Err_Titel" xml:space="preserve"><value>Error</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -90,6 +90,7 @@
   <data name="Err_KategorieErforderlich" xml:space="preserve"><value>Category is required</value></data>
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Error saving: {0}</value></data>
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Error deleting: {0}</value></data>
+  <data name="Err_LadenFehlgeschlagen" xml:space="preserve"><value>Error loading data: {0}</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Folder could not be selected: {0}</value></data>
   <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>The search could not be completed.</value></data>
 
@@ -100,6 +101,8 @@
   <data name="Dlg_DauerauftragLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
   <data name="Dlg_TransaktionLoeschen" xml:space="preserve"><value>Delete Transaction</value></data>
   <data name="Dlg_TransaktionLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
+  <data name="Dlg_SparZielLoeschen" xml:space="preserve"><value>Delete Savings Goal</value></data>
+  <data name="Dlg_SparZielLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
 
   <!-- Settings Messages -->
   <data name="Stn_UngueltigerOrdner" xml:space="preserve"><value>Invalid Folder</value></data>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -90,6 +90,7 @@ public static class ResourceKeys
     public const string Err_KategorieErforderlich = nameof(Err_KategorieErforderlich);
     public const string Err_SpeichernFehlgeschlagen = nameof(Err_SpeichernFehlgeschlagen);
     public const string Err_LoeschenFehlgeschlagen = nameof(Err_LoeschenFehlgeschlagen);
+    public const string Err_LadenFehlgeschlagen = nameof(Err_LadenFehlgeschlagen);
     public const string Err_OrdnerNichtWaehlbar = nameof(Err_OrdnerNichtWaehlbar);
     public const string Err_SucheFehlgeschlagen = nameof(Err_SucheFehlgeschlagen);
 
@@ -100,6 +101,8 @@ public static class ResourceKeys
     public const string Dlg_DauerauftragLoeschenFrage = nameof(Dlg_DauerauftragLoeschenFrage);
     public const string Dlg_TransaktionLoeschen = nameof(Dlg_TransaktionLoeschen);
     public const string Dlg_TransaktionLoeschenFrage = nameof(Dlg_TransaktionLoeschenFrage);
+    public const string Dlg_SparZielLoeschen = nameof(Dlg_SparZielLoeschen);
+    public const string Dlg_SparZielLoeschenFrage = nameof(Dlg_SparZielLoeschenFrage);
 
     // Settings Messages
     public const string Stn_UngueltigerOrdner = nameof(Stn_UngueltigerOrdner);

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -81,6 +81,8 @@ public static class ResourceKeys
     public const string Empty_KeineSuchergebnisse = nameof(Empty_KeineSuchergebnisse);
     public const string Empty_KeineDashboardDaten = nameof(Empty_KeineDashboardDaten);
     public const string Empty_KeineJahresDaten = nameof(Empty_KeineJahresDaten);
+    public const string Empty_NochKeineTransaktionen = nameof(Empty_NochKeineTransaktionen);
+    public const string Btn_ZuTransaktionen = nameof(Btn_ZuTransaktionen);
 
     // Error Messages
     public const string Err_Titel = nameof(Err_Titel);

--- a/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
@@ -39,6 +39,14 @@ public partial class CategoriesViewModel(
             var liste = await _loadCategoriesUseCase.ExecuteAsync();
             Kategorien = new ObservableCollection<Category>(liste);
         }
+        catch (Exception ex)
+        {
+            try { Finanzuebersicht.Services.FileLogger.Append("CategoriesViewModel", nameof(LoadKategorien), ex); } catch { }
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LadenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
         finally
         {
             IsLoading = false;
@@ -54,8 +62,19 @@ public partial class CategoriesViewModel(
             _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
         if (!confirm) return;
 
-        await _deleteCategoryUseCase.ExecuteAsync(kategorie.Id);
-        Kategorien.Remove(kategorie);
+        try
+        {
+            await _deleteCategoryUseCase.ExecuteAsync(kategorie.Id);
+            Kategorien.Remove(kategorie);
+        }
+        catch (Exception ex)
+        {
+            try { Finanzuebersicht.Services.FileLogger.Append("CategoriesViewModel", nameof(DeleteKategorie), ex); } catch { }
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
@@ -84,7 +84,7 @@ public partial class CategoryDetailViewModel(
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"[CategoryDetailViewModel] LoadBudgetAsync failed: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("CategoryDetailViewModel", "LoadBudgetAsync", ex); } catch { }
         }
     }
 

--- a/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoryDetailViewModel.cs
@@ -84,7 +84,7 @@ public partial class CategoryDetailViewModel(
         }
         catch (Exception ex)
         {
-            try { Finanzuebersicht.Services.FileLogger.Append("CategoryDetailViewModel", "LoadBudgetAsync", ex); } catch { }
+            try { Finanzuebersicht.Services.FileLogger.Append("CategoryDetailViewModel", nameof(LoadBudgetAsync), ex); } catch { }
         }
     }
 

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -184,7 +184,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     private async Task EnsureMinJahrLoadedAsync()
     {
-        if (_minJahrLoaded) return;
+        if (_minJahrLoaded && HasAnyDataLoaded) return;
         _minJahrLoaded = true;
         try
         {

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -79,9 +79,11 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private decimal jahrGesamtAusgaben;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private ObservableCollection<CategorySummary> jahrKategorien = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasYearData))]
     private List<MonthSummary> jahrMonate = [];
 
     // --- Allgemein ---
@@ -178,7 +180,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
             if (all.Count > 0)
                 _minJahr = all.Min(t => t.Datum.Year);
         }
-        catch { /* Fallback auf initialen Wert */ }
+        catch (Exception ex)
+        {
+            try { Finanzuebersicht.Services.FileLogger.Append("DashboardViewModel", "EnsureMinJahrLoadedAsync failed", ex); } catch { }
+        }
         PreviousYearCommand.NotifyCanExecuteChanged();
     }
 

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -93,6 +93,8 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsYearView))]
+    [NotifyPropertyChangedFor(nameof(ShowMonthView))]
+    [NotifyPropertyChangedFor(nameof(ShowYearView))]
     private bool isMonthView = true;
 
     public bool IsYearView => !IsMonthView;
@@ -100,6 +102,16 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     public bool HasMonthData => KategorieAusgaben.Count > 0 || KategorieEinnahmen.Count > 0;
 
     public bool HasYearData => JahrMonate.Count > 0 || JahrKategorien.Count > 0;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasAnyData))]
+    [NotifyPropertyChangedFor(nameof(ShowMonthView))]
+    [NotifyPropertyChangedFor(nameof(ShowYearView))]
+    private bool hasAnyDataLoaded;
+
+    public bool HasAnyData => HasAnyDataLoaded;
+    public bool ShowMonthView => HasAnyDataLoaded && IsMonthView;
+    public bool ShowYearView => HasAnyDataLoaded && IsYearView;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasDueItems))]
@@ -178,7 +190,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         {
             var all = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
             if (all.Count > 0)
+            {
                 _minJahr = all.Min(t => t.Datum.Year);
+                HasAnyDataLoaded = true;
+            }
         }
         catch (Exception ex)
         {
@@ -325,5 +340,11 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private async Task NavigateToDauerauftraege()
     {
         await _navigationService.GoToAsync("//RecurringTransactionsPage");
+    }
+
+    [RelayCommand]
+    private async Task NavigateToTransaktionen()
+    {
+        await _navigationService.GoToAsync("//TransactionsPage");
     }
 }

--- a/Finanzuebersicht/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht/ViewModels/DashboardViewModel.cs
@@ -97,7 +97,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     public bool HasMonthData => KategorieAusgaben.Count > 0 || KategorieEinnahmen.Count > 0;
 
-    public bool HasYearData => JahrGesamtAusgaben > 0;
+    public bool HasYearData => JahrMonate.Count > 0 || JahrKategorien.Count > 0;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasDueItems))]
@@ -110,7 +110,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         ? _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig_Singular, DueRecurringCount)
         : _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig, DueRecurringCount);
 
+    private readonly ITransactionRepository _transactionRepository;
     private int _aktuellesJahr;
+    private int _minJahr;
+    private bool _minJahrLoaded;
 
     public DashboardViewModel(
         LoadDashboardMonthUseCase loadDashboardMonthUseCase,
@@ -121,10 +124,12 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         IReportingService reportingService,
         ILocalizationService localizationService,
         INavigationService navigationService,
+        ITransactionRepository transactionRepository,
         IClock? clock = null) : base(clock)
     {
         _clock = clock ?? SystemClock.Instance;
         _aktuellesJahr = _clock.Today.Year;
+        _minJahr = _clock.Today.Year - 10;
         _loadDashboardMonthUseCase = loadDashboardMonthUseCase;
         _loadDashboardYearUseCase = loadDashboardYearUseCase;
         _loadForecastUseCase = loadForecastUseCase;
@@ -133,6 +138,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _reportingService = reportingService;
         _loc = localizationService;
         _navigationService = navigationService;
+        _transactionRepository = transactionRepository;
         UpdateJahrAnzeige();
     }
 
@@ -145,6 +151,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         IsLoading = true;
         try
         {
+            await EnsureMinJahrLoadedAsync();
             if (IsMonthView)
             {
                 await LadeMonatAsync();
@@ -159,6 +166,20 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         {
             IsLoading = false;
         }
+    }
+
+    private async Task EnsureMinJahrLoadedAsync()
+    {
+        if (_minJahrLoaded) return;
+        _minJahrLoaded = true;
+        try
+        {
+            var all = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+            if (all.Count > 0)
+                _minJahr = all.Min(t => t.Datum.Year);
+        }
+        catch { /* Fallback auf initialen Wert */ }
+        PreviousYearCommand.NotifyCanExecuteChanged();
     }
 
     private async Task LadeMonatAsync()
@@ -278,9 +299,9 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         await LoadDashboard();
     }
 
-    private bool CanGoNextYear() => _aktuellesJahr < _clock.Today.Year;
+    private bool CanGoNextYear() => _aktuellesJahr < _clock.Today.Year + 1;
 
-    private bool CanGoPreviousYear() => _aktuellesJahr > _clock.Today.Year - 30;
+    private bool CanGoPreviousYear() => _aktuellesJahr > _minJahr;
 
     private void UpdateJahrAnzeige()
     {

--- a/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringInstanceShiftViewModel.cs
@@ -50,10 +50,10 @@ public partial class RecurringInstanceShiftViewModel(
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"Error while shifting recurring instance: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("RecurringInstanceShiftViewModel", nameof(Save), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
             return;
         }

--- a/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
@@ -41,6 +41,14 @@ public partial class RecurringTransactionsViewModel(
             var liste = await _loadRecurringTransactionsUseCase.ExecuteAsync();
             Dauerauftraege = new ObservableCollection<RecurringTransaction>(liste);
         }
+        catch (Exception ex)
+        {
+            try { Finanzuebersicht.Services.FileLogger.Append("RecurringTransactionsViewModel", nameof(LoadDauerauftraege), ex); } catch { }
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LadenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
         finally
         {
             IsLoading = false;
@@ -71,6 +79,7 @@ public partial class RecurringTransactionsViewModel(
         }
         catch (Exception ex)
         {
+            try { Finanzuebersicht.Services.FileLogger.Append("RecurringTransactionsViewModel", nameof(DeleteDauerauftrag), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),

--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -448,7 +448,7 @@ public partial class SettingsViewModel : ObservableObject
 
         try
         {
-            var csvStream = await _backupService.ExportAsCSVAsync();
+            await using var csvStream = await _backupService.ExportAsCSVAsync();
             csvStream.Seek(0, System.IO.SeekOrigin.Begin);
 
             var fileName = $"Finanzuebersicht_Export_{_clock.Now:yyyy-MM-dd}.csv";
@@ -460,6 +460,14 @@ public partial class SettingsViewModel : ObservableObject
                 await _dialogService.ShowAlertAsync(
                     _loc.GetString(ResourceKeys.Msg_CSVExportedTitle),
                     string.Format(_loc.GetString(ResourceKeys.Msg_CSVExportedBody), result.FilePath),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+            }
+            else if (result.Exception is not null and not OperationCanceledException)
+            {
+                _logger?.LogError(result.Exception, "ExportAsCSV SaveAsync failed");
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_CSVExportFailedTitle),
+                    string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), result.Exception.Message),
                     _loc.GetString(ResourceKeys.Btn_OK));
             }
         }

--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -449,22 +449,23 @@ public partial class SettingsViewModel : ObservableObject
         try
         {
             var csvStream = await _backupService.ExportAsCSVAsync();
-            var csvData = new byte[csvStream.Length];
             csvStream.Seek(0, System.IO.SeekOrigin.Begin);
-            csvStream.Read(csvData, 0, csvData.Length);
 
-            var fileName = $"Finanzuebersicht_{_clock.Now:yyyyMMdd_HHmmss}.csv";
-            var filePath = Path.Combine(Path.GetTempPath(), fileName);
+            var fileName = $"Finanzuebersicht_Export_{_clock.Now:yyyy-MM-dd}.csv";
+            var result = await CommunityToolkit.Maui.Storage.FileSaver.Default
+                .SaveAsync(fileName, csvStream, CancellationToken.None);
 
-            File.WriteAllBytes(filePath, csvData);
-
-            await _dialogService.ShowAlertAsync(
-                _loc.GetString(ResourceKeys.Msg_CSVExportedTitle),
-                string.Format(_loc.GetString(ResourceKeys.Msg_CSVExportedBody), filePath),
-                _loc.GetString(ResourceKeys.Btn_OK));
+            if (result.IsSuccessful)
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_CSVExportedTitle),
+                    string.Format(_loc.GetString(ResourceKeys.Msg_CSVExportedBody), result.FilePath),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+            }
         }
         catch (Exception ex)
         {
+            _logger?.LogError(ex, "ExportAsCSV failed");
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Msg_CSVExportFailedTitle),
                 string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), ex.Message),

--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -127,7 +127,7 @@ public partial class SparZieleViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"SaveNewSparZiel failed: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("SparZieleViewModel", nameof(SaveNewSparZiel), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen),
@@ -149,7 +149,7 @@ public partial class SparZieleViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"UpdateBetrag failed: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("SparZieleViewModel", nameof(UpdateBetrag), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
@@ -174,7 +174,7 @@ public partial class SparZieleViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            System.Diagnostics.Debug.WriteLine($"DeleteSparZiel failed: {ex}");
+            try { Finanzuebersicht.Services.FileLogger.Append("SparZieleViewModel", nameof(DeleteSparZiel), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),

--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -130,7 +130,7 @@ public partial class SparZieleViewModel : ObservableObject
             try { Finanzuebersicht.Services.FileLogger.Append("SparZieleViewModel", nameof(SaveNewSparZiel), ex); } catch { }
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
             return;
         }

--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -142,14 +142,43 @@ public partial class SparZieleViewModel : ObservableObject
     [RelayCommand]
     private async Task UpdateBetrag(SparZiel ziel)
     {
-        await _saveUseCase.ExecuteAsync(ziel);
-        await LoadSparZieleCommand.ExecuteAsync(null);
+        try
+        {
+            await _saveUseCase.ExecuteAsync(ziel);
+            await LoadSparZieleCommand.ExecuteAsync(null);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"UpdateBetrag failed: {ex}");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 
     [RelayCommand]
     private async Task DeleteSparZiel(string id)
     {
-        await _deleteUseCase.ExecuteAsync(id);
-        await LoadSparZieleCommand.ExecuteAsync(null);
+        var titel = SparZiele.FirstOrDefault(z => z.SparZiel.Id == id)?.SparZiel.Titel ?? id;
+        var confirm = await _dialogService.ShowConfirmationAsync(
+            _loc.GetString(ResourceKeys.Dlg_SparZielLoeschen),
+            _loc.GetString(ResourceKeys.Dlg_SparZielLoeschenFrage, titel),
+            _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
+        if (!confirm) return;
+
+        try
+        {
+            await _deleteUseCase.ExecuteAsync(id);
+            await LoadSparZieleCommand.ExecuteAsync(null);
+        }
+        catch (Exception ex)
+        {
+            System.Diagnostics.Debug.WriteLine($"DeleteSparZiel failed: {ex}");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
     }
 }

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -297,6 +297,14 @@ public partial class TransactionsViewModel(
             if (AvailableKategorien.Count == 0)
                 await LoadKategorienAsync();
         }
+        catch (Exception ex)
+        {
+            LogError(nameof(LoadTransaktionen), ex);
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LadenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
         finally
         {
             IsLoading = false;

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -46,7 +46,7 @@
                                TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                         <Label Grid.Column="1" Text="›" FontSize="20" FontAttributes="Bold"
                                VerticalTextAlignment="Center"
-                               SemanticProperties.Description=""
+                               AutomationProperties.IsInAccessibleTree="False"
                                TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                     </Grid>
                 </Border>

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -51,10 +51,26 @@
                     </Grid>
                 </Border>
 
+                <!-- Global Empty State – keine Transaktionen vorhanden -->
+                <VerticalStackLayout Spacing="16" HorizontalOptions="Center" Margin="0,40,0,0"
+                                     IsVisible="{Binding HasAnyData, Converter={StaticResource InvertBool}}">
+                    <Label Text="📊" FontSize="56" HorizontalTextAlignment="Center" />
+                    <Label Text="{loc:Translate Empty_NochKeineTransaktionen}"
+                           FontSize="17" TextColor="Gray"
+                           HorizontalTextAlignment="Center" />
+                    <Button Text="{loc:Translate Btn_ZuTransaktionen}"
+                            Command="{Binding NavigateToTransaktionenCommand}"
+                            HorizontalOptions="Center"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            TextColor="White"
+                            CornerRadius="10" Padding="20,10" />
+                </VerticalStackLayout>
+
                 <!-- Ansicht-Umschalter -->
                 <Border StrokeShape="RoundRectangle 10"
                         Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                        BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#2C2C2E}" Padding="2">
+                        BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#2C2C2E}" Padding="2"
+                        IsVisible="{Binding HasAnyData}">
                     <Grid ColumnDefinitions="*, *" ColumnSpacing="2">
                         <Border Grid.Column="0" StrokeShape="RoundRectangle 8" Stroke="Transparent"
                                 BackgroundColor="{Binding IsMonthView, Converter={StaticResource ToggleActiveColor}}"
@@ -80,7 +96,7 @@
                 </Border>
 
                 <!-- Monatsansicht -->
-                <VerticalStackLayout Spacing="16" IsVisible="{Binding IsMonthView}">
+                <VerticalStackLayout Spacing="16" IsVisible="{Binding ShowMonthView}">
 
                 <!-- Monatsnavigation -->
                 <Grid ColumnDefinitions="Auto, *, Auto">
@@ -270,7 +286,7 @@
                 </VerticalStackLayout>
 
                 <!-- Jahresansicht -->
-                <VerticalStackLayout Spacing="16" IsVisible="{Binding IsYearView}">
+                <VerticalStackLayout Spacing="16" IsVisible="{Binding ShowYearView}">
 
                 <!-- Jahresnavigation -->
                 <Grid ColumnDefinitions="Auto, *, Auto">

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -54,7 +54,8 @@
                 <!-- Global Empty State – keine Transaktionen vorhanden -->
                 <VerticalStackLayout Spacing="16" HorizontalOptions="Center" Margin="0,40,0,0"
                                      IsVisible="{Binding HasAnyData, Converter={StaticResource InvertBool}}">
-                    <Label Text="📊" FontSize="56" HorizontalTextAlignment="Center" />
+                    <Label Text="📊" FontSize="56" HorizontalTextAlignment="Center"
+                           AutomationProperties.IsInAccessibleTree="False" />
                     <Label Text="{loc:Translate Empty_NochKeineTransaktionen}"
                            FontSize="17" TextColor="Gray"
                            HorizontalTextAlignment="Center" />

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -46,7 +46,7 @@
                                TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                         <Label Grid.Column="1" Text="›" FontSize="20" FontAttributes="Bold"
                                VerticalTextAlignment="Center"
-                               AutomationProperties.IsInAccessibleTree="False"
+                               SemanticProperties.Description=""
                                TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
                     </Grid>
                 </Border>

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -67,8 +67,7 @@
                     Padding="0"
                     WidthRequest="44" HeightRequest="44"
                     VerticalOptions="Center"
-                    SemanticProperties.Description="{loc:Translate A11y_FilterUmschalten}"
-                    AutomationProperties.Name="{loc:Translate A11y_FilterUmschalten}">
+                    SemanticProperties.Description="{loc:Translate A11y_FilterUmschalten}">
                 <Button.Triggers>
                     <DataTrigger TargetType="Button" Binding="{Binding IsFilterActive}" Value="True">
                         <Setter Property="BackgroundColor" Value="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.1",
+  "version": "1.2",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.2",
+  "version": "1.3",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## v1.3 – Dashboard & Navigation

Mergt `release/v1.3` (basiert auf `develop`) nach `main`.

### Enthaltene Issues

| # | Titel |
|---|-------|
| #128 | Fix: `HasYearData`-Logik berücksichtigt nur Ausgaben |
| #129 | Fix: Jahresnavigation – kein nächstes Jahr, 30-Jahres-Hardcode |
| #130 | Fix: SparZieleViewModel – Delete und Update ohne Fehlerbehandlung |
| #131 | UX: SparZieleViewModel – Bestätigungsdialog vor dem Löschen |
| #132 | Fix: LoadTransaktionen – Keine Fehlerbehandlung bei Ladefehler |
| #133 | UX: Dashboard – Kein Empty State wenn keine Transaktionen |
| #134 | Chore: AutomationProperties durch SemanticProperties ersetzt |
| #135 | Chore: Error-Logging in allen ViewModels vereinheitlichen |
| #136 | Fix: CSV-Export via FileSaver statt temporärem Ordner |

### Zusätzlich
- Code-Review-Fix: `Err_SpeichernFehlgeschlagen` mit fehlendem `ex.Message` Parameter

✅ 161/161 Tests · ✅ Build 0 Fehler · ✅ Code Review durchgeführt