### PR TITLE
✨ feat(ui): BackupListPage – Backup-Auswahl vor Wiederherstellung

### DIFF
--- a/Finanzuebersicht/AppShell.xaml.cs
+++ b/Finanzuebersicht/AppShell.xaml.cs
@@ -13,6 +13,7 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute(nameof(CategoryDetailPage), typeof(CategoryDetailPage));
 		Routing.RegisterRoute(nameof(RecurringInstanceShiftPage), typeof(RecurringInstanceShiftPage));
 		Routing.RegisterRoute(nameof(SettingsPage), typeof(SettingsPage));
+		Routing.RegisterRoute(nameof(BackupListPage), typeof(BackupListPage));
 	}
 
 	private async void OnSettingsClicked(object? sender, EventArgs e)

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -98,6 +98,7 @@ public static class MauiProgram
         builder.Services.AddTransient<RecurringInstanceShiftViewModel>();
 		builder.Services.AddTransient<SettingsViewModel>();
 		builder.Services.AddTransient<SparZieleViewModel>();
+		builder.Services.AddTransient<BackupListViewModel>();
 
 		// Pages
 		builder.Services.AddTransient<DashboardPage>();
@@ -110,6 +111,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<CategoryDetailPage>();
 		builder.Services.AddTransient<SettingsPage>();
 		builder.Services.AddTransient<SparZielePage>();
+		builder.Services.AddTransient<BackupListPage>();
 
 #if DEBUG
 		builder.Logging.AddDebug();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -181,6 +181,13 @@ Bitte starte die App neu.</value></data>
   <data name="Btn_BackupRestore" xml:space="preserve"><value>📥 Wiederherstellen</value></data>
   <data name="Btn_ExportCSV" xml:space="preserve"><value>📊 CSV exportieren</value></data>
   <data name="Msg_BackupRestoreTitle" xml:space="preserve"><value>Sicherung &amp; Wiederherstellung</value></data>
+  <data name="Ttl_BackupAuswaehlen" xml:space="preserve"><value>Backup auswählen</value></data>
+  <data name="Lbl_BackupTransaktionen" xml:space="preserve"><value>{0} Transaktionen, {1} Kategorien</value></data>
+  <data name="Lbl_BackupDatum" xml:space="preserve"><value>Erstellt: {0}</value></data>
+  <data name="Btn_BackupWiederherstellen" xml:space="preserve"><value>Wiederherstellen</value></data>
+  <data name="Empty_KeineBackupsVorhanden" xml:space="preserve"><value>Keine Backups im konfigurierten Backup-Ordner gefunden.</value></data>
+  <data name="Msg_BackupRestoreConfirmTitle" xml:space="preserve"><value>Backup wiederherstellen</value></data>
+  <data name="Msg_BackupRestoreConfirmBody" xml:space="preserve"><value>Backup vom {0} wiederherstellen? Alle aktuellen Daten werden überschrieben.</value></data>
   <data name="Msg_BackupRestoreDesc" xml:space="preserve"><value>Erstelle Sicherungen deiner Daten und stelle sie bei Bedarf wieder her.</value></data>
   <data name="Btn_Import" xml:space="preserve"><value>Import</value></data>
   <data name="Btn_FilterZuruecksetzen" xml:space="preserve"><value>Filter zurücksetzen</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -181,6 +181,13 @@ Please restart the app.</value></data>
   <data name="Btn_BackupRestore" xml:space="preserve"><value>📥 Restore</value></data>
   <data name="Btn_ExportCSV" xml:space="preserve"><value>📊 Export CSV</value></data>
   <data name="Msg_BackupRestoreTitle" xml:space="preserve"><value>Backup &amp; Restore</value></data>
