### PR TITLE
✨ feat(ui): BackupListPage + fix Settings stacking bug

### DIFF
--- a/Finanzuebersicht/AppShell.xaml.cs
+++ b/Finanzuebersicht/AppShell.xaml.cs
@@ -18,6 +18,8 @@ public partial class AppShell : Shell
 
 	private async void OnSettingsClicked(object? sender, EventArgs e)
 	{
+		var location = Shell.Current.CurrentState.Location.ToString();
+		if (location.EndsWith(nameof(SettingsPage))) return;
 		await Shell.Current.GoToAsync(nameof(SettingsPage));
 	}
 }


### PR DESCRIPTION
## Changes

- #137 BackupListPage: Liste aller Backups mit Datum/Uhrzeit und Wiederherstellungsmöglichkeit
- Navigations-Fix: Settings-Icon öffnet keine neue Instanz wenn bereits auf SettingsPage

## Issues

Closes #137

## Affected Files

- `BackupListViewModel.cs` (neu)
- `BackupListPage.xaml` / `BackupListPage.xaml.cs` (neu)
- `SettingsViewModel.cs` – navigiert zu BackupListPage statt auto-restore
- `AppShell.xaml.cs` – Route + Settings-Stacking-Fix
- `MauiProgram.cs` – DI-Registrierung
- `ResourceKeys.cs` + `AppResources.resx` + `AppResources.de.resx` – 7 neue Strings