### PR TITLE
🐛 fix(review): address all 13 PR #173 review comments

### DIFF
--- a/Finanzuebersicht.Presentation/Finanzuebersicht.Presentation.csproj
+++ b/Finanzuebersicht.Presentation/Finanzuebersicht.Presentation.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Finanzuebersicht.Presentation/Navigation/Routes.cs
+++ b/Finanzuebersicht.Presentation/Navigation/Routes.cs
@@ -6,10 +6,10 @@ namespace Finanzuebersicht.Navigation;
 /// </summary>
 public static class Routes
 {
-    public const string TransactionDetail = "TransactionDetailPage";
-    public const string RecurringTransactionDetail = "RecurringTransactionDetailPage";
-    public const string CategoryDetail = "CategoryDetailPage";
-    public const string RecurringInstanceShift = "RecurringInstanceShiftPage";
-    public const string Settings = "SettingsPage";
-    public const string BackupList = "BackupListPage";
+    public static readonly string TransactionDetail = "TransactionDetailPage";
+    public static readonly string RecurringTransactionDetail = "RecurringTransactionDetailPage";
+    public static readonly string CategoryDetail = "CategoryDetailPage";
+    public static readonly string RecurringInstanceShift = "RecurringInstanceShiftPage";
+    public static readonly string Settings = "SettingsPage";
+    public static readonly string BackupList = "BackupListPage";
 }

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -143,6 +143,7 @@ public static class ResourceKeys
     public const string Msg_NoBackupsTitle = nameof(Msg_NoBackupsTitle);
     public const string Msg_NoBackupsDesc = nameof(Msg_NoBackupsDesc);
     public const string Msg_AvailableBackupsTitle = nameof(Msg_AvailableBackupsTitle);
+    public const string Msg_AndMoreBackups = nameof(Msg_AndMoreBackups);
     public const string Msg_RestoreConfirmTitle = nameof(Msg_RestoreConfirmTitle);
     public const string Msg_RestoreConfirmBody = nameof(Msg_RestoreConfirmBody);
     public const string Msg_RestoreSuccessTitle = nameof(Msg_RestoreSuccessTitle);