+  <data name="Ttl_BackupAuswaehlen" xml:space="preserve"><value>Select Backup</value></data>
+  <data name="Lbl_BackupTransaktionen" xml:space="preserve"><value>{0} transactions, {1} categories</value></data>
+  <data name="Lbl_BackupDatum" xml:space="preserve"><value>Created: {0}</value></data>
+  <data name="Btn_BackupWiederherstellen" xml:space="preserve"><value>Restore</value></data>
+  <data name="Empty_KeineBackupsVorhanden" xml:space="preserve"><value>No backups found in the configured backup folder.</value></data>
+  <data name="Msg_BackupRestoreConfirmTitle" xml:space="preserve"><value>Restore backup</value></data>
+  <data name="Msg_BackupRestoreConfirmBody" xml:space="preserve"><value>Restore backup from {0}? All current data will be overwritten.</value></data>
   <data name="Msg_BackupRestoreDesc" xml:space="preserve"><value>Create backups of your data and restore when needed.</value></data>
   <data name="Btn_Import" xml:space="preserve"><value>Import</value></data>
   <data name="Btn_FilterZuruecksetzen" xml:space="preserve"><value>Clear filter</value></data>

--- a/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht/Resources/Strings/ResourceKeys.cs
@@ -216,6 +216,15 @@ public static class ResourceKeys
     public const string Btn_NeuesZiel = nameof(Btn_NeuesZiel);
     public const string Btn_ZielHinzufuegen = nameof(Btn_ZielHinzufuegen);
 
+    // Backup-Liste
+    public const string Ttl_BackupAuswaehlen = nameof(Ttl_BackupAuswaehlen);
+    public const string Lbl_BackupTransaktionen = nameof(Lbl_BackupTransaktionen);
+    public const string Lbl_BackupDatum = nameof(Lbl_BackupDatum);
+    public const string Btn_BackupWiederherstellen = nameof(Btn_BackupWiederherstellen);
+    public const string Empty_KeineBackupsVorhanden = nameof(Empty_KeineBackupsVorhanden);
+    public const string Msg_BackupRestoreConfirmTitle = nameof(Msg_BackupRestoreConfirmTitle);
+    public const string Msg_BackupRestoreConfirmBody = nameof(Msg_BackupRestoreConfirmBody);
+
     // Accessibility
     public const string A11y_VorherigerMonat = nameof(A11y_VorherigerMonat);
     public const string A11y_NaechsterMonat = nameof(A11y_NaechsterMonat);

--- a/Finanzuebersicht/ViewModels/BackupListViewModel.cs
+++ b/Finanzuebersicht/ViewModels/BackupListViewModel.cs
@@ -1,0 +1,116 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Services;
+using Finanzuebersicht.Resources.Strings;
+
+namespace Finanzuebersicht.ViewModels;
+
+public partial class BackupListViewModel : ObservableObject
+{
+    private readonly IBackupService _backupService;
+    private readonly SettingsService _settings;
+    private readonly IDialogService _dialogService;
+    private readonly ILocalizationService _loc;
+    private readonly INavigationService _navigationService;
+
+    [ObservableProperty]
+    private ObservableCollection<BackupMetadata> backups = [];
+
+    [ObservableProperty]
+    private bool isLoading;
+
+    [ObservableProperty]
+    private bool isEmpty;
+
+    public BackupListViewModel(
+        IBackupService backupService,
+        SettingsService settings,
+        IDialogService dialogService,
+        ILocalizationService localizationService,
+        INavigationService navigationService)
+    {
+        _backupService = backupService;
+        _settings = settings;
+        _dialogService = dialogService;
+        _loc = localizationService;
+        _navigationService = navigationService;
+    }
+
+    [RelayCommand]
+    private async Task LoadBackups()
+    {
+        if (IsLoading) return;
+        IsLoading = true;
+        try
+        {
+            var backupPath = GetBackupPath();
+            var list = (await _backupService.ListBackupsAsync(backupPath)).ToList();
+            Backups = new ObservableCollection<BackupMetadata>(list);
+            IsEmpty = Backups.Count == 0;
+        }
+        catch (Exception ex)
+        {
+            try { FileLogger.Append("BackupListViewModel", "LoadBackups failed", ex); } catch { }
+            IsEmpty = true;
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task RestoreBackup(BackupMetadata backup)
+    {
+        var dateDisplay = backup.CreatedAt.ToLocalTime().ToString("g");
+        var confirmed = await _dialogService.ShowConfirmationAsync(
+            _loc.GetString(ResourceKeys.Msg_BackupRestoreConfirmTitle),
+            string.Format(_loc.GetString(ResourceKeys.Msg_BackupRestoreConfirmBody), dateDisplay),
+            _loc.GetString(ResourceKeys.Btn_Ja),
+            _loc.GetString(ResourceKeys.Btn_Abbrechen));
+
+        if (!confirmed) return;
+
+        try
+        {
+            var backupPath = GetBackupPath();
+            var result = await _backupService.RestoreBackupAsync(backupPath, backup.Id);
+            if (result.Success)
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_RestoreSuccessTitle),
+                    _loc.GetString(ResourceKeys.Msg_RestoreSuccessDesc),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+                await _navigationService.GoBackAsync();
+            }
+            else
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_RestoreFailedTitle),
+                    result.ErrorMessage ?? string.Empty,
+                    _loc.GetString(ResourceKeys.Btn_OK));
+            }
+        }
+        catch (Exception ex)
+        {
+            try { FileLogger.Append("BackupListViewModel", "RestoreBackup failed", ex); } catch { }
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    private string GetBackupPath()
+    {
+        var backupPath = _settings.Get("BackupPath", "");
+        if (!string.IsNullOrEmpty(backupPath)) return backupPath;
+
+        var dataPath = _settings.Get("DataPath", "");
+        if (string.IsNullOrEmpty(dataPath))
+            dataPath = AppPaths.GetDefaultDataDir();
+
+        return Path.Combine(dataPath, "backups");
+    }
+}

