### PR TITLE
🔧 chore(config): bump version to 1.5

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.4",
+  "version": "1.5",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Version bump `1.4` → `1.5` in `version.json` for the Milestone v1.5 release.

Nach dem Merge: Tag `v1.5.0` anlegen um den GitHub Release auszulösen.