### PR TITLE
♻️ refactor: clean code improvements (post v1.6 review)

### DIFF
--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -64,7 +64,7 @@ namespace Finanzuebersicht.Services
         {
             try
             {
-                var backupPath = customPath ?? GetDefaultBackupPath();
+                var backupPath = customPath ?? _settingsService.GetBackupPath();
                 Directory.CreateDirectory(backupPath);
 
                 // Backup ID = ISO-Timestamp format (z.B. 2026-03-11T21-46-19-123)
@@ -112,7 +112,7 @@ namespace Finanzuebersicht.Services
                     fileName, metadata.EntityCounts["categories"], metadata.EntityCounts["transactions"], metadata.EntityCounts["recurring"], metadata.EntityCounts["budgets"], metadata.EntityCounts["sparziele"]);
 
                 // Speichere Zeitstempel in Settings
-                _settingsService.Set("LastBackupTime", _clock.UtcNow.ToString("O"));
+                _settingsService.SetLastBackupTime(_clock.UtcNow);
 
                 return metadata;
             }
@@ -386,19 +386,6 @@ namespace Finanzuebersicht.Services
         }
 
         // ========== Hilfsmethoden ==========
-
-        private string GetDefaultBackupPath()
-        {
-            var backupPath = _settingsService.Get("BackupPath");
-            if (!string.IsNullOrEmpty(backupPath))
-                return backupPath;
-
-            var dataPath = _settingsService.Get("DataPath");
-            if (string.IsNullOrEmpty(dataPath))
-                dataPath = AppPaths.GetDefaultDataDir();
-
-            return Path.Combine(dataPath, "backups");
-        }
 
         private static void WriteJsonToZip<T>(ZipArchive archive, string entryName, T data)
         {

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -93,18 +93,27 @@ namespace Finanzuebersicht.Services
             var duplicates = new List<Transaction>();
             var skippedMalformed = 0;
 
-            // Load existing transactions once for the full import date range (avoids N+1 queries)
+            // Load existing transactions once for the full import date range (avoids N+1 queries).
+            // Only consider DTOs with a valid Buchungsdatum — malformed ones (default/MinValue) are
+            // skipped later in the loop and must not distort the date range.
             List<Transaction>? existingInRange = null;
-            try
+            var validDates = dtosList
+                .Where(d => d?.Buchungsdatum != null && d.Buchungsdatum != default)
+                .Select(d => d!.Buchungsdatum)
+                .ToList();
+            if (validDates.Count > 0)
             {
-                var minDate = dtosList.Min(d => d?.Buchungsdatum ?? DateTime.MaxValue).Date.AddDays(-1);
-                var maxDate = dtosList.Max(d => d?.Buchungsdatum ?? DateTime.MinValue).Date.AddDays(1);
-                existingInRange = await _transactionRepository
-                    .GetTransactionsAsync(minDate, maxDate).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "ImportService: failed to load existing transactions for duplicate check; duplicates won't be detected");
+                try
+                {
+                    var minDate = validDates.Min().Date.AddDays(-1);
+                    var maxDate = validDates.Max().Date.AddDays(1);
+                    existingInRange = await _transactionRepository
+                        .GetTransactionsAsync(minDate, maxDate).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "ImportService: failed to load existing transactions for duplicate check; duplicates won't be detected");
+                }
             }
 
             foreach (var dto in dtosList)

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -93,6 +93,20 @@ namespace Finanzuebersicht.Services
             var duplicates = new List<Transaction>();
             var skippedMalformed = 0;
 
+            // Load existing transactions once for the full import date range (avoids N+1 queries)
+            List<Transaction>? existingInRange = null;
+            try
+            {
+                var minDate = dtosList.Min(d => d?.Buchungsdatum ?? DateTime.MaxValue).Date.AddDays(-1);
+                var maxDate = dtosList.Max(d => d?.Buchungsdatum ?? DateTime.MinValue).Date.AddDays(1);
+                existingInRange = await _transactionRepository
+                    .GetTransactionsAsync(minDate, maxDate).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to load existing transactions for duplicate check; duplicates won't be detected");
+            }
+
             foreach (var dto in dtosList)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -116,22 +130,16 @@ namespace Finanzuebersicht.Services
                     AccountId = accountId ?? dto.SourceAccountId
                 };
 