--- a/Finanzuebersicht/ViewModels/BackupListViewModel.cs
+++ b/Finanzuebersicht/ViewModels/BackupListViewModel.cs
@@ -51,7 +51,8 @@ public partial class BackupListViewModel : ObservableObject
         }
         catch (Exception ex)
         {
-            try { FileLogger.Append("BackupListViewModel", "LoadBackups failed", ex); } catch { }
+            try { FileLogger.Append("BackupListViewModel", $"{nameof(LoadBackups)} failed", ex); } catch { }
+            Backups = [];
             IsEmpty = true;
         }
         finally
@@ -88,7 +89,7 @@ public partial class BackupListViewModel : ObservableObject
             {
                 await _dialogService.ShowAlertAsync(
                     _loc.GetString(ResourceKeys.Msg_RestoreFailedTitle),
-                    result.ErrorMessage ?? string.Empty,
+                    string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), result.ErrorMessage ?? string.Empty),
                     _loc.GetString(ResourceKeys.Btn_OK));
             }
         }

--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -16,6 +16,7 @@ public partial class SettingsViewModel : ObservableObject
     private readonly ILocalizationService _loc;
     private readonly IDialogService _dialogService;
     private readonly IBackupService? _backupService;
+    private readonly INavigationService _navigationService;
     private readonly Finanzuebersicht.Services.IClock _clock;
 
 
@@ -41,6 +42,7 @@ public partial class SettingsViewModel : ObservableObject
         ThemeService themeService,
         ILocalizationService localizationService,
         IDialogService dialogService,
+        INavigationService navigationService,
         IBackupService? backupService = null,
         ILogger<SettingsViewModel>? logger = null,
         Finanzuebersicht.Services.IClock? clock = null)
@@ -51,6 +53,7 @@ public partial class SettingsViewModel : ObservableObject
         _loc = localizationService;
         _dialogService = dialogService;
         _backupService = backupService;
+        _navigationService = navigationService;
         _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
 
         // Version aus Assembly-Metadaten lesen (von Nerdbank.GitVersioning gesetzt)
@@ -373,65 +376,7 @@ public partial class SettingsViewModel : ObservableObject
             return;
         }
 