--- a/Finanzuebersicht.Presentation/ViewModels/IAutoLoadViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/IAutoLoadViewModel.cs
@@ -7,4 +7,5 @@ namespace Finanzuebersicht.ViewModels;
 public interface IAutoLoadViewModel
 {
     System.Windows.Input.ICommand AutoLoadCommand { get; }
+    bool ShouldAutoLoad => true;
 }

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/AboutViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/AboutViewModel.cs
@@ -6,18 +6,19 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class AboutViewModel : ObservableObject
 {
+    private readonly Assembly _appAssembly;
     private readonly ILogger<AboutViewModel>? _logger;
 
     public string AppVersion { get; }
     public string BuildInfo { get; }
     public List<LibraryInfo> Libraries { get; } = [];
 
-    public AboutViewModel(ILogger<AboutViewModel>? logger = null)
+    public AboutViewModel(Assembly? appAssembly = null, ILogger<AboutViewModel>? logger = null)
     {
+        _appAssembly = appAssembly ?? Assembly.GetExecutingAssembly();
         _logger = logger;
 
-        var assembly = Assembly.GetExecutingAssembly();
-        var infoVersion = assembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unbekannt";
+        var infoVersion = _appAssembly.GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion ?? "unbekannt";
 
         AppVersion = infoVersion.Contains('+')
             ? infoVersion[..infoVersion.IndexOf('+')]
@@ -33,7 +34,7 @@ public partial class AboutViewModel : ObservableObject
     {
         try
         {
-            var entry = Assembly.GetEntryAssembly() ?? Assembly.GetExecutingAssembly();
+            var entry = Assembly.GetEntryAssembly() ?? _appAssembly;
             var refs = entry.GetReferencedAssemblies();
 
             foreach (var reference in refs.OrderBy(r => r.Name))

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/AppearanceViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/AppearanceViewModel.cs
@@ -26,7 +26,7 @@ public partial class AppearanceViewModel : ObservableObject
         _loc = localizationService;
 
         var theme = _settings.Get("Theme", "System");
-        SelectedThemeIndex = theme switch
+        selectedThemeIndex = theme switch
         {
             "Light" => 1,
             "Dark" => 2,
@@ -34,7 +34,7 @@ public partial class AppearanceViewModel : ObservableObject
         };
 
         var lang = _loc.CurrentLanguageCode;
-        SelectedLanguageIndex = lang switch
+        selectedLanguageIndex = lang switch
         {
             "de" => 1,
             "en" => 2,

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/BackupViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/BackupViewModel.cs
@@ -96,7 +96,7 @@ public partial class BackupViewModel : ObservableObject
             var backupList = string.Join("\n", backups.Take(5).Select(b => $"{b.CreatedAt:g} - {Path.GetFileNameWithoutExtension(b.FileName)}"));
             if (backups.Count > 5)
             {
-                backupList += $"\n... und {backups.Count - 5} weitere";
+                backupList += "\n" + _loc.GetString(ResourceKeys.Msg_AndMoreBackups, backups.Count - 5);
             }
 
             await _dialogService.ShowAlertAsync(

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/BackupViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/BackupViewModel.cs
@@ -46,18 +46,13 @@ public partial class BackupViewModel : ObservableObject
     [RelayCommand]
     private async Task CreateBackup()
     {
-        if (_backupService == null)
-        {
-            await _dialogService.ShowAlertAsync(
-                _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Msg_BackupServiceNotAvailable),
-                _loc.GetString(ResourceKeys.Btn_OK));
-            return;
-        }
+        if (!await EnsureBackupServiceAvailableAsync()) return;
+
+        var backupService = _backupService!;
 
         try
         {
-            var metadata = await _backupService.CreateBackupAsync(GetBackupPath());
+            var metadata = await backupService.CreateBackupAsync(GetBackupPath());
 
             UpdateLastBackupInfo();
 
@@ -82,18 +77,13 @@ public partial class BackupViewModel : ObservableObject
     [RelayCommand]
     private async Task BrowseBackups()
     {
-        if (_backupService == null)
-        {
-            await _dialogService.ShowAlertAsync(
-                _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Msg_BackupServiceNotAvailable),
-                _loc.GetString(ResourceKeys.Btn_OK));
-            return;
-        }
+        if (!await EnsureBackupServiceAvailableAsync()) return;
+
+        var backupService = _backupService!;
 
         try
         {
-            var backups = (await _backupService.ListBackupsAsync(GetBackupPath())).ToList();
+            var backups = (await backupService.ListBackupsAsync(GetBackupPath())).ToList();
             if (!backups.Any())
             {
                 await _dialogService.ShowAlertAsync(
@@ -126,14 +116,7 @@ public partial class BackupViewModel : ObservableObject
     [RelayCommand]
     private async Task RestoreBackup()
     {
-        if (_backupService == null)
-        {
-            await _dialogService.ShowAlertAsync(
-                _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Msg_BackupServiceNotAvailable),
-                _loc.GetString(ResourceKeys.Btn_OK));
-            return;
-        }
+        if (!await EnsureBackupServiceAvailableAsync()) return;
 
         await _navigationService.GoToAsync(Routes.BackupList);
     }
@@ -141,14 +124,9 @@ public partial class BackupViewModel : ObservableObject
     [RelayCommand]
     private async Task ExportAsCSV()
     {
-        if (_backupService == null)
-        {
-            await _dialogService.ShowAlertAsync(
-                _loc.GetString(ResourceKeys.Err_Titel),
-                _loc.GetString(ResourceKeys.Msg_BackupServiceNotAvailable),
-                _loc.GetString(ResourceKeys.Btn_OK));
-            return;
-        }
+        if (!await EnsureBackupServiceAvailableAsync()) return;
+
+        var backupService = _backupService!;
 
         try
         {
@@ -157,7 +135,7 @@ public partial class BackupViewModel : ObservableObject
                 return;
             }
 
-            await using var csvStream = await _backupService.ExportAsCSVAsync();
+            await using var csvStream = await backupService.ExportAsCSVAsync();
             csvStream.Seek(0, SeekOrigin.Begin);
 
             var fileName = $"Finanzuebersicht_Export_{_clock.Now:yyyy-MM-dd}.csv";
@@ -187,6 +165,17 @@ public partial class BackupViewModel : ObservableObject
                 string.Format(_loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen), ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
         }
+    }
+
+    private async Task<bool> EnsureBackupServiceAvailableAsync()
+    {
+        if (_backupService != null) return true;
+
+        await _dialogService.ShowAlertAsync(
+            _loc.GetString(ResourceKeys.Err_Titel),
+            _loc.GetString(ResourceKeys.Msg_BackupServiceNotAvailable),
+            _loc.GetString(ResourceKeys.Btn_OK));
+        return false;
     }
 
     private void UpdateLastBackupInfo()

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/StorageViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/StorageViewModel.cs
@@ -38,6 +38,10 @@ public partial class StorageViewModel : ObservableObject
     {
         if (_folderPicker == null)
         {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Msg_ImportServiceNichtVerfuegbar),
+                _loc.GetString(ResourceKeys.Btn_OK));
             return;
         }
 

--- a/Finanzuebersicht.Tests/ViewModels/Settings/AboutViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/Settings/AboutViewModelTests.cs
@@ -1,3 +1,5 @@
+using System.Reflection;
+using System.Reflection.Emit;
 using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Tests.ViewModels.Settings;
@@ -14,10 +16,39 @@ public class AboutViewModelTests
     }
 
     [Fact]
+    public void AppVersion_WithPlusSuffix_ExtractsVersionBeforePlus()
+    {
+        var assembly = CreateAssemblyWithInformationalVersion("1.2.3+abc");
+        var sut = new AboutViewModel(assembly);
+
+        Assert.Equal("1.2.3", sut.AppVersion);
+        Assert.Equal("abc", sut.BuildInfo);
+    }
+
+    [Fact]
+    public void BuildInfo_WithPlusSuffix_ExtractsBuildInfoAfterPlus()
+    {
+        var assembly = CreateAssemblyWithInformationalVersion("1.2.3+abc");
+        var sut = new AboutViewModel(assembly);
+
+        Assert.Equal("1.2.3+abc", $"{sut.AppVersion}+{sut.BuildInfo}");
+    }
+
+    [Fact]
     public void Libraries_IsNotNull()
     {
         var sut = new AboutViewModel();
 
         Assert.NotNull(sut.Libraries);
+    }
+
+    private static Assembly CreateAssemblyWithInformationalVersion(string informationalVersion)
+    {
+        var assemblyName = new AssemblyName($"AboutViewModelTests_{Guid.NewGuid():N}");
+        var assemblyBuilder = AssemblyBuilder.DefineDynamicAssembly(assemblyName, AssemblyBuilderAccess.Run);
+        var constructor = typeof(AssemblyInformationalVersionAttribute).GetConstructor([typeof(string)])!;
+        var attributeBuilder = new CustomAttributeBuilder(constructor, [informationalVersion]);
+        assemblyBuilder.SetCustomAttribute(attributeBuilder);
+        return assemblyBuilder;
     }
 }

--- a/Finanzuebersicht.Tests/ViewModels/Settings/StorageViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/Settings/StorageViewModelTests.cs
@@ -74,6 +74,25 @@ public class StorageViewModelTests
     }
 
     [Fact]
+    public async Task ChooseDataPath_WhenFolderPickerIsNull_ShowsErrorAlert()
+    {
+        using var settingsScope = new SettingsScope(nameof(StorageViewModelTests));
+        var dialogService = CreateDialogService();
+        var sut = new StorageViewModel(
+            settingsScope.Settings,
+            dialogService,
+            CreateLocalizationService(),
+            folderPicker: null);
+
+        await sut.ChooseDataPathCommand.ExecuteAsync(null);
+
+        await dialogService.Received(1).ShowAlertAsync(
+            ResourceKeys.Err_Titel,
+            ResourceKeys.Msg_ImportServiceNichtVerfuegbar,
+            ResourceKeys.Btn_OK);
+    }
+
+    [Fact]
     public async Task ChooseDataPath_WhenPickerReturnsTempPath_ShowsError()
     {
         using var settingsScope = new SettingsScope(nameof(StorageViewModelTests));

--- a/Finanzuebersicht/Converters/KategorieIdToIconConverter.cs
+++ b/Finanzuebersicht/Converters/KategorieIdToIconConverter.cs
@@ -13,7 +13,7 @@ public class KategorieIdToIconConverter : IMultiValueConverter
         if (values.Length < 1 || values[0] is not string kategorieId || string.IsNullOrEmpty(kategorieId))
             return "📁";
 
-        if (values.Length >= 2 && values[1] is Dictionary<string, string> iconMap
+        if (values.Length >= 2 && values[1] is IDictionary<string, string> iconMap
             && iconMap.TryGetValue(kategorieId, out var icon))
             return icon;
 

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -1,4 +1,5 @@
-﻿using CommunityToolkit.Maui;
+﻿using System.Reflection;
+using CommunityToolkit.Maui;
 using Finanzuebersicht.Application.UseCases.Categories;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
@@ -105,7 +106,8 @@ public static class MauiProgram
 		builder.Services.AddTransient<AppearanceViewModel>();
 		builder.Services.AddTransient<StorageViewModel>();
 		builder.Services.AddTransient<BackupViewModel>();
-		builder.Services.AddTransient<AboutViewModel>();
+		builder.Services.AddTransient<AboutViewModel>(sp =>
+			new AboutViewModel(Assembly.GetExecutingAssembly(), sp.GetService<ILogger<AboutViewModel>>()));
 		builder.Services.AddTransient<SettingsViewModel>();
 		builder.Services.AddTransient<SparZieleViewModel>();
 		builder.Services.AddTransient<BackupListViewModel>();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -156,6 +156,7 @@ Bitte starte die App neu.</value></data>
   <data name="Msg_NoBackupsTitle" xml:space="preserve"><value>Keine Sicherungen</value></data>
   <data name="Msg_NoBackupsDesc" xml:space="preserve"><value>Es wurden noch keine Sicherungen erstellt.</value></data>
   <data name="Msg_AvailableBackupsTitle" xml:space="preserve"><value>Verfügbare Sicherungen</value></data>
+  <data name="Msg_AndMoreBackups" xml:space="preserve"><value>... und {0} weitere</value></data>
   <data name="Msg_RestoreConfirmTitle" xml:space="preserve"><value>Sicherung wiederherstellen</value></data>
   <data name="Msg_RestoreConfirmBody" xml:space="preserve"><value>Möchtest du die Sicherung vom {0} mit {1} Transaktionen wiederherstellen? Dies überschreibt alle aktuellen Daten.</value></data>
   <data name="Msg_RestoreSuccessTitle" xml:space="preserve"><value>Wiederherstellung erfolgreich</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -156,6 +156,7 @@ Please restart the app.</value></data>
   <data name="Msg_NoBackupsTitle" xml:space="preserve"><value>No backups</value></data>
   <data name="Msg_NoBackupsDesc" xml:space="preserve"><value>No backups have been created yet.</value></data>
   <data name="Msg_AvailableBackupsTitle" xml:space="preserve"><value>Available backups</value></data>
+  <data name="Msg_AndMoreBackups" xml:space="preserve"><value>... and {0} more</value></data>
   <data name="Msg_RestoreConfirmTitle" xml:space="preserve"><value>Restore backup</value></data>
   <data name="Msg_RestoreConfirmBody" xml:space="preserve"><value>Do you want to restore the backup from {0} with {1} transactions? This will overwrite current data.</value></data>
   <data name="Msg_RestoreSuccessTitle" xml:space="preserve"><value>Restore successful</value></data>

--- a/Finanzuebersicht/Services/MauiFileSaver.cs
+++ b/Finanzuebersicht/Services/MauiFileSaver.cs
@@ -1,5 +1,3 @@
-using Finanzuebersicht.Services;
-
 namespace Finanzuebersicht.Services;
 
 public class MauiFileSaver : IFileSaver

--- a/Finanzuebersicht/Services/MauiFolderPicker.cs
+++ b/Finanzuebersicht/Services/MauiFolderPicker.cs
@@ -1,5 +1,3 @@
-using Finanzuebersicht.Services;
-
 namespace Finanzuebersicht.Services;
 
 public class MauiFolderPicker : IFolderPicker

--- a/Finanzuebersicht/Views/BaseContentPage.cs
+++ b/Finanzuebersicht/Views/BaseContentPage.cs
@@ -7,6 +7,16 @@ namespace Finanzuebersicht.Views;
 /// on appearing. Pages with complex OnAppearing logic (e.g. DashboardPage) should
 /// override directly instead of using this base class.
 /// </summary>
+/// <remarks>
+/// <b>Requirement:</b> <see cref="ContentPage.BindingContext"/> must be set before
+/// <c>OnAppearing</c> fires (i.e. via constructor injection, not XAML binding or
+/// late assignment in code-behind), otherwise auto-load will silently not fire.
+/// <para>
+/// Pages that should <em>not</em> reload on every back-navigation can override
+/// <see cref="IAutoLoadViewModel.ShouldAutoLoad"/> to return <c>false</c> based
+/// on cached state.
+/// </para>
+/// </remarks>
 public abstract class BaseContentPage : ContentPage
 {
     protected override void OnAppearing()

--- a/Finanzuebersicht/Views/BaseContentPage.cs
+++ b/Finanzuebersicht/Views/BaseContentPage.cs
@@ -12,7 +12,7 @@ public abstract class BaseContentPage : ContentPage
     protected override void OnAppearing()
     {
         base.OnAppearing();
-        if (BindingContext is IAutoLoadViewModel vm)
+        if (BindingContext is IAutoLoadViewModel vm && vm.ShouldAutoLoad)
             vm.AutoLoadCommand.Execute(null);
     }
 }

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -35,8 +35,8 @@
                         <Label.Text>
                             <MultiBinding Converter="{StaticResource KategorieIdToIcon}">
                                 <Binding Path="KategorieId" />
-                                <Binding Source="{RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}"
-                                         Path="IconMap" />
+                                <Binding Source="{RelativeSource AncestorType={x:Type views:BaseContentPage}}"
+                                         Path="BindingContext.IconMap" />
                             </MultiBinding>
                         </Label.Text>
                     </Label>
@@ -215,8 +215,8 @@
                                             <Label.Text>
                                                 <MultiBinding Converter="{StaticResource KategorieIdToIcon}">
                                                     <Binding Path="KategorieId" />
-                                                    <Binding Source="{RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}"
-                                                             Path="IconMap" />
+                                                    <Binding Source="{RelativeSource AncestorType={x:Type views:BaseContentPage}}"
+                                                             Path="BindingContext.IconMap" />
                                                 </MultiBinding>
                                             </Label.Text>
                                         </Label>


### PR DESCRIPTION
## Summary

Addresses all 13 review comments from PR #173 (develop→main).

## Changes

### 🐛 Bugs fixed
- **TransactionsPage.xaml**: Fixed `RelativeSource AncestorType={x:Type vm:TransactionsViewModel}` for IconMap bindings — ViewModel is not a visual element, ancestor lookup never resolved → icons always showed 📁. Now uses `BaseContentPage` + `BindingContext.IconMap`
- **KategorieIdToIconConverter**: Changed `is Dictionary<string, string>` to `is IDictionary<string, string>` for robustness
- **AppearanceViewModel**: Constructor now sets backing fields directly (`selectedThemeIndex`, `selectedLanguageIndex`) instead of properties, preventing redundant `OnChanged` callbacks, disk writes, and theme applies during initialization
- **AboutViewModel**: Assembly now injected via constructor — `GetExecutingAssembly()` in Presentation returned wrong assembly after layer split; MAUI registers the correct app assembly via DI

### 🔧 Code quality
- **Presentation.csproj**: Pinned `Microsoft.Extensions.Logging.Abstractions` version
- **BackupViewModel**: Extracted `EnsureBackupServiceAvailableAsync()` helper
- **StorageViewModel**: Shows error alert when `_folderPicker` is null
- **MauiFolderPicker / MauiFileSaver**: Removed redundant `using` directives
- **Routes.cs**: `const` → `static readonly`
- **BaseContentPage / IAutoLoadViewModel**: Added `ShouldAutoLoad` opt-out hook

### 🧪 Tests (+3 new, 198 total)
- **AboutViewModelTests**: Version parsing tests
- **StorageViewModelTests**: Null folderPicker constructor test