-                // Duplicate check
+                // Duplicate check (against in-memory snapshot loaded once before the loop)
                 bool isDuplicate = false;
-                try
+                if (existingInRange is not null)
                 {
                     var from = dto.Buchungsdatum.Date.AddDays(-1);
                     var to = dto.Buchungsdatum.Date.AddDays(1);
-                    var existing = await _transactionRepository.GetTransactionsAsync(from, to).ConfigureAwait(false);
-                    isDuplicate = existing?.Any(e =>
+                    isDuplicate = existingInRange.Any(e =>
                         e.Datum.Date >= from && e.Datum.Date <= to &&
                         e.Betrag == dto.Betrag &&
-                        Normalize(e.Titel) == Normalize(title)) ?? false;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "ImportService: duplicate check failed for '{Title}'", title);
-                    // On duplicate check failure, treat as non-duplicate (safer: import rather than lose data)
+                        Normalize(e.Titel) == Normalize(title));
                 }
 
                 if (isDuplicate)

--- a/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
+++ b/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
@@ -20,7 +20,7 @@ public static class RecurringScheduleCalculator
         return recurring.Interval switch
         {
             RecurrenceInterval.Daily => fromDate.Date.AddDays(1 * factor),
-            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7L * factor),
+            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7 * factor),
             RecurrenceInterval.Monthly => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
             RecurrenceInterval.Quarterly => AddMonthsPreserveDay(fromDate.Date, 3 * factor),
             RecurrenceInterval.Yearly => AddMonthsPreserveDay(fromDate.Date, 12 * factor),
@@ -41,7 +41,8 @@ public static class RecurringScheduleCalculator
             return adjusted;
 
         // Loop to handle consecutive Skip exceptions (e.g. two back-to-back skipped dates).
-        // Upper bound prevents infinite loops for pathological configurations.
+        // 366 = max days in a leap year; handles the worst-case of a daily recurring with
+        // a full year of consecutive Skips before finding a non-excepted date.
         const int maxIterations = 366;
         for (int i = 0; i < maxIterations; i++)
         {

--- a/Finanzuebersicht.Core/Services/SettingsService.cs
+++ b/Finanzuebersicht.Core/Services/SettingsService.cs
@@ -7,7 +7,7 @@ namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Verwaltet App-Einstellungen als Key-Value-Paare (JSON-Datei).
-/// File-I/O beim Speichern erfolgt asynchron im Hintergrund um den UI-Thread nicht zu blockieren.
+/// Lese- und Schreibzugriffe sind thread-safe über einen internen Lock.
 /// </summary>
 public class SettingsService : ISettingsService
 {


### PR DESCRIPTION
## Übersicht

Kleinere Clean-Code-Verbesserungen nach dem Code-Review von #177.

## Änderungen

### Performance
- **ImportService**: N+1 Query-Pattern im Duplicate-Check eliminiert — statt pro Import-Zeile einen eigenen DB-Call, werden alle vorhandenen Transaktionen für den gesamten Import-Zeitraum einmalig geladen und in-memory geprüft

### DRY / API-Konsistenz
- **BackupService**: Private `GetDefaultBackupPath()` entfernt (duplizierte Logik aus `SettingsService.GetBackupPath()`); direkter Aufruf der Helper-Methode
- **BackupService**: `Set("LastBackupTime", ...)` ersetzt durch `SetLastBackupTime()`

### Dokumentation / Kleinigkeiten
- **SettingsService**: Irreführenden Kommentar korrigiert ("async" — `Save()` ist tatsächlich synchron)
- **RecurringScheduleCalculator**: `maxIterations = 366` mit Begründung dokumentiert
- **RecurringScheduleCalculator**: `7L`-Literal entfernt (`AddDays` erwartet `double`)

## Teststand

- **228 Tests** ✅
- Build für macOS (Mac Catalyst) ✅