-        try
-        {
-            var backupPath = _settings.Get("BackupPath", "");
-            if (string.IsNullOrEmpty(backupPath))
-            {
-                var dataPath = _settings.Get("DataPath", "");
-                if (string.IsNullOrEmpty(dataPath))
-                {
-                    dataPath = AppPaths.GetDefaultDataDir();
-                }
-
-                backupPath = Path.Combine(dataPath, "backups");
-            }
-
-            var backups = (await _backupService.ListBackupsAsync(backupPath)).ToList();
-            if (!backups.Any())
-            {
-                await _dialogService.ShowAlertAsync(
-                    _loc.GetString(ResourceKeys.Msg_NoBackupsTitle),
-                    _loc.GetString(ResourceKeys.Msg_NoBackupsDesc),
-                    _loc.GetString(ResourceKeys.Btn_OK));
-                return;
-            }
-
-            // Hier könnten wir zu einer separaten Restore-Dialog-Page navigieren
-            // Für nun: Informationen anzeigen
-            var newestBackup = backups.First();
-            var confirmed = await _dialogService.ShowConfirmationAsync(
-                _loc.GetString(ResourceKeys.Msg_RestoreConfirmTitle),
-                string.Format(_loc.GetString(ResourceKeys.Msg_RestoreConfirmBody), newestBackup.CreatedAt.ToString("g"), newestBackup.EntityCounts["transactions"]),
-                _loc.GetString(ResourceKeys.Btn_Ja),
-                _loc.GetString(ResourceKeys.Btn_Abbrechen));
-
-            if (confirmed)
-            {
-                var result = await _backupService.RestoreBackupAsync(backupPath, newestBackup.Id);
-                if (result.Success)
-                {
-                    await _dialogService.ShowAlertAsync(
-                        _loc.GetString(ResourceKeys.Msg_RestoreSuccessTitle),
-                        _loc.GetString(ResourceKeys.Msg_RestoreSuccessDesc),
-                        _loc.GetString(ResourceKeys.Btn_OK));
-                }
-                else
-                {
-                    await _dialogService.ShowAlertAsync(
-                        _loc.GetString(ResourceKeys.Msg_RestoreFailedTitle),
-                        string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), result.ErrorMessage),
-                        _loc.GetString(ResourceKeys.Btn_OK));
-                }
-            }
-        }
-        catch (Exception ex)
-        {
-            await _dialogService.ShowAlertAsync(
-                _loc.GetString(ResourceKeys.Err_Titel),
-                string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), ex.Message),
-                _loc.GetString(ResourceKeys.Btn_OK));
-        }
+        await _navigationService.GoToAsync("BackupListPage");
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SettingsViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Resources.Strings;
+using Finanzuebersicht.Views;
 
 namespace Finanzuebersicht.ViewModels;
 
@@ -376,7 +377,7 @@ public partial class SettingsViewModel : ObservableObject
             return;
         }
 
-        await _navigationService.GoToAsync("BackupListPage");
+        await _navigationService.GoToAsync(nameof(BackupListPage));
     }
 
     [RelayCommand]

--- a/Finanzuebersicht/Views/BackupListPage.xaml
+++ b/Finanzuebersicht/Views/BackupListPage.xaml
@@ -4,9 +4,14 @@
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Services;assembly=Finanzuebersicht.Core"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              x:Class="Finanzuebersicht.Views.BackupListPage"
              x:DataType="vm:BackupListViewModel"
              Title="{loc:Translate Ttl_BackupAuswaehlen}">
+
+    <ContentPage.Resources>
+        <conv:InvertBoolConverter x:Key="InvertBool" />
+    </ContentPage.Resources>
 
     <RefreshView Command="{Binding LoadBackupsCommand}"
                  IsRefreshing="{Binding IsLoading}">

--- a/Finanzuebersicht/Views/BackupListPage.xaml
+++ b/Finanzuebersicht/Views/BackupListPage.xaml
@@ -36,9 +36,9 @@
                                     Padding="16">
                                 <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto, Auto" RowSpacing="4">
 
-                                    <!-- Datum -->
+                                    <!-- Datum (lokale Zeit) -->
                                     <Label Grid.Row="0" Grid.Column="0"
