### PR TITLE
♻️ refactor: Remove static icon cache (#164) and unify OnAppearing pattern (#158)

### DIFF
--- a/Finanzuebersicht/Converters/KategorieIdToIconConverter.cs
+++ b/Finanzuebersicht/Converters/KategorieIdToIconConverter.cs
@@ -2,29 +2,24 @@ using System.Globalization;
 
 namespace Finanzuebersicht.Converters;
 
-public class KategorieIdToIconConverter : IValueConverter
+/// <summary>
+/// Converts a KategorieId (values[0]) to its icon emoji using an IconMap dictionary (values[1]).
+/// Using IMultiValueConverter avoids a static shared cache.
+/// </summary>
+public class KategorieIdToIconConverter : IMultiValueConverter
 {
-    // Static cache - populated when app starts
-    private static Dictionary<string, string> _iconCache = new();
-
-    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is not string kategorieId || string.IsNullOrEmpty(kategorieId))
+        if (values.Length < 1 || values[0] is not string kategorieId || string.IsNullOrEmpty(kategorieId))
             return "📁";
 
-        // Return from cache (already loaded by TransactionsPage.xaml.cs)
-        if (_iconCache.TryGetValue(kategorieId, out var icon))
+        if (values.Length >= 2 && values[1] is Dictionary<string, string> iconMap
+            && iconMap.TryGetValue(kategorieId, out var icon))
             return icon;
 
         return "📁";
     }
 
-    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
         => throw new NotImplementedException();
-
-    // Static method to populate cache - called from TransactionsPage.xaml.cs
-    public static void SetCache(Dictionary<string, string> kategorieIdToIconMap)
-    {
-        _iconCache = kategorieIdToIconMap;
-    }
 }

--- a/Finanzuebersicht/ViewModels/BackupListViewModel.cs
+++ b/Finanzuebersicht/ViewModels/BackupListViewModel.cs
@@ -6,13 +6,15 @@ using Finanzuebersicht.Resources.Strings;
 
 namespace Finanzuebersicht.ViewModels;
 
-public partial class BackupListViewModel : ObservableObject
+public partial class BackupListViewModel : ObservableObject, IAutoLoadViewModel
 {
     private readonly IBackupService _backupService;
     private readonly SettingsService _settings;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
     private readonly INavigationService _navigationService;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadBackupsCommand;
 
     [ObservableProperty]
     private ObservableCollection<BackupMetadata> backups = [];

--- a/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht/ViewModels/CategoriesViewModel.cs
@@ -14,13 +14,15 @@ public partial class CategoriesViewModel(
     LoadCategoriesUseCase loadCategoriesUseCase,
     ILocalizationService localizationService,
     INavigationService navigationService,
-    IDialogService dialogService) : ObservableObject
+    IDialogService dialogService) : ObservableObject, IAutoLoadViewModel
 {
     private readonly DeleteCategoryUseCase _deleteCategoryUseCase = deleteCategoryUseCase;
     private readonly LoadCategoriesUseCase _loadCategoriesUseCase = loadCategoriesUseCase;
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadKategorienCommand;
 
     [ObservableProperty]
     private ObservableCollection<Category> kategorien = [];

--- a/Finanzuebersicht/ViewModels/IAutoLoadViewModel.cs
+++ b/Finanzuebersicht/ViewModels/IAutoLoadViewModel.cs
@@ -1,0 +1,10 @@
+namespace Finanzuebersicht.ViewModels;
+
+/// <summary>
+/// ViewModels implementing this interface expose a single load command
+/// that BaseContentPage calls automatically on OnAppearing.
+/// </summary>
+public interface IAutoLoadViewModel
+{
+    System.Windows.Input.ICommand AutoLoadCommand { get; }
+}

--- a/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -23,7 +23,7 @@ public partial class RecurringTransactionDetailViewModel(
     IDialogService dialogService,
     ILocalizationService localizationService,
     ILogger<RecurringTransactionDetailViewModel>? logger = null,
-    Finanzuebersicht.Services.IClock? clock = null) : ObservableObject
+    Finanzuebersicht.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel
 {
     private readonly SaveRecurringTransactionDetailUseCase _saveRecurringTransactionDetailUseCase = saveRecurringTransactionDetailUseCase;
     private readonly LoadRecurringTransactionDetailDataUseCase _loadRecurringTransactionDetailDataUseCase = loadRecurringTransactionDetailDataUseCase;
@@ -36,6 +36,8 @@ public partial class RecurringTransactionDetailViewModel(
     private readonly ILocalizationService _loc = localizationService;
     private readonly ILogger<RecurringTransactionDetailViewModel>? _logger = logger;
     private readonly Finanzuebersicht.Services.IClock _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadKategorienCommand;
 
     [ObservableProperty]
     private string betragText = string.Empty;

--- a/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/RecurringTransactionsViewModel.cs
@@ -15,7 +15,7 @@ public partial class RecurringTransactionsViewModel(
     ToggleRecurringTransactionActiveUseCase toggleRecurringTransactionActiveUseCase,
     ILocalizationService localizationService,
     INavigationService navigationService,
-    IDialogService dialogService) : ObservableObject
+    IDialogService dialogService) : ObservableObject, IAutoLoadViewModel
 {
     private readonly DeleteRecurringTransactionUseCase _deleteRecurringTransactionUseCase = deleteRecurringTransactionUseCase;
     private readonly LoadRecurringTransactionsUseCase _loadRecurringTransactionsUseCase = loadRecurringTransactionsUseCase;
@@ -23,6 +23,8 @@ public partial class RecurringTransactionsViewModel(
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadDauerauftraegeCommand;
 
     [ObservableProperty]
     private ObservableCollection<RecurringTransaction> dauerauftraege = [];

--- a/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht/ViewModels/SparZieleViewModel.cs
@@ -8,13 +8,15 @@ using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht.ViewModels;
 
-public partial class SparZieleViewModel : ObservableObject
+public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
 {
     private readonly LoadSparZieleUseCase _loadUseCase;
     private readonly SaveSparZielUseCase _saveUseCase;
     private readonly DeleteSparZielUseCase _deleteUseCase;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadSparZieleCommand;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsEmpty))]

--- a/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionDetailViewModel.cs
@@ -18,7 +18,7 @@ public partial class TransactionDetailViewModel(
     INavigationService navigationService,
     IDialogService dialogService,
     ILogger<TransactionDetailViewModel>? logger = null,
-    Finanzuebersicht.Services.IClock? clock = null) : ObservableObject
+    Finanzuebersicht.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel
 {
     private readonly SaveTransactionDetailUseCase _saveTransactionDetailUseCase = saveTransactionDetailUseCase;
     private readonly LoadTransactionDetailDataUseCase _loadTransactionDetailDataUseCase = loadTransactionDetailDataUseCase;
@@ -29,6 +29,8 @@ public partial class TransactionDetailViewModel(
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILogger<TransactionDetailViewModel>? _logger = logger;
     private readonly Finanzuebersicht.Services.IClock _clock = clock ?? Finanzuebersicht.Services.SystemClock.Instance;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadKategorienCommand;
 
     [ObservableProperty]
     private string betragText = string.Empty;

--- a/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht/ViewModels/TransactionsViewModel.cs
@@ -21,10 +21,12 @@ public partial class TransactionsViewModel(
     IDialogService dialogService,
     ILocalizationService localizationService,
     ICategoryRepository categoryRepository,
-    ILogger<TransactionsViewModel> logger) : MonthNavigationViewModel
+    ILogger<TransactionsViewModel> logger) : MonthNavigationViewModel, IAutoLoadViewModel
 {
     private readonly DeleteTransactionUseCase _deleteTransactionUseCase = deleteTransactionUseCase;
     private readonly LoadTransactionsMonthUseCase _loadTransactionsMonthUseCase = loadTransactionsMonthUseCase;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadTransaktionenCommand;
     private readonly SearchTransactionsUseCase _searchTransactionsUseCase = searchTransactionsUseCase;
     private readonly INavigationService _navigationService = navigationService;
     private readonly ImportService _importService = importService;
@@ -49,6 +51,9 @@ public partial class TransactionsViewModel(
 
     [ObservableProperty]
     private ObservableCollection<TransactionGroup> transaktionsGruppen = [];
+
+    [ObservableProperty]
+    private Dictionary<string, string> iconMap = [];
 
     [ObservableProperty]
     private bool isLoading;
@@ -226,7 +231,7 @@ public partial class TransactionsViewModel(
             if (version >= 0 && version != _searchVersion) return;
             SearchErgebnisGruppen = new ObservableCollection<TransactionGroup>(result.Gruppen);
             TotalSearchCount = result.TotalCount;
-            Converters.KategorieIdToIconConverter.SetCache(result.IconMap);
+            IconMap = result.IconMap;
         }
         catch (Exception ex)
         {
@@ -292,7 +297,7 @@ public partial class TransactionsViewModel(
         {
             var data = await _loadTransactionsMonthUseCase.ExecuteAsync(AktuellerMonat);
             TransaktionsGruppen = new ObservableCollection<TransactionGroup>(data.Gruppen);
-            Converters.KategorieIdToIconConverter.SetCache(data.IconMap);
+            IconMap = data.IconMap;
 
             if (AvailableKategorien.Count == 0)
                 await LoadKategorienAsync();

--- a/Finanzuebersicht/Views/BackupListPage.xaml
+++ b/Finanzuebersicht/Views/BackupListPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Services;assembly=Finanzuebersicht.Core"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
@@ -9,9 +10,9 @@
              x:DataType="vm:BackupListViewModel"
              Title="{loc:Translate Ttl_BackupAuswaehlen}">
 
-    <ContentPage.Resources>
+    <views:BaseContentPage.Resources>
         <conv:InvertBoolConverter x:Key="InvertBool" />
-    </ContentPage.Resources>
+    </views:BaseContentPage.Resources>
 
     <RefreshView Command="{Binding LoadBackupsCommand}"
                  IsRefreshing="{Binding IsLoading}">
@@ -69,4 +70,4 @@
         </ScrollView>
     </RefreshView>
 
-</ContentPage>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/BackupListPage.xaml.cs
+++ b/Finanzuebersicht/Views/BackupListPage.xaml.cs
@@ -2,18 +2,11 @@ using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
-public partial class BackupListPage : ContentPage
+public partial class BackupListPage : BaseContentPage
 {
     public BackupListPage(BackupListViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
-    }
-
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-        if (BindingContext is BackupListViewModel vm)
-            vm.LoadBackupsCommand.Execute(null);
     }
 }

--- a/Finanzuebersicht/Views/BaseContentPage.cs
+++ b/Finanzuebersicht/Views/BaseContentPage.cs
@@ -1,0 +1,18 @@
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Views;
+
+/// <summary>
+/// Base page that automatically executes <see cref="IAutoLoadViewModel.AutoLoadCommand"/>
+/// on appearing. Pages with complex OnAppearing logic (e.g. DashboardPage) should
+/// override directly instead of using this base class.
+/// </summary>
+public abstract class BaseContentPage : ContentPage
+{
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        if (BindingContext is IAutoLoadViewModel vm)
+            vm.AutoLoadCommand.Execute(null);
+    }
+}

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
@@ -73,4 +74,4 @@
                 Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
                 Command="{Binding GoToDetailCommand}" />
     </Grid>
-</ContentPage>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/CategoriesPage.xaml.cs
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml.cs
@@ -2,18 +2,11 @@ using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
-public partial class CategoriesPage : ContentPage
+public partial class CategoriesPage : BaseContentPage
 {
     public CategoriesPage(CategoriesViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
-    }
-
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-        if (BindingContext is CategoriesViewModel vm)
-            vm.LoadKategorienCommand.Execute(null);
     }
 }

--- a/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
@@ -9,10 +10,10 @@
              x:DataType="vm:RecurringTransactionDetailViewModel"
              Title="{loc:Translate Title_Dauerauftrag}">
 
-    <ContentPage.Resources>
+    <views:BaseContentPage.Resources>
         <conv:TypButtonColorConverter x:Key="TypButtonColor" />
         <conv:EnumToLocalizedStringConverter x:Key="EnumToLocalizedStringConverter" />
-    </ContentPage.Resources>
+    </views:BaseContentPage.Resources>
 
     <ScrollView Padding="16">
         <VerticalStackLayout Spacing="20">
@@ -132,4 +133,4 @@
 
         </VerticalStackLayout>
     </ScrollView>
-</ContentPage>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml.cs
@@ -2,18 +2,11 @@ using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
-public partial class RecurringTransactionDetailPage : ContentPage
+public partial class RecurringTransactionDetailPage : BaseContentPage
 {
     public RecurringTransactionDetailPage(RecurringTransactionDetailViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
-    }
-
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-        if (BindingContext is RecurringTransactionDetailViewModel vm)
-            vm.LoadKategorienCommand.Execute(null);
     }
 }

--- a/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
@@ -9,12 +10,12 @@
              x:DataType="vm:RecurringTransactionsViewModel"
              Title="Daueraufträge">
 
-    <ContentPage.Resources>
+    <views:BaseContentPage.Resources>
         <conv:TransactionTypToColorConverter x:Key="TypToColor" />
         <conv:BoolToOpacityConverter x:Key="BoolToOpacity" />
         <conv:VorzeichenConverter x:Key="VorzeichenConv" />
         <conv:AktivTextConverter x:Key="AktivText" />
-    </ContentPage.Resources>
+    </views:BaseContentPage.Resources>
 
     <Grid>
         <RefreshView Command="{Binding LoadDauerauftraegeCommand}"
@@ -110,4 +111,4 @@
             Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
             Command="{Binding GoToDetailCommand}" />
     </Grid>
-</ContentPage>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/RecurringTransactionsPage.xaml.cs
+++ b/Finanzuebersicht/Views/RecurringTransactionsPage.xaml.cs
@@ -2,18 +2,11 @@ using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
-public partial class RecurringTransactionsPage : ContentPage
+public partial class RecurringTransactionsPage : BaseContentPage
 {
     public RecurringTransactionsPage(RecurringTransactionsViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
-    }
-
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-        if (BindingContext is RecurringTransactionsViewModel vm)
-            vm.LoadDauerauftraegeCommand.Execute(null);
     }
 }

--- a/Finanzuebersicht/Views/SparZielePage.xaml
+++ b/Finanzuebersicht/Views/SparZielePage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
@@ -9,9 +10,9 @@
              x:DataType="vm:SparZieleViewModel"
              Title="{loc:Translate Title_SparZiele}">
 
-    <ContentPage.Resources>
+    <views:BaseContentPage.Resources>
         <conv:DecimalCurrencyConverter x:Key="Currency" />
-    </ContentPage.Resources>
+    </views:BaseContentPage.Resources>
 
     <Grid>
         <RefreshView Command="{Binding LoadSparZieleCommand}"
@@ -166,4 +167,4 @@
                 Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
                 Command="{Binding ToggleAddFormCommand}" />
     </Grid>
-</ContentPage>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/SparZielePage.xaml.cs
+++ b/Finanzuebersicht/Views/SparZielePage.xaml.cs
@@ -2,18 +2,11 @@ using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
-public partial class SparZielePage : ContentPage
+public partial class SparZielePage : BaseContentPage
 {
     public SparZielePage(SparZieleViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
-    }
-
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-        if (BindingContext is SparZieleViewModel vm)
-            vm.LoadSparZieleCommand.Execute(null);
     }
 }

--- a/Finanzuebersicht/Views/TransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/TransactionDetailPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
@@ -73,8 +74,8 @@
         </VerticalStackLayout>
     </ScrollView>
 
-    <ContentPage.Resources>
+    <views:BaseContentPage.Resources>
         <local:TypButtonColorConverter x:Key="TypButtonColor"
                                        xmlns:local="clr-namespace:Finanzuebersicht.Converters" />
-    </ContentPage.Resources>
-</ContentPage>
+    </views:BaseContentPage.Resources>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/TransactionDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/TransactionDetailPage.xaml.cs
@@ -2,18 +2,11 @@ using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
-public partial class TransactionDetailPage : ContentPage
+public partial class TransactionDetailPage : BaseContentPage
 {
     public TransactionDetailPage(TransactionDetailViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
-    }
-
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-        if (BindingContext is TransactionDetailViewModel vm)
-            vm.LoadKategorienCommand.Execute(null);
     }
 }

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
@@ -9,7 +10,7 @@
              x:DataType="vm:TransactionsViewModel"
              Title="Transaktionen">
 
-    <ContentPage.Resources>
+    <views:BaseContentPage.Resources>
         <conv:TransactionTypToColorConverter x:Key="TypToColor" />
         <conv:BetragDisplayConverter x:Key="BetragDisplay" />
         <conv:KategorieIdToIconConverter x:Key="KategorieIdToIcon" />
@@ -30,8 +31,15 @@
                         StrokeShape="RoundRectangle 10" Stroke="Transparent"
                         WidthRequest="40" HeightRequest="40"
                         HorizontalOptions="Center" VerticalOptions="Center">
-                    <Label Text="{Binding KategorieId, Converter={StaticResource KategorieIdToIcon}}" FontSize="18"
-                           HorizontalOptions="Center" VerticalOptions="Center" />
+                    <Label FontSize="18" HorizontalOptions="Center" VerticalOptions="Center">
+                        <Label.Text>
+                            <MultiBinding Converter="{StaticResource KategorieIdToIcon}">
+                                <Binding Path="KategorieId" />
+                                <Binding Source="{RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}"
+                                         Path="IconMap" />
+                            </MultiBinding>
+                        </Label.Text>
+                    </Label>
                 </Border>
                 <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
                     <Label Text="{Binding Titel}" FontSize="16" FontAttributes="Bold"
@@ -46,7 +54,7 @@
                        VerticalTextAlignment="Center" />
             </Grid>
         </DataTemplate>
-    </ContentPage.Resources>
+    </views:BaseContentPage.Resources>
 
     <Grid RowDefinitions="Auto, Auto, Auto, *">
 
@@ -203,8 +211,15 @@
                                             StrokeShape="RoundRectangle 10" Stroke="Transparent"
                                             WidthRequest="40" HeightRequest="40"
                                             HorizontalOptions="Center" VerticalOptions="Center">
-                                        <Label Text="{Binding KategorieId, Converter={StaticResource KategorieIdToIcon}}" FontSize="18"
-                                               HorizontalOptions="Center" VerticalOptions="Center" />
+                                        <Label FontSize="18" HorizontalOptions="Center" VerticalOptions="Center">
+                                            <Label.Text>
+                                                <MultiBinding Converter="{StaticResource KategorieIdToIcon}">
+                                                    <Binding Path="KategorieId" />
+                                                    <Binding Source="{RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}"
+                                                             Path="IconMap" />
+                                                </MultiBinding>
+                                            </Label.Text>
+                                        </Label>
                                     </Border>
                                     <VerticalStackLayout Grid.Column="1" Spacing="2" VerticalOptions="Center">
                                         <Label Text="{Binding Titel}" FontSize="16" FontAttributes="Bold"
@@ -274,4 +289,4 @@
         </Grid>
 
     </Grid>
-</ContentPage>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/TransactionsPage.xaml.cs
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml.cs
@@ -1,10 +1,9 @@
 using Finanzuebersicht.ViewModels;
-using Microsoft.Maui.Controls;
 using Microsoft.Extensions.Logging;
 
 namespace Finanzuebersicht.Views;
 
-public partial class TransactionsPage : ContentPage
+public partial class TransactionsPage : BaseContentPage
 {
     public TransactionsPage(TransactionsViewModel viewModel, ILogger<TransactionsPage> logger)
     {
@@ -14,45 +13,11 @@ public partial class TransactionsPage : ContentPage
         {
             logger?.LogError("TransactionsPage: injected TransactionsViewModel is null. DI may have failed.");
             try { Finanzuebersicht.Services.FileLogger.Append("TransactionsPage", "injected TransactionsViewModel is null"); } catch { }
-            // avoid creating types from other layers here — leave BindingContext empty to prevent further NREs
             BindingContext = new object();
         }
         else
         {
-            logger?.LogDebug("TransactionsPage: TransactionsViewModel injected successfully");
-            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsPage", "TransactionsViewModel injected successfully"); } catch { }
             BindingContext = viewModel;
-        }
-    }
-
-    protected override void OnAppearing()
-    {
-        base.OnAppearing();
-
-        if (BindingContext is TransactionsViewModel vm)
-            vm.LoadTransaktionenCommand.Execute(null);
-    }
-
-    private void OnSelectionChanged(object sender, SelectionChangedEventArgs e)
-    {
-        try
-        {
-            var selected = e.CurrentSelection?.FirstOrDefault() as Finanzuebersicht.Models.Transaction;
-            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsPage", $"OnSelectionChanged selected={(selected?.Id ?? "(null)")}"); } catch { }
-
-            if (BindingContext is TransactionsViewModel vm)
-            {
-                // call ViewModel command directly
-                vm.GoToDetailCommand.Execute(selected);
-            }
-
-            // clear selection so same item can be tapped again
-            if (sender is CollectionView cv)
-                cv.SelectedItem = null;
-        }
-        catch (Exception ex)
-        {
-            try { Finanzuebersicht.Services.FileLogger.Append("TransactionsPage", "OnSelectionChanged failed", ex); } catch { }
         }
     }
 }


### PR DESCRIPTION
## Änderungen

Schließt #164 und #158.

### #164 – Static Cache aus KategorieIdToIconConverter entfernen

- `KategorieIdToIconConverter` von `IValueConverter` auf `IMultiValueConverter` umgestellt
- Statisches `_iconCache`-Feld und `SetCache()`-Methode entfernt
- `TransactionsViewModel`: neue Observable-Property `IconMap`, beide `SetCache()`-Aufrufe ersetzt
- `TransactionsPage.xaml`: Icon-Labels nutzen nun `MultiBinding` mit `RelativeSource AncestorType=TransactionsViewModel`

### #158 – Lifecycle- und Selection-Logik aus Views entfernen

- Neues `IAutoLoadViewModel`-Interface mit `AutoLoadCommand`-Property
- Neues `BaseContentPage : ContentPage` ruft `AutoLoadCommand.Execute(null)` in `OnAppearing` auf
- 7 ViewModels implementieren das Interface
- 7 Pages erben `BaseContentPage`, identische `OnAppearing`-Overrides entfernt
- Toter `OnSelectionChanged`-Handler aus `TransactionsPage` entfernt
- XAML-Root-Elemente von `ContentPage` auf `views:BaseContentPage` aktualisiert

## Qualität
- ✅ 161/161 Tests bestehen
- ✅ Build ohne Fehler (0 errors, 2 pre-existing warnings)