-                                           Text="{Binding CreatedAt}"
+                                           Text="{Binding CreatedAt.LocalDateTime, StringFormat='{0:G}'}"
                                            FontSize="15" FontAttributes="Bold"
                                            TextColor="{AppThemeBinding Light=#1C1C1E, Dark=#F2F2F7}" />
 

--- a/Finanzuebersicht/Views/BackupListPage.xaml
+++ b/Finanzuebersicht/Views/BackupListPage.xaml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             xmlns:models="clr-namespace:Finanzuebersicht.Services;assembly=Finanzuebersicht.Core"
+             xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             x:Class="Finanzuebersicht.Views.BackupListPage"
+             x:DataType="vm:BackupListViewModel"
+             Title="{loc:Translate Ttl_BackupAuswaehlen}">
+
+    <RefreshView Command="{Binding LoadBackupsCommand}"
+                 IsRefreshing="{Binding IsLoading}">
+        <ScrollView>
+            <VerticalStackLayout Spacing="12" Padding="16">
+
+                <!-- Leerer Zustand -->
+                <Label Text="{loc:Translate Empty_KeineBackupsVorhanden}"
+                       FontSize="15" TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
+                       HorizontalTextAlignment="Center"
+                       Margin="0,40,0,0"
+                       IsVisible="{Binding IsEmpty}" />
+
+                <!-- Backup-Liste -->
+                <VerticalStackLayout BindableLayout.ItemsSource="{Binding Backups}" Spacing="12"
+                                     IsVisible="{Binding IsEmpty, Converter={StaticResource InvertBool}}">
+                    <BindableLayout.ItemTemplate>
+                        <DataTemplate x:DataType="models:BackupMetadata">
+                            <Border StrokeShape="RoundRectangle 12"
+                                    Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                    BackgroundColor="{AppThemeBinding Light=White, Dark=#1C1C1E}"
+                                    Padding="16">
+                                <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto, Auto" RowSpacing="4">
+
+                                    <!-- Datum -->
+                                    <Label Grid.Row="0" Grid.Column="0"
+                                           Text="{Binding CreatedAt}"
+                                           FontSize="15" FontAttributes="Bold"
+                                           TextColor="{AppThemeBinding Light=#1C1C1E, Dark=#F2F2F7}" />
+
+                                    <!-- Dateiname -->
+                                    <Label Grid.Row="1" Grid.Column="0"
+                                           Text="{Binding FileName}"
+                                           FontSize="12"
+                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+
+                                    <!-- Restore-Button -->
+                                    <Button Grid.Row="0" Grid.Column="1" Grid.RowSpan="3"
+                                            Text="{loc:Translate Btn_BackupWiederherstellen}"
+                                            FontSize="13"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                            TextColor="White"
+                                            CornerRadius="8"
+                                            Padding="12,8"
+                                            VerticalOptions="Center"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:BackupListViewModel}}, Path=RestoreBackupCommand}"
+                                            CommandParameter="{Binding .}" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+
+            </VerticalStackLayout>
+        </ScrollView>
+    </RefreshView>
+
+</ContentPage>

--- a/Finanzuebersicht/Views/BackupListPage.xaml.cs
+++ b/Finanzuebersicht/Views/BackupListPage.xaml.cs
@@ -1,0 +1,19 @@
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Views;
+
+public partial class BackupListPage : ContentPage
+{
+    public BackupListPage(BackupListViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is BackupListViewModel vm)
+            vm.LoadBackupsCommand.Execute(null);
+    }
+}


### PR DESCRIPTION
Schließt #137

## Was wurde gemacht
- **BackupListPage** – neue Seite mit allen verfügbaren Backups (Datum, Dateiname, Restore-Button pro Eintrag)
- **BackupListViewModel** – lädt Backups via IBackupService, Bestätigungsdialog vor Restore, Fehlerbehandlung + FileLogger
- **SettingsViewModel** – INavigationService injiziert; navigiert zu BackupListPage statt auto-restore
- Shell-Route + DI-Registrierung (BackupListViewModel, BackupListPage)
- 7 neue Strings (DE + EN)