### PR TITLE
🚀 release: v1.6 – Datenrobustheit, Architektur & Clean Code

### DIFF
--- a/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -1,0 +1,48 @@
+using Finanzuebersicht.Application.UseCases.Categories;
+using Finanzuebersicht.Application.UseCases.Dashboard;
+using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Application.UseCases.SparZiele;
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Services;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Finanzuebersicht.Application.DependencyInjection;
+
+public static class ApplicationServiceCollectionExtensions
+{
+    public static IServiceCollection AddApplicationUseCases(this IServiceCollection services)
+    {
+        services.AddTransient<DeleteCategoryUseCase>();
+        services.AddTransient<LoadCategoriesUseCase>();
+        services.AddTransient<SaveCategoryDetailUseCase>();
+        services.AddTransient<SaveCategoryBudgetUseCase>();
+
+        services.AddTransient<LoadDashboardMonthUseCase>();
+        services.AddTransient<LoadDashboardYearUseCase>();
+        services.AddTransient<LoadForecastUseCase>();
+
+        services.AddTransient<DeleteRecurringTransactionUseCase>();
+        services.AddTransient<LoadRecurringTransactionDetailDataUseCase>();
+        services.AddTransient<LoadRecurringTransactionsUseCase>();
+        services.AddTransient<ToggleRecurringTransactionActiveUseCase>();
+        services.AddTransient<AddRecurringExceptionUseCase>();
+        services.AddTransient<RemoveRecurringExceptionUseCase>();
+        services.AddTransient<ShiftRecurringInstanceUseCase>();
+        services.AddTransient<GetDueRecurringWithHintsUseCase>();
+
+        services.AddTransient<LoadTransactionDetailDataUseCase>();
+        services.AddTransient<DeleteTransactionUseCase>();
+        services.AddTransient<LoadTransactionsMonthUseCase>();
+        services.AddTransient<SearchTransactionsUseCase>();
+        services.AddTransient<SaveRecurringTransactionDetailUseCase>();
+        services.AddTransient<SaveTransactionDetailUseCase>();
+
+        services.AddTransient<LoadSparZieleUseCase>();
+        services.AddTransient<SaveSparZielUseCase>();
+        services.AddTransient<DeleteSparZielUseCase>();
+
+        services.AddSingleton<InitializationService>();
+
+        return services;
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Categories/DeleteCategoryUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Categories/DeleteCategoryUseCase.cs
@@ -12,7 +12,7 @@ public class DeleteCategoryUseCase(
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
 
-    public async Task ExecuteAsync(string categoryId)
+    public async Task ExecuteAsync(string categoryId, CancellationToken cancellationToken = default)
     {
         var categories = await _categoryRepository.GetCategoriesAsync();
         if (!categories.Any(c => c.Id == categoryId))

--- a/Finanzuebersicht.Application/UseCases/Categories/LoadCategoriesUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Categories/LoadCategoriesUseCase.cs
@@ -7,7 +7,7 @@ public class LoadCategoriesUseCase(ICategoryRepository categoryRepository)
 {
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
 
-    public async Task<List<Category>> ExecuteAsync()
+    public async Task<List<Category>> ExecuteAsync(CancellationToken cancellationToken = default)
     {
         return await _categoryRepository.GetCategoriesAsync();
     }

--- a/Finanzuebersicht.Application/UseCases/Categories/SaveCategoryBudgetUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Categories/SaveCategoryBudgetUseCase.cs
@@ -5,7 +5,7 @@ namespace Finanzuebersicht.Application.UseCases.Categories;
 
 public class SaveCategoryBudgetUseCase(IBudgetRepository budgetRepository)
 {
-    public async Task ExecuteAsync(string kategorieId, decimal betrag, int? monat = null, int? jahr = null)
+    public async Task ExecuteAsync(string kategorieId, decimal betrag, int? monat = null, int? jahr = null, CancellationToken cancellationToken = default)
     {
         var budgets = await budgetRepository.GetBudgetsAsync();
         var existing = budgets.FirstOrDefault(b =>

--- a/Finanzuebersicht.Application/UseCases/Categories/SaveCategoryDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Categories/SaveCategoryDetailUseCase.cs
@@ -12,7 +12,7 @@ public class SaveCategoryDetailUseCase(ICategoryRepository categoryRepository)
         string name,
         string icon,
         string color,
-        TransactionType typ)
+        TransactionType typ, CancellationToken cancellationToken = default)
     {
         var category = existingCategory ?? new Category();
         category.Name = name;

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
@@ -15,7 +15,7 @@ public class LoadDashboardMonthUseCase(
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
     private readonly IBudgetRepository _budgetRepository = budgetRepository;
 
-    public async Task<DashboardMonthData> ExecuteAsync(DateTime aktuellerMonat, DateTime today)
+    public async Task<DashboardMonthData> ExecuteAsync(DateTime aktuellerMonat, DateTime today, CancellationToken cancellationToken = default)
     {
         var kategorien = await _categoryRepository.GetCategoriesAsync();
 

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardYearUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardYearUseCase.cs
@@ -7,7 +7,7 @@ public class LoadDashboardYearUseCase(IReportingService reportingService)
 {
     private readonly IReportingService _reportingService = reportingService;
 
-    public async Task<DashboardYearData> ExecuteAsync(int year)
+    public async Task<DashboardYearData> ExecuteAsync(int year, CancellationToken cancellationToken = default)
     {
         var summary = await _reportingService.GetYearSummaryAsync(year);
         if (summary == null)

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadForecastUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadForecastUseCase.cs
@@ -5,6 +5,6 @@ namespace Finanzuebersicht.Application.UseCases.Dashboard;
 
 public class LoadForecastUseCase(IForecastService forecastService)
 {
-    public Task<ForecastResult> ExecuteAsync(int year, int month, int lookbackMonths = 3)
+    public Task<ForecastResult> ExecuteAsync(int year, int month, int lookbackMonths = 3, CancellationToken cancellationToken = default)
         => forecastService.GetMovingAverageAsync(year, month, lookbackMonths);
 }

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/AddRecurringExceptionUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/AddRecurringExceptionUseCase.cs
@@ -12,7 +12,7 @@ public class AddRecurringExceptionUseCase
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
 
-    public async Task ExecuteAsync(string recurringTransactionId, RecurringException exception)
+    public async Task ExecuteAsync(string recurringTransactionId, RecurringException exception, CancellationToken cancellationToken = default)
     {
         var list = await _recurringTransactionRepository.GetRecurringTransactionsAsync();
         var recurring = list.FirstOrDefault(r => r.Id == recurringTransactionId);

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/DeleteRecurringTransactionUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/DeleteRecurringTransactionUseCase.cs
@@ -6,7 +6,7 @@ public class DeleteRecurringTransactionUseCase(IRecurringTransactionRepository r
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
 
-    public async Task ExecuteAsync(string recurringTransactionId)
+    public async Task ExecuteAsync(string recurringTransactionId, CancellationToken cancellationToken = default)
     {
         await _recurringTransactionRepository.DeleteRecurringTransactionAsync(recurringTransactionId);
     }

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/GetDueRecurringWithHintsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/GetDueRecurringWithHintsUseCase.cs
@@ -13,182 +13,41 @@ public class DueRecurringItem
     public string? Hint { get; set; }
 }
 
-public class GetDueRecurringWithHintsUseCase
-(
-    IRecurringTransactionRepository recurringTransactionRepository
-)
+public class GetDueRecurringWithHintsUseCase(
+    IRecurringTransactionRepository recurringTransactionRepository)
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
 
-    public async Task<List<DueRecurringItem>> ExecuteAsync(DateTime referenceDate)
+    public async Task<List<DueRecurringItem>> ExecuteAsync(
+        DateTime referenceDate,
+        CancellationToken cancellationToken = default)
     {
         var list = await _recurringTransactionRepository.GetRecurringTransactionsAsync();
         var result = new List<DueRecurringItem>();
-        foreach (var r in list.Where(x => x.Aktiv).Where(x => IsWithinActiveRange(x, referenceDate)))
+
+        foreach (var r in list.Where(x => x.Aktiv)
+                               .Where(x => RecurringScheduleCalculator.IsWithinActiveRange(x, referenceDate)))
         {
-            // determine the next candidate instance using same rules as generator
-            DateTime candidate;
-            if (r.LetzteAusfuehrung.HasValue)
-            {
-                candidate = GetNextInstance(r, r.LetzteAusfuehrung.Value, r.IntervalFactor);
-            }
-            else
-            {
-                candidate = r.Startdatum.Date;
-            }
+            cancellationToken.ThrowIfCancellationRequested();
 
-            while (candidate.Date < referenceDate.Date)
-            {
-                candidate = GetNextInstance(r, candidate, r.IntervalFactor);
-            }
+            var dueDate = RecurringScheduleCalculator.GetNextDueDate(r, referenceDate);
+            if (dueDate is null)
+                continue;
 
-            // apply any defined exceptions (Skip/Shift) to the calculated candidate
-            candidate = ApplyExceptionsIfAny(r, candidate, r.IntervalFactor);
-
-            var daysUntil = (candidate.Date - referenceDate.Date).Days;
+            var daysUntil = (dueDate.Value.Date - referenceDate.Date).Days;
             var isDue = daysUntil <= 0;
-            string? hint = null;
-            if (daysUntil == 0)
-                hint = "Heute fällig";
-            else if (daysUntil < 0)
-                hint = $"Seit {-daysUntil} Tagen überfällig";
-            else if (r.ReminderDaysBefore > 0 && daysUntil <= r.ReminderDaysBefore)
-                hint = $"Fällig in {daysUntil} Tagen";
+            string? hint = daysUntil switch
+            {
+                0 => "Heute fällig",
+                < 0 => $"Seit {-daysUntil} Tagen überfällig",
+                _ when r.ReminderDaysBefore > 0 && daysUntil <= r.ReminderDaysBefore => $"Fällig in {daysUntil} Tagen",
+                _ => null,
+            };
 
             result.Add(new DueRecurringItem { Recurring = r, IsDue = isDue, Hint = hint });
         }
 
         return result;
-
     }
-
-    private static bool IsWithinActiveRange(RecurringTransaction recurring, DateTime referenceDate)
-    {
-        var reference = referenceDate.Date;
-        var start = recurring.Startdatum.Date;
-
-        if (reference < start.AddDays(-recurring.ReminderDaysBefore))
-        {
-            return false;
-        }
-
-        // Enddatum is optional – access via reflection to avoid hard dependency
-        var endProperty = recurring.GetType().GetProperty("Enddatum");
-        if (endProperty != null)
-        {
-            var value = endProperty.GetValue(recurring);
-            if (value is DateTime endDate && reference > endDate.Date)
-            {
-                return false;
-            }
-        }
-
-        return true;
-    }
-
-    private static DateTime ApplyExceptionsIfAny(RecurringTransaction recurring, DateTime candidate, int intervalFactor)
-    {
-        var exceptionsProperty = recurring.GetType().GetProperty("Exceptions");
-        if (exceptionsProperty == null)
-        {
-            return candidate;
-        }
-
-        var exceptionsValue = exceptionsProperty.GetValue(recurring) as System.Collections.IEnumerable;
-        if (exceptionsValue == null)
-        {
-            return candidate;
-        }
-
-        var adjustedCandidate = candidate.Date;
-
-        foreach (var exception in exceptionsValue)
-        {
-            if (exception == null)
-            {
-                continue;
-            }
-
-            var exceptionType = exception.GetType();
-
-            // try to get the exception date (commonly "Date" or "Datum")
-            var dateProperty =
-                exceptionType.GetProperty("Date") ??
-                exceptionType.GetProperty("Datum");
-
-            if (dateProperty == null)
-            {
-                continue;
-            }
-
-            var dateValue = dateProperty.GetValue(exception);
-            if (dateValue is not DateTime exceptionDate || exceptionDate.Date != adjustedCandidate)
-            {
-                continue;
-            }
-
-            // try to get the exception type (commonly "Type", "Typ" or "Art")
-            var typeProperty =
-                exceptionType.GetProperty("Type") ??
-                exceptionType.GetProperty("Typ") ??
-                exceptionType.GetProperty("Art");
-
-            var typeName = typeProperty?.GetValue(exception)?.ToString() ?? string.Empty;
-
-            if (string.IsNullOrWhiteSpace(typeName))
-            {
-                continue;
-            }
-
-            var normalizedType = typeName.Trim();
-
-            // Skip: move to the next instance
-            if (string.Equals(normalizedType, "Skip", StringComparison.OrdinalIgnoreCase))
-            {
-                adjustedCandidate = GetNextInstance(recurring, adjustedCandidate, intervalFactor).Date;
-                continue;
-            }
-
-            // Shift: move by configured number of days if available
-            if (string.Equals(normalizedType, "Shift", StringComparison.OrdinalIgnoreCase))
-            {
-                var shiftDaysProperty =
-                    exceptionType.GetProperty("ShiftDays") ??
-                    exceptionType.GetProperty("VerschiebungTage");
-
-                var shiftValue = shiftDaysProperty?.GetValue(exception);
-                if (shiftValue is int shiftDays && shiftDays != 0)
-                {
-                    adjustedCandidate = adjustedCandidate.AddDays(shiftDays);
-                }
-            }
-        }
-
-        return adjustedCandidate;
-    }
-
-    private static DateTime GetNextInstance(RecurringTransaction recurring, DateTime fromDate, int intervalFactor)
-    {
-        var factor = Math.Max(1, intervalFactor);
-        return recurring.Interval switch
-        {
-            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7L * factor),
-            RecurrenceInterval.Monthly => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
-            RecurrenceInterval.Quarterly => AddMonthsPreserveDay(fromDate.Date, 3 * factor),
-            RecurrenceInterval.Yearly => AddMonthsPreserveDay(fromDate.Date, 12 * factor),
-            RecurrenceInterval.Daily => fromDate.Date.AddDays(1 * factor),
-            _ => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
-        };
-    }
-
-    private static DateTime AddMonthsPreserveDay(DateTime date, int months)
-    {
-        var target = date.AddMonths(months);
-        var day = date.Day;
-        var daysInTarget = DateTime.DaysInMonth(target.Year, target.Month);
-        if (day > daysInTarget)
-            day = daysInTarget;
-        return new DateTime(target.Year, target.Month, day);
-    }
-
 }
+

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/LoadRecurringTransactionDetailDataUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/LoadRecurringTransactionDetailDataUseCase.cs
@@ -7,7 +7,7 @@ public class LoadRecurringTransactionDetailDataUseCase(ICategoryRepository categ
 {
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
 
-    public async Task<RecurringTransactionDetailData> ExecuteAsync(string? selectedCategoryId)
+    public async Task<RecurringTransactionDetailData> ExecuteAsync(string? selectedCategoryId, CancellationToken cancellationToken = default)
     {
         var categories = await _categoryRepository.GetCategoriesAsync();
         var selectedCategory = selectedCategoryId == null

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/LoadRecurringTransactionsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/LoadRecurringTransactionsUseCase.cs
@@ -7,7 +7,7 @@ public class LoadRecurringTransactionsUseCase(IRecurringTransactionRepository re
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
 
-    public async Task<List<RecurringTransaction>> ExecuteAsync()
+    public async Task<List<RecurringTransaction>> ExecuteAsync(CancellationToken cancellationToken = default)
     {
         var liste = await _recurringTransactionRepository.GetRecurringTransactionsAsync();
         return [.. liste.OrderByDescending(d => d.Aktiv).ThenBy(d => d.Titel)];

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/RemoveRecurringExceptionUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/RemoveRecurringExceptionUseCase.cs
@@ -11,7 +11,7 @@ public class RemoveRecurringExceptionUseCase
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
 
-    public async Task ExecuteAsync(string recurringTransactionId, string exceptionId)
+    public async Task ExecuteAsync(string recurringTransactionId, string exceptionId, CancellationToken cancellationToken = default)
     {
         var list = await _recurringTransactionRepository.GetRecurringTransactionsAsync();
         var recurring = list.FirstOrDefault(r => r.Id == recurringTransactionId);

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/SaveRecurringTransactionDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/SaveRecurringTransactionDetailUseCase.cs
@@ -22,7 +22,7 @@ public class SaveRecurringTransactionDetailUseCase(
         RecurrenceInterval interval = RecurrenceInterval.Monthly,
         int intervalFactor = 1,
         int reminderDaysBefore = 0,
-        List<RecurringException>? exceptions = null)
+        List<RecurringException>? exceptions = null, CancellationToken cancellationToken = default)
     {
         // logging removed: prefer centralized ILogger or conditional debug logging
 

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/ShiftRecurringInstanceUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/ShiftRecurringInstanceUseCase.cs
@@ -11,7 +11,7 @@ public class ShiftRecurringInstanceUseCase
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
 
-    public async Task ExecuteAsync(string recurringTransactionId, DateTime instanceDate, DateTime newDate, string? note = null)
+    public async Task ExecuteAsync(string recurringTransactionId, DateTime instanceDate, DateTime newDate, string? note = null, CancellationToken cancellationToken = default)
     {
         var list = await _recurringTransactionRepository.GetRecurringTransactionsAsync();
         var recurring = list.FirstOrDefault(r => r.Id == recurringTransactionId);

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/ToggleRecurringTransactionActiveUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/ToggleRecurringTransactionActiveUseCase.cs
@@ -7,7 +7,7 @@ public class ToggleRecurringTransactionActiveUseCase(IRecurringTransactionReposi
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
 
-    public async Task ExecuteAsync(RecurringTransaction recurringTransaction)
+    public async Task ExecuteAsync(RecurringTransaction recurringTransaction, CancellationToken cancellationToken = default)
     {
         recurringTransaction.Aktiv = !recurringTransaction.Aktiv;
         await _recurringTransactionRepository.SaveRecurringTransactionAsync(recurringTransaction);

--- a/Finanzuebersicht.Application/UseCases/SparZiele/DeleteSparZielUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/SparZiele/DeleteSparZielUseCase.cs
@@ -4,6 +4,6 @@ namespace Finanzuebersicht.Application.UseCases.SparZiele;
 
 public class DeleteSparZielUseCase(ISparZielRepository sparZielRepository)
 {
-    public Task ExecuteAsync(string id)
+    public Task ExecuteAsync(string id, CancellationToken cancellationToken = default)
         => sparZielRepository.DeleteSparZielAsync(id);
 }

--- a/Finanzuebersicht.Application/UseCases/SparZiele/LoadSparZieleUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/SparZiele/LoadSparZieleUseCase.cs
@@ -5,7 +5,7 @@ namespace Finanzuebersicht.Application.UseCases.SparZiele;
 
 public class LoadSparZieleUseCase(ISparZielRepository sparZielRepository)
 {
-    public async Task<List<SparZielSummary>> ExecuteAsync()
+    public async Task<List<SparZielSummary>> ExecuteAsync(CancellationToken cancellationToken = default)
     {
         var ziele = await sparZielRepository.GetSparZieleAsync();
         return ziele.Select(z => new SparZielSummary { SparZiel = z }).ToList();

--- a/Finanzuebersicht.Application/UseCases/SparZiele/SaveSparZielUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/SparZiele/SaveSparZielUseCase.cs
@@ -5,6 +5,6 @@ namespace Finanzuebersicht.Application.UseCases.SparZiele;
 
 public class SaveSparZielUseCase(ISparZielRepository sparZielRepository)
 {
-    public Task ExecuteAsync(SparZiel sparZiel)
+    public Task ExecuteAsync(SparZiel sparZiel, CancellationToken cancellationToken = default)
         => sparZielRepository.SaveSparZielAsync(sparZiel);
 }

--- a/Finanzuebersicht.Application/UseCases/Transactions/DeleteTransactionUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/DeleteTransactionUseCase.cs
@@ -6,7 +6,7 @@ public class DeleteTransactionUseCase(ITransactionRepository transactionReposito
 {
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
 
-    public async Task ExecuteAsync(string transactionId)
+    public async Task ExecuteAsync(string transactionId, CancellationToken cancellationToken = default)
     {
         await _transactionRepository.DeleteTransactionAsync(transactionId);
     }

--- a/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionDetailDataUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionDetailDataUseCase.cs
@@ -7,7 +7,7 @@ public class LoadTransactionDetailDataUseCase(ICategoryRepository categoryReposi
 {
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
 
-    public async Task<TransactionDetailData> ExecuteAsync(string? selectedCategoryId)
+    public async Task<TransactionDetailData> ExecuteAsync(string? selectedCategoryId, CancellationToken cancellationToken = default)
     {
         var categories = await _categoryRepository.GetCategoriesAsync();
         var selectedCategory = selectedCategoryId == null

--- a/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionsMonthUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionsMonthUseCase.cs
@@ -10,7 +10,7 @@ public class LoadTransactionsMonthUseCase(
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
 
-    public async Task<TransactionsMonthData> ExecuteAsync(DateTime aktuellerMonat)
+    public async Task<TransactionsMonthData> ExecuteAsync(DateTime aktuellerMonat, CancellationToken cancellationToken = default)
     {
         var von = aktuellerMonat;
         var bis = aktuellerMonat.AddMonths(1).AddDays(-1);

--- a/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionDetailUseCase.cs
@@ -14,7 +14,7 @@ public class SaveTransactionDetailUseCase(ITransactionRepository transactionRepo
         DateTime datum,
         string kategorieId,
         TransactionType typ,
-        string verwendungszweck)
+        string verwendungszweck, CancellationToken cancellationToken = default)
     {
         var transaction = existingTransaction ?? new Transaction();
         transaction.Betrag = betrag;

--- a/Finanzuebersicht.Application/UseCases/Transactions/SearchTransactionsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SearchTransactionsUseCase.cs
@@ -27,7 +27,7 @@ public class SearchTransactionsUseCase(
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
 
-    public async Task<SearchTransactionsResult> ExecuteAsync(SearchTransactionsQuery query)
+    public async Task<SearchTransactionsResult> ExecuteAsync(SearchTransactionsQuery query, CancellationToken cancellationToken = default)
     {
         var von = query.VonDatum ?? DateTime.MinValue;
         var bis = query.BisDatum ?? DateTime.MaxValue;

--- a/Finanzuebersicht.Core/Models/DataCorruptionException.cs
+++ b/Finanzuebersicht.Core/Models/DataCorruptionException.cs
@@ -1,0 +1,16 @@
+namespace Finanzuebersicht.Models;
+
+/// <summary>
+/// Thrown when a data file exists but cannot be parsed due to corruption or invalid content.
+/// Distinct from "file not found" — signals that data may have been lost or damaged.
+/// </summary>
+public class DataCorruptionException : Exception
+{
+    public string FilePath { get; }
+
+    public DataCorruptionException(string filePath, Exception innerException)
+        : base($"Data file is corrupted and cannot be loaded: {filePath}", innerException)
+    {
+        FilePath = filePath;
+    }
+}

--- a/Finanzuebersicht.Core/Models/ImportResult.cs
+++ b/Finanzuebersicht.Core/Models/ImportResult.cs
@@ -1,0 +1,28 @@
+namespace Finanzuebersicht.Models;
+
+/// <summary>
+/// Result of a CSV import operation with a full breakdown of what happened.
+/// </summary>
+public class ImportResult
+{
+    /// <summary>Transactions that were successfully parsed, validated, and saved.</summary>
+    public IReadOnlyList<Transaction> Imported { get; init; } = [];
+
+    /// <summary>Transactions that were skipped due to being duplicates of existing records.</summary>
+    public IReadOnlyList<Transaction> Duplicates { get; init; } = [];
+
+    /// <summary>Rows skipped because they were malformed (e.g., missing date or amount).</summary>
+    public int SkippedMalformed { get; init; }
+
+    /// <summary>Transactions that were valid and not duplicates but failed to save.</summary>
+    public IReadOnlyList<string> SaveErrors { get; init; } = [];
+
+    /// <summary>Top-level error message if the import failed entirely (e.g., no parser matched, stream read error).</summary>
+    public string? ErrorMessage { get; init; }
+
+    /// <summary>Whether the import completed without a top-level error.</summary>
+    public bool Success => ErrorMessage is null;
+
+    /// <summary>Total number of records processed (includes duplicates and malformed).</summary>
+    public int TotalProcessed => Imported.Count + Duplicates.Count + SkippedMalformed + SaveErrors.Count;
+}

--- a/Finanzuebersicht.Core/Models/RollbackFailedException.cs
+++ b/Finanzuebersicht.Core/Models/RollbackFailedException.cs
@@ -1,0 +1,12 @@
+namespace Finanzuebersicht.Models;
+
+/// <summary>
+/// Thrown when a rollback after a failed restore operation itself fails.
+/// When this exception is caught, the data state may be inconsistent and
+/// the user should be warned immediately.
+/// </summary>
+public class RollbackFailedException : Exception
+{
+    public RollbackFailedException(string message, Exception innerException)
+        : base(message, innerException) { }
+}

--- a/Finanzuebersicht.Core/Services/BackupMetadata.cs
+++ b/Finanzuebersicht.Core/Services/BackupMetadata.cs
@@ -57,6 +57,12 @@ namespace Finanzuebersicht.Services
         public string? ErrorMessage { get; set; }
 
         /// <summary>
+        /// true wenn der Rollback nach einem fehlgeschlagenen Restore ebenfalls fehlgeschlagen ist.
+        /// In diesem Fall kann der Datenzustand inkonsistent sein.
+        /// </summary>
+        public bool DataMayBeInconsistent { get; set; }
+
+        /// <summary>
         /// Optionale Detailinformation (z.B. Anzahl wiederhergestellter Transaktionen).
         /// </summary>
         public string? Details { get; set; }

--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -17,7 +17,7 @@ namespace Finanzuebersicht.Services
     public class BackupService : IBackupService
     {
         private readonly IDataService _dataService;
-        private readonly SettingsService _settingsService;
+        private readonly ISettingsService _settingsService;
         private readonly ILogger<BackupService>? _logger;
         private readonly Finanzuebersicht.Services.IClock _clock;
         private readonly DataMigrationService _migrationService;
@@ -31,7 +31,7 @@ namespace Finanzuebersicht.Services
         private const string BackupMetadataFileName = "backup.metadata.json";
         private const int CurrentSchemaVersion = 2;
 
-        public BackupService(IDataService dataService, SettingsService settingsService, DataMigrationService migrationService, ILogger<BackupService>? logger = null, Finanzuebersicht.Services.IClock? clock = null)
+        public BackupService(IDataService dataService, ISettingsService settingsService, DataMigrationService migrationService, ILogger<BackupService>? logger = null, Finanzuebersicht.Services.IClock? clock = null)
         {
             _dataService = dataService ?? throw new ArgumentNullException(nameof(dataService));
             _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));

--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -219,6 +219,16 @@ namespace Finanzuebersicht.Services
                     RestoredMetadata = archiveData.Metadata
                 };
             }
+            catch (RollbackFailedException ex)
+            {
+                _logger?.LogCritical(ex, "Restore und Rollback fehlgeschlagen für Backup {BackupId} – Daten möglicherweise inkonsistent", backupId);
+                return new RestoreResult
+                {
+                    Success = false,
+                    DataMayBeInconsistent = true,
+                    ErrorMessage = "Wiederherstellung und Rollback sind fehlgeschlagen. Die Daten könnten inkonsistent sein. Bitte starte die App neu und versuche es erneut."
+                };
+            }
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Fehler beim Restore aus Backup {BackupId}", backupId);
@@ -233,6 +243,7 @@ namespace Finanzuebersicht.Services
         /// <summary>
         /// Stellt alle Daten aus dem Backup wieder her in je einem einzigen Schreibvorgang pro Entity-Typ.
         /// Bei einem Fehler wird ein Rollback auf den vorherigen Zustand durchgeführt.
+        /// Wirft <see cref="RollbackFailedException"/> wenn der Rollback selbst fehlschlägt.
         /// </summary>
         private async Task<bool> AtomicRestoreAsync(
             List<Category> categories,
@@ -241,7 +252,9 @@ namespace Finanzuebersicht.Services
             List<CategoryBudget> budgets,
             List<SparZiel> sparziele)
         {
-            // Snapshot des aktuellen Zustands laden (für Rollback)
+            // Snapshot des aktuellen Zustands laden (für Rollback).
+            // Wenn dieser Schritt fehlschlägt (z.B. DataCorruptionException), bricht der Restore
+            // ab bevor irgendetwas überschrieben wurde — das ist das gewünschte Verhalten.
             var snapshotCategories = await _dataService.GetCategoriesAsync();
             var snapshotTransactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
             var snapshotRecurring = await _dataService.GetRecurringTransactionsAsync();
@@ -289,6 +302,7 @@ namespace Finanzuebersicht.Services
             catch (Exception rollbackEx)
             {
                 _logger?.LogCritical(rollbackEx, "Rollback fehlgeschlagen – Datenzustand ist möglicherweise inkonsistent");
+                throw new RollbackFailedException("Rollback nach fehlgeschlagenem Restore ist fehlgeschlagen. Der Datenzustand kann inkonsistent sein.", rollbackEx);
             }
         }
 

--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -64,7 +64,7 @@ namespace Finanzuebersicht.Services
         {
             try
             {
-                var backupPath = customPath ?? GetDefaultBackupPath();
+                var backupPath = customPath ?? _settingsService.GetBackupPath();
                 Directory.CreateDirectory(backupPath);
 
                 // Backup ID = ISO-Timestamp format (z.B. 2026-03-11T21-46-19-123)
@@ -112,7 +112,7 @@ namespace Finanzuebersicht.Services
                     fileName, metadata.EntityCounts["categories"], metadata.EntityCounts["transactions"], metadata.EntityCounts["recurring"], metadata.EntityCounts["budgets"], metadata.EntityCounts["sparziele"]);
 
                 // Speichere Zeitstempel in Settings
-                _settingsService.Set("LastBackupTime", _clock.UtcNow.ToString("O"));
+                _settingsService.SetLastBackupTime(_clock.UtcNow);
 
                 return metadata;
             }
@@ -386,19 +386,6 @@ namespace Finanzuebersicht.Services
         }
 
         // ========== Hilfsmethoden ==========
-
-        private string GetDefaultBackupPath()
-        {
-            var backupPath = _settingsService.Get("BackupPath");
-            if (!string.IsNullOrEmpty(backupPath))
-                return backupPath;
-
-            var dataPath = _settingsService.Get("DataPath");
-            if (string.IsNullOrEmpty(dataPath))
-                dataPath = AppPaths.GetDefaultDataDir();
-
-            return Path.Combine(dataPath, "backups");
-        }
 
         private static void WriteJsonToZip<T>(ZipArchive archive, string entryName, T data)
         {

--- a/Finanzuebersicht.Core/Services/BackupService.cs
+++ b/Finanzuebersicht.Core/Services/BackupService.cs
@@ -16,7 +16,11 @@ namespace Finanzuebersicht.Services
     /// </summary>
     public class BackupService : IBackupService
     {
-        private readonly IDataService _dataService;
+        private readonly ICategoryRepository _categoryRepository;
+        private readonly ITransactionRepository _transactionRepository;
+        private readonly IRecurringTransactionRepository _recurringRepository;
+        private readonly IBudgetRepository _budgetRepository;
+        private readonly ISparZielRepository _sparZielRepository;
         private readonly ISettingsService _settingsService;
         private readonly ILogger<BackupService>? _logger;
         private readonly Finanzuebersicht.Services.IClock _clock;
@@ -31,9 +35,22 @@ namespace Finanzuebersicht.Services
         private const string BackupMetadataFileName = "backup.metadata.json";
         private const int CurrentSchemaVersion = 2;
 
-        public BackupService(IDataService dataService, ISettingsService settingsService, DataMigrationService migrationService, ILogger<BackupService>? logger = null, Finanzuebersicht.Services.IClock? clock = null)
+        public BackupService(
+            ICategoryRepository categoryRepository,
+            ITransactionRepository transactionRepository,
+            IRecurringTransactionRepository recurringRepository,
+            IBudgetRepository budgetRepository,
+            ISparZielRepository sparZielRepository,
+            ISettingsService settingsService,
+            DataMigrationService migrationService,
+            ILogger<BackupService>? logger = null,
+            Finanzuebersicht.Services.IClock? clock = null)
         {
-            _dataService = dataService ?? throw new ArgumentNullException(nameof(dataService));
+            _categoryRepository = categoryRepository ?? throw new ArgumentNullException(nameof(categoryRepository));
+            _transactionRepository = transactionRepository ?? throw new ArgumentNullException(nameof(transactionRepository));
+            _recurringRepository = recurringRepository ?? throw new ArgumentNullException(nameof(recurringRepository));
+            _budgetRepository = budgetRepository ?? throw new ArgumentNullException(nameof(budgetRepository));
+            _sparZielRepository = sparZielRepository ?? throw new ArgumentNullException(nameof(sparZielRepository));
             _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
             _migrationService = migrationService ?? throw new ArgumentNullException(nameof(migrationService));
             _logger = logger;
@@ -56,11 +73,11 @@ namespace Finanzuebersicht.Services
                 var filePath = Path.Combine(backupPath, fileName);
 
                 // Lade alle Daten
-                var categories = await _dataService.GetCategoriesAsync();
-                var transactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
-                var recurring = await _dataService.GetRecurringTransactionsAsync();
-                var budgets = await _dataService.GetBudgetsAsync();
-                var sparziele = await _dataService.GetSparZieleAsync();
+                var categories = await _categoryRepository.GetCategoriesAsync();
+                var transactions = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+                var recurring = await _recurringRepository.GetRecurringTransactionsAsync();
+                var budgets = await _budgetRepository.GetBudgetsAsync();
+                var sparziele = await _sparZielRepository.GetSparZieleAsync();
 
                 // Erstelle Metadaten
                 var metadata = new BackupMetadata
@@ -255,22 +272,22 @@ namespace Finanzuebersicht.Services
             // Snapshot des aktuellen Zustands laden (für Rollback).
             // Wenn dieser Schritt fehlschlägt (z.B. DataCorruptionException), bricht der Restore
             // ab bevor irgendetwas überschrieben wurde — das ist das gewünschte Verhalten.
-            var snapshotCategories = await _dataService.GetCategoriesAsync();
-            var snapshotTransactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
-            var snapshotRecurring = await _dataService.GetRecurringTransactionsAsync();
-            var snapshotBudgets = await _dataService.GetBudgetsAsync();
-            var snapshotSparziele = await _dataService.GetSparZieleAsync();
+            var snapshotCategories = await _categoryRepository.GetCategoriesAsync();
+            var snapshotTransactions = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+            var snapshotRecurring = await _recurringRepository.GetRecurringTransactionsAsync();
+            var snapshotBudgets = await _budgetRepository.GetBudgetsAsync();
+            var snapshotSparziele = await _sparZielRepository.GetSparZieleAsync();
 
             try
             {
                 _logger?.LogInformation("Starte Wiederherstellung: {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträge, {BudCount} Budgets, {SparCount} Sparziele",
                     categories.Count, transactions.Count, recurring.Count, budgets.Count, sparziele.Count);
 
-                await _dataService.ReplaceAllCategoriesAsync(categories);
-                await _dataService.ReplaceAllTransactionsAsync(transactions);
-                await _dataService.ReplaceAllRecurringTransactionsAsync(recurring);
-                await _dataService.ReplaceAllBudgetsAsync(budgets);
-                await _dataService.ReplaceAllSparZieleAsync(sparziele);
+                await _categoryRepository.ReplaceAllCategoriesAsync(categories);
+                await _transactionRepository.ReplaceAllTransactionsAsync(transactions);
+                await _recurringRepository.ReplaceAllRecurringTransactionsAsync(recurring);
+                await _budgetRepository.ReplaceAllBudgetsAsync(budgets);
+                await _sparZielRepository.ReplaceAllSparZieleAsync(sparziele);
 
                 return true;
             }
@@ -291,11 +308,11 @@ namespace Finanzuebersicht.Services
         {
             try
             {
-                await _dataService.ReplaceAllCategoriesAsync(categories);
-                await _dataService.ReplaceAllTransactionsAsync(transactions);
-                await _dataService.ReplaceAllRecurringTransactionsAsync(recurring);
-                await _dataService.ReplaceAllBudgetsAsync(budgets);
-                await _dataService.ReplaceAllSparZieleAsync(sparziele);
+                await _categoryRepository.ReplaceAllCategoriesAsync(categories);
+                await _transactionRepository.ReplaceAllTransactionsAsync(transactions);
+                await _recurringRepository.ReplaceAllRecurringTransactionsAsync(recurring);
+                await _budgetRepository.ReplaceAllBudgetsAsync(budgets);
+                await _sparZielRepository.ReplaceAllSparZieleAsync(sparziele);
 
                 _logger?.LogInformation("Rollback erfolgreich abgeschlossen");
             }
@@ -336,8 +353,8 @@ namespace Finanzuebersicht.Services
         {
             try
             {
-                var transactions = await _dataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
-                var categories = await _dataService.GetCategoriesAsync();
+                var transactions = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+                var categories = await _categoryRepository.GetCategoriesAsync();
                 var categoryMap = categories.ToDictionary(c => c.Id, c => c.Name);
 
                 var memoryStream = new MemoryStream();

--- a/Finanzuebersicht.Core/Services/DataServiceFacade.cs
+++ b/Finanzuebersicht.Core/Services/DataServiceFacade.cs
@@ -55,8 +55,8 @@ public class DataServiceFacade(
     public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring)
         => _recurringRepository.ReplaceAllRecurringTransactionsAsync(recurring);
 
-    public Task GeneratePendingRecurringTransactionsAsync()
-        => _recurringGenerationService.GeneratePendingRecurringTransactionsAsync();
+    public Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default)
+        => _recurringGenerationService.GeneratePendingRecurringTransactionsAsync(cancellationToken);
 
     public Task<YearSummary> GetYearSummaryAsync(int year)
         => _reportingService.GetYearSummaryAsync(year);

--- a/Finanzuebersicht.Core/Services/DataServiceFacade.cs
+++ b/Finanzuebersicht.Core/Services/DataServiceFacade.cs
@@ -1,5 +1,6 @@
 using Finanzuebersicht.Models;
 
+#pragma warning disable CS0618 // IDataService is intentionally implemented here as the facade
 namespace Finanzuebersicht.Services;
 
 public class DataServiceFacade(

--- a/Finanzuebersicht.Core/Services/IDataService.cs
+++ b/Finanzuebersicht.Core/Services/IDataService.cs
@@ -1,5 +1,16 @@
 namespace Finanzuebersicht.Services;
 
+/// <summary>
+/// Broad facade interface aggregating all domain repositories and services.
+/// <para>
+/// This interface exists for legacy compatibility (BackupService, LocalDataService).
+/// All new code should inject the specific repository interfaces directly
+/// (<see cref="ICategoryRepository"/>, <see cref="ITransactionRepository"/>,
+/// <see cref="IRecurringTransactionRepository"/>, <see cref="IBudgetRepository"/>,
+/// <see cref="ISparZielRepository"/>).
+/// </para>
+/// </summary>
+[Obsolete("Inject specific repository interfaces instead. IDataService will be removed in a future version.")]
 public interface IDataService :
     ICategoryRepository,
     ITransactionRepository,

--- a/Finanzuebersicht.Core/Services/IRecurringGenerationService.cs
+++ b/Finanzuebersicht.Core/Services/IRecurringGenerationService.cs
@@ -2,5 +2,5 @@ namespace Finanzuebersicht.Services;
 
 public interface IRecurringGenerationService
 {
-    Task GeneratePendingRecurringTransactionsAsync();
+    Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default);
 }

--- a/Finanzuebersicht.Core/Services/ISettingsService.cs
+++ b/Finanzuebersicht.Core/Services/ISettingsService.cs
@@ -1,0 +1,29 @@
+namespace Finanzuebersicht.Services;
+
+/// <summary>
+/// Abstraction over settings persistence. Decouples ViewModels and services
+/// from the concrete file-based implementation, enabling testability.
+/// </summary>
+public interface ISettingsService
+{
+    /// <summary>Gets a setting value. Returns <paramref name="defaultValue"/> if not found.</summary>
+    string Get(string key, string defaultValue = "");
+
+    /// <summary>Sets a setting value and persists asynchronously in the background.</summary>
+    void Set(string key, string value);
+
+    string GetBackupPath();
+    void SetBackupPath(string path);
+
+    DateTime? GetLastBackupTime();
+    void SetLastBackupTime(DateTime time);
+
+    bool IsAutoBackupEnabled();
+    void SetAutoBackupEnabled(bool enabled);
+
+    string GetBackupFrequency();
+    void SetBackupFrequency(string frequency);
+
+    int GetMaxBackupsToKeep();
+    void SetMaxBackupsToKeep(int max);
+}

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -25,200 +25,242 @@ namespace Finanzuebersicht.Services
         private readonly ICategoryRepository? _categoryRepository = categoryRepository;
         private readonly CategorizationService? _categorizationService = categorizationService;
 
-        public async System.Threading.Tasks.Task<IEnumerable<Transaction>> ImportFromCsvAsync(System.IO.Stream csvStream, string? accountId = null, System.Threading.CancellationToken cancellationToken = default)
+        public async System.Threading.Tasks.Task<ImportResult> ImportFromCsvAsync(
+            System.IO.Stream csvStream,
+            string? accountId = null,
+            System.Threading.CancellationToken cancellationToken = default)
         {
+            cancellationToken.ThrowIfCancellationRequested();
+            _logger.LogInformation("ImportService: starting import (accountId={AccountId})", accountId ?? "(none)");
+
+            // 1. Read stream into memory
+            byte[] buffer;
             try
             {
-                _logger?.LogInformation("ImportService: starting import (accountId={AccountId})", accountId ?? "(none)");
-                try { FileLogger.Append("ImportService", $"starting import (accountId={accountId ?? "(none)"})"); } catch { }
+                using var ms = new MemoryStream();
+                await csvStream.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
+                buffer = ms.ToArray();
+                _logger.LogDebug("ImportService: read input stream {Bytes} bytes", buffer.Length);
+            }
+            catch (OperationCanceledException)
+            {
+                throw;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex, "ImportService: failed to read input stream");
+                return new ImportResult { ErrorMessage = $"Fehler beim Lesen der Datei: {ex.Message}" };
+            }
 
-                if (_transactionRepository == null)
-                {
-                    _logger?.LogError("ImportService: ITransactionRepository is null - cannot persist transactions");
-                    return [];
-                }
+            // 2. Find a parser that returns records
+            var parserList = _parsers?.ToList() ?? [];
+            _logger.LogInformation("ImportService: available parsers={Count}", parserList.Count);
 
-                // read incoming stream fully into memory to avoid platform-specific SecurityScopedStream issues
-                byte[] buffer;
+            List<TransactionDto>? dtosList = null;
+            foreach (var parser in parserList)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                using var parserStream = new MemoryStream(buffer, writable: false);
                 try
                 {
-                    using var ms = new MemoryStream();
-                    await csvStream.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
-                    buffer = ms.ToArray();
-                    try { FileLogger.Append("ImportService", $"read input stream {buffer.Length} bytes"); } catch { }
+                    dtosList = parser.Parse(parserStream)?.ToList();
                 }
-                catch (System.Exception ex)
+                catch (Exception ex)
                 {
-                    _logger?.LogError(ex, "ImportService: failed to read input stream");
-                    try { FileLogger.Append("ImportService", "failed to read input stream", ex); } catch { }
-                    return [];
+                    _logger.LogWarning(ex, "ImportService: parser {Parser} threw during Parse", parser.GetType().Name);
+                    dtosList = null;
+                    continue;
                 }
 
-                var parserList = _parsers?.ToList() ?? [];
-                _logger?.LogInformation("ImportService: available parsers={Count}", parserList.Count);
-
-                // Choose parser by heuristics: try each parser until one returns non-empty
-                foreach (var p in parserList)
+                if (dtosList is { Count: > 0 })
                 {
-                    // create a fresh MemoryStream for each parser so parser disposal won't affect other attempts
-                    using var parserStream = new MemoryStream(buffer, writable: false);
-                    List<TransactionDto>? dtosList = null;
-                    try
-                    {
-                        // materialize results within the using block so parser can dispose the reader/stream safely
-                        dtosList = p.Parse(parserStream)?.ToList();
-                    }
-                    catch (System.Exception ex)
-                    {
-                        _logger?.LogWarning(ex, "ImportService: parser {Parser} threw during Parse", p.GetType().FullName);
-                        try { FileLogger.Append("ImportService", $"parser {p.GetType().FullName} threw during Parse", ex); } catch { }
-                        continue;
-                    }
-
-                    var count = dtosList?.Count ?? 0;
-                    _logger?.LogInformation("ImportService: parser {Parser} returned {Count} records", p.GetType().FullName, count);
-                    try { FileLogger.Append("ImportService", $"parser {p.GetType().FullName} returned {count} records"); } catch { }
-
-                    if (dtosList != null && dtosList.Count != 0)
-                    {
-                        var importedTransactions = new List<Transaction>();
-
-                        foreach (var importedRecord in dtosList)
-                        {
-                            cancellationToken.ThrowIfCancellationRequested();
-                            if (importedRecord == null)
-                            {
-                                _logger?.LogWarning("ImportService: skipping null DTO");
-                                continue;
-                            }
-
-                            if (importedRecord.Buchungsdatum == default)
-                            {
-                                _logger?.LogWarning("ImportService: skipping malformed DTO with empty Buchungsdatum: {Dto}", importedRecord);
-                                continue; // skip malformed rows
-                            }
-
-                            var title = !string.IsNullOrWhiteSpace(importedRecord.Zahlungsempfaenger)
-                                ? importedRecord.Zahlungsempfaenger
-                                : !string.IsNullOrWhiteSpace(importedRecord.Zahlungspflichtige)
-                                    ? importedRecord.Zahlungspflichtige
-                                    : importedRecord.Verwendungszweck;
-
-                            var finalTitle = string.IsNullOrWhiteSpace(title) ? (string.IsNullOrWhiteSpace(importedRecord.Verwendungszweck) ? $"Buchung {importedRecord.Buchungsdatum:dd.MM.yyyy} {importedRecord.Betrag:0.00}€" : importedRecord.Verwendungszweck) : title;
-                            var transaction = new Transaction
-                            {
-                                Betrag = importedRecord.Betrag,
-                                Datum = importedRecord.Buchungsdatum,
-                                Titel = finalTitle,
-                                Verwendungszweck = importedRecord.Verwendungszweck ?? string.Empty,
-                                KategorieId = string.Empty,
-                                Typ = importedRecord.Betrag >= 0 ? TransactionType.Einnahme : TransactionType.Ausgabe,
-                                AccountId = accountId ?? importedRecord.SourceAccountId
-                            };
-
-                            // Improved duplicate check: look for nearby dates (+/-1 day) with same amount and normalized title
-                            bool isDuplicate = false;
-                            try
-                            {
-                                var from = importedRecord.Buchungsdatum.Date.AddDays(-1);
-                                var to = importedRecord.Buchungsdatum.Date.AddDays(1);
-                                var existing = await _transactionRepository.GetTransactionsAsync(from, to).ConfigureAwait(false);
-                                if (existing != null && existing.Any(e => e.Datum.Date >= from && e.Datum.Date <= to && e.Betrag == importedRecord.Betrag && Normalize(e.Titel) == Normalize(title)))
-                                {
-                                    isDuplicate = true;
-                                    _logger?.LogInformation("ImportService: duplicate detected for '{Title}' amount {Amount} on {Date}", title, importedRecord.Betrag, importedRecord.Buchungsdatum);
-                                }
-                            }
-                            catch (System.Exception ex)
-                            {
-                                _logger?.LogWarning(ex, "ImportService: duplicate check failed");
-                                 try { FileLogger.Append("ImportService", "duplicate check failed", ex); } catch { }
-                            }
-
-                            if (!isDuplicate)
-                            {
-                                // Auto-categorize using CategorizationService if available
-                                if (_categorizationService != null && _categoryRepository != null && string.IsNullOrWhiteSpace(transaction.KategorieId))
-                                {
-                                    try
-                                    {
-                                        var categories = await _categoryRepository.GetCategoriesAsync().ConfigureAwait(false);
-                                        if (categories != null && categories.Count > 0)
-                                        {
-                                            var category = await _categorizationService.CategorizAsync(importedRecord, categories, cancellationToken).ConfigureAwait(false);
-                                            if (category != null)
-                                            {
-                                                transaction.KategorieId = category.Id;
-                                                _logger?.LogInformation("ImportService: auto-categorized '{Title}' → {Category}", transaction.Titel, category.Name);
-                                            }
-                                        }
-                                    }
-                                    catch (System.Exception ex)
-                                    {
-                                        _logger?.LogWarning(ex, "ImportService: categorization failed, falling back to Unkategorisiert");
-                                        try { FileLogger.Append("ImportService", "categorization failed, using fallback", ex); } catch { }
-                                    }
-                                }
-
-                                // Fallback: ensure an "Unkategorisiert" category exists if still no category assigned
-                                if (_categoryRepository != null && string.IsNullOrWhiteSpace(transaction.KategorieId))
-                                {
-                                    try
-                                    {
-                                        var categories = await _categoryRepository.GetCategoriesAsync().ConfigureAwait(false);
-                                        var unclassifiedCategory = categories?.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert || c.Name == "Unkategorisiert");
-                                        if (unclassifiedCategory == null)
-                                        {
-                                            unclassifiedCategory = new Finanzuebersicht.Models.Category
-                                            {
-                                                Name = "Unkategorisiert",
-                                                Icon = "❓",
-                                                Color = "#A2845E",
-                                                Typ = Finanzuebersicht.Models.TransactionType.Ausgabe,
-                                                SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert
-                                            };
-                                            await _categoryRepository.SaveCategoryAsync(unclassifiedCategory).ConfigureAwait(false);
-                                            try { FileLogger.Append("ImportService", "created default 'Unkategorisiert' category"); } catch { }
-                                        }
-
-                                        if (unclassifiedCategory != null)
-                                            transaction.KategorieId = unclassifiedCategory.Id;
-                                    }
-                                    catch (System.Exception ex)
-                                    {
-                                        _logger?.LogWarning(ex, "ImportService: failed to ensure default category");
-                                    }
-                                }
-
-                                importedTransactions.Add(transaction);
-
-                                // persist using repository API (SaveTransactionAsync)
-                                try
-                                {
-                                    await _transactionRepository.SaveTransactionAsync(transaction).ConfigureAwait(false);
-                                    _logger?.LogInformation("ImportService: saved transaction '{Title}' amount {Amount} on {Date}", transaction.Titel, transaction.Betrag, transaction.Datum);
-                                }
-                                catch (System.Exception ex)
-                                {
-                                    _logger?.LogError(ex, "ImportService: failed to save transaction {Title} amount {Amount} on {Date}", transaction.Titel, transaction.Betrag, transaction.Datum);
-                                         try { FileLogger.Append("ImportService", $"failed to save transaction {transaction.Titel} amount {transaction.Betrag} on {transaction.Datum}", ex); } catch { }
-                                }
-                            }
-                        }
-
-                        _logger?.LogInformation("ImportService: finished importing {Count} transactions", importedTransactions.Count);
-                        return importedTransactions;
-                    }
+                    _logger.LogInformation("ImportService: parser {Parser} matched with {Count} records",
+                        parser.GetType().Name, dtosList.Count);
+                    break;
                 }
 
-                _logger?.LogInformation("ImportService: no parser matched or no records found");
-                return [];
+                dtosList = null;
             }
-            catch (System.Exception ex)
+
+            if (dtosList is null or { Count: 0 })
             {
-                _logger?.LogError(ex, "ImportService: unexpected error during import");
-                try { FileLogger.Append("ImportService", "unexpected error during import", ex); } catch { }
-                throw;
+                _logger.LogInformation("ImportService: no parser matched or no records found");
+                return new ImportResult { ErrorMessage = "Kein passender Parser gefunden oder keine Datensätze in der Datei." };
+            }
+
+            // 3. Validate and build transaction list (no saves yet)
+            var toImport = new List<Transaction>();
+            var duplicates = new List<Transaction>();
+            var skippedMalformed = 0;
+
+            foreach (var dto in dtosList)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                if (dto is null || dto.Buchungsdatum == default)
+                {
+                    skippedMalformed++;
+                    _logger.LogDebug("ImportService: skipping malformed DTO");
+                    continue;
+                }
+
+                var title = BuildTitle(dto);
+                var transaction = new Transaction
+                {
+                    Betrag = dto.Betrag,
+                    Datum = dto.Buchungsdatum,
+                    Titel = title,
+                    Verwendungszweck = dto.Verwendungszweck ?? string.Empty,
+                    KategorieId = string.Empty,
+                    Typ = dto.Betrag >= 0 ? TransactionType.Einnahme : TransactionType.Ausgabe,
+                    AccountId = accountId ?? dto.SourceAccountId
+                };
+
+                // Duplicate check
+                bool isDuplicate = false;
+                try
+                {
+                    var from = dto.Buchungsdatum.Date.AddDays(-1);
+                    var to = dto.Buchungsdatum.Date.AddDays(1);
+                    var existing = await _transactionRepository.GetTransactionsAsync(from, to).ConfigureAwait(false);
+                    isDuplicate = existing?.Any(e =>
+                        e.Datum.Date >= from && e.Datum.Date <= to &&
+                        e.Betrag == dto.Betrag &&
+                        Normalize(e.Titel) == Normalize(title)) ?? false;
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "ImportService: duplicate check failed for '{Title}'", title);
+                    // On duplicate check failure, treat as non-duplicate (safer: import rather than lose data)
+                }
+
+                if (isDuplicate)
+                {
+                    _logger.LogDebug("ImportService: duplicate detected for '{Title}' {Amount} on {Date}",
+                        title, dto.Betrag, dto.Buchungsdatum);
+                    duplicates.Add(transaction);
+                    continue;
+                }
+
+                // Auto-categorize
+                transaction.KategorieId = await ResolveCategoryAsync(dto, transaction, cancellationToken)
+                    .ConfigureAwait(false);
+
+                toImport.Add(transaction);
+            }
+
+            // 4. Save all valid transactions (bulk — fail individually but continue for others)
+            var saveErrors = new List<string>();
+            var imported = new List<Transaction>();
+
+            foreach (var transaction in toImport)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                try
+                {
+                    await _transactionRepository.SaveTransactionAsync(transaction).ConfigureAwait(false);
+                    imported.Add(transaction);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "ImportService: failed to save transaction '{Title}' {Amount} on {Date}",
+                        transaction.Titel, transaction.Betrag, transaction.Datum);
+                    saveErrors.Add($"{transaction.Titel} ({transaction.Datum:dd.MM.yyyy}): {ex.Message}");
+                }
+            }
+
+            _logger.LogInformation(
+                "ImportService: finished — imported={I}, duplicates={D}, malformed={M}, saveErrors={E}",
+                imported.Count, duplicates.Count, skippedMalformed, saveErrors.Count);
+
+            return new ImportResult
+            {
+                Imported = imported,
+                Duplicates = duplicates,
+                SkippedMalformed = skippedMalformed,
+                SaveErrors = saveErrors,
+            };
+        }
+
+        private static string BuildTitle(TransactionDto dto)
+        {
+            var title = !string.IsNullOrWhiteSpace(dto.Zahlungsempfaenger)
+                ? dto.Zahlungsempfaenger
+                : !string.IsNullOrWhiteSpace(dto.Zahlungspflichtige)
+                    ? dto.Zahlungspflichtige
+                    : dto.Verwendungszweck;
+
+            return string.IsNullOrWhiteSpace(title)
+                ? (string.IsNullOrWhiteSpace(dto.Verwendungszweck)
+                    ? $"Buchung {dto.Buchungsdatum:dd.MM.yyyy} {dto.Betrag:0.00}€"
+                    : dto.Verwendungszweck)
+                : title;
+        }
+
+        private async System.Threading.Tasks.Task<string> ResolveCategoryAsync(
+            TransactionDto dto,
+            Transaction transaction,
+            CancellationToken cancellationToken)
+        {
+            if (_categoryRepository is null)
+                return string.Empty;
+
+            List<Category>? categories = null;
+            try
+            {
+                categories = await _categoryRepository.GetCategoriesAsync().ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to load categories for auto-categorization");
+                return string.Empty;
+            }
+
+            if (categories is { Count: > 0 } && _categorizationService is not null)
+            {
+                try
+                {
+                    var category = await _categorizationService
+                        .CategorizAsync(dto, categories, cancellationToken).ConfigureAwait(false);
+                    if (category is not null)
+                    {
+                        _logger.LogDebug("ImportService: auto-categorized '{Title}' → {Category}",
+                            transaction.Titel, category.Name);
+                        return category.Id;
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "ImportService: categorization failed for '{Title}'", transaction.Titel);
+                }
+            }
+
+            // Fallback to "Unkategorisiert" system category
+            try
+            {
+                var unclassified = categories?.FirstOrDefault(c =>
+                    c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert ||
+                    c.Name == "Unkategorisiert");
+
+                if (unclassified is null)
+                {
+                    unclassified = new Category
+                    {
+                        Name = "Unkategorisiert",
+                        Icon = "❓",
+                        Color = "#A2845E",
+                        Typ = TransactionType.Ausgabe,
+                        SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert
+                    };
+                    await _categoryRepository.SaveCategoryAsync(unclassified).ConfigureAwait(false);
+                }
+
+                return unclassified.Id;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to ensure default category");
+                return string.Empty;
             }
         }
 
@@ -226,17 +268,14 @@ namespace Finanzuebersicht.Services
         {
             if (string.IsNullOrWhiteSpace(input)) return string.Empty;
             var lowered = input.Trim().ToLowerInvariant();
-            // remove diacritics
             var normalized = lowered.Normalize(NormalizationForm.FormD);
             var sb = new StringBuilder();
             foreach (var c in normalized)
             {
-                var uc = CharUnicodeInfo.GetUnicodeCategory(c);
-                if (uc != UnicodeCategory.NonSpacingMark)
+                if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
                     sb.Append(c);
             }
             var cleaned = new string([.. sb.ToString().Where(c => char.IsLetterOrDigit(c) || char.IsWhiteSpace(c))]);
-            // collapse whitespace
             return Regex.Replace(cleaned, "\\s+", " ").Trim();
         }
     }

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -93,18 +93,27 @@ namespace Finanzuebersicht.Services
             var duplicates = new List<Transaction>();
             var skippedMalformed = 0;
 
-            // Load existing transactions once for the full import date range (avoids N+1 queries)
+            // Load existing transactions once for the full import date range (avoids N+1 queries).
+            // Only consider DTOs with a valid Buchungsdatum — malformed ones (default/MinValue) are
+            // skipped later in the loop and must not distort the date range.
             List<Transaction>? existingInRange = null;
-            try
+            var validDates = dtosList
+                .Where(d => d?.Buchungsdatum != null && d.Buchungsdatum != default)
+                .Select(d => d!.Buchungsdatum)
+                .ToList();
+            if (validDates.Count > 0)
             {
-                var minDate = dtosList.Min(d => d?.Buchungsdatum ?? DateTime.MaxValue).Date.AddDays(-1);
-                var maxDate = dtosList.Max(d => d?.Buchungsdatum ?? DateTime.MinValue).Date.AddDays(1);
-                existingInRange = await _transactionRepository
-                    .GetTransactionsAsync(minDate, maxDate).ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "ImportService: failed to load existing transactions for duplicate check; duplicates won't be detected");
+                try
+                {
+                    var minDate = validDates.Min().Date.AddDays(-1);
+                    var maxDate = validDates.Max().Date.AddDays(1);
+                    existingInRange = await _transactionRepository
+                        .GetTransactionsAsync(minDate, maxDate).ConfigureAwait(false);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogWarning(ex, "ImportService: failed to load existing transactions for duplicate check; duplicates won't be detected");
+                }
             }
 
             foreach (var dto in dtosList)

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -212,8 +212,8 @@ namespace Finanzuebersicht.Services
             }
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "ImportService: failed to load categories for auto-categorization");
-                return string.Empty;
+                _logger.LogWarning(ex, "ImportService: failed to load categories for auto-categorization; attempting Unkategorisiert fallback");
+                // categories stays null — fall through to Unkategorisiert fallback below
             }
 
             if (categories is { Count: > 0 } && _categorizationService is not null)

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -93,6 +93,20 @@ namespace Finanzuebersicht.Services
             var duplicates = new List<Transaction>();
             var skippedMalformed = 0;
 
+            // Load existing transactions once for the full import date range (avoids N+1 queries)
+            List<Transaction>? existingInRange = null;
+            try
+            {
+                var minDate = dtosList.Min(d => d?.Buchungsdatum ?? DateTime.MaxValue).Date.AddDays(-1);
+                var maxDate = dtosList.Max(d => d?.Buchungsdatum ?? DateTime.MinValue).Date.AddDays(1);
+                existingInRange = await _transactionRepository
+                    .GetTransactionsAsync(minDate, maxDate).ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to load existing transactions for duplicate check; duplicates won't be detected");
+            }
+
             foreach (var dto in dtosList)
             {
                 cancellationToken.ThrowIfCancellationRequested();
@@ -116,22 +130,16 @@ namespace Finanzuebersicht.Services
                     AccountId = accountId ?? dto.SourceAccountId
                 };
 
-                // Duplicate check
+                // Duplicate check (against in-memory snapshot loaded once before the loop)
                 bool isDuplicate = false;
-                try
+                if (existingInRange is not null)
                 {
                     var from = dto.Buchungsdatum.Date.AddDays(-1);
                     var to = dto.Buchungsdatum.Date.AddDays(1);
-                    var existing = await _transactionRepository.GetTransactionsAsync(from, to).ConfigureAwait(false);
-                    isDuplicate = existing?.Any(e =>
+                    isDuplicate = existingInRange.Any(e =>
                         e.Datum.Date >= from && e.Datum.Date <= to &&
                         e.Betrag == dto.Betrag &&
-                        Normalize(e.Titel) == Normalize(title)) ?? false;
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "ImportService: duplicate check failed for '{Title}'", title);
-                    // On duplicate check failure, treat as non-duplicate (safer: import rather than lose data)
+                        Normalize(e.Titel) == Normalize(title));
                 }
 
                 if (isDuplicate)

--- a/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
+++ b/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
@@ -15,13 +15,15 @@ public class RecurringGenerationService(
     private readonly ILogger<RecurringGenerationService>? _logger = logger;
     private const int MaxInstancesPerRun = 500;
 
-    public async Task GeneratePendingRecurringTransactionsAsync()
+    public async Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default)
     {
         var recurringItems = await _recurringRepository.GetRecurringTransactionsAsync();
         var today = _clock.Today;
 
         foreach (var recurring in recurringItems.Where(item => item.Aktiv))
         {
+            cancellationToken.ThrowIfCancellationRequested();
+
             if (recurring.Enddatum.HasValue && recurring.Enddatum.Value < today)
                 continue;
 
@@ -40,7 +42,7 @@ public class RecurringGenerationService(
             // determine the first instance to consider
             var candidate = !recurring.LetzteAusfuehrung.HasValue
                 ? recurring.Startdatum
-                : GetNextInstance(recurring, recurring.LetzteAusfuehrung.Value);
+                : RecurringScheduleCalculator.GetNextInstance(recurring, recurring.LetzteAusfuehrung.Value);
 
             while (candidate <= today && generatedCount < MaxInstancesPerRun)
             {
@@ -50,7 +52,7 @@ public class RecurringGenerationService(
                 {
                     // mark as executed (skip this instance)
                     recurring.LetzteAusfuehrung = candidate;
-                    candidate = GetNextInstance(recurring, candidate);
+                    candidate = RecurringScheduleCalculator.GetNextInstance(recurring, candidate);
                     continue;
                 }
 
@@ -59,11 +61,6 @@ public class RecurringGenerationService(
                 {
                     transactionDate = exception.ShiftToDate.Value.Date;
                 }
-
-                // Previously we skipped generating transactions whose effective date
-                // was in the future (e.g., a Shift into the future). Create the
-                // transaction regardless of whether the effective date is in the
-                // future so that shifted instances are materialized as expected by tests.
 
                 var transaction = new Transaction
                 {
@@ -80,7 +77,7 @@ public class RecurringGenerationService(
 
                 // mark this instance as last executed (use the template instance date)
                 recurring.LetzteAusfuehrung = candidate;
-                candidate = GetNextInstance(recurring, candidate);
+                candidate = RecurringScheduleCalculator.GetNextInstance(recurring, candidate);
             }
 
             // Warn if the limit was hit and instances are still pending
@@ -97,29 +94,9 @@ public class RecurringGenerationService(
         }
     }
 
-    private DateTime GetNextInstance(RecurringTransaction recurring, DateTime fromDate)
-    {
-        // Calculate the next instance date after fromDate according to Interval and IntervalFactor
-        var factor = Math.Max(1, recurring.IntervalFactor);
-
-        return recurring.Interval switch
-        {
-            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7L * factor),
-            RecurrenceInterval.Monthly => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
-            RecurrenceInterval.Quarterly => AddMonthsPreserveDay(fromDate.Date, 3 * factor),
-            RecurrenceInterval.Yearly => AddMonthsPreserveDay(fromDate.Date, 12 * factor),
-            RecurrenceInterval.Daily => fromDate.Date.AddDays(1 * factor),
-            _ => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
-        };
-    }
+    private static DateTime GetNextInstance(RecurringTransaction recurring, DateTime fromDate)
+        => RecurringScheduleCalculator.GetNextInstance(recurring, fromDate);
 
     private static DateTime AddMonthsPreserveDay(DateTime date, int months)
-    {
-        var target = date.AddMonths(months);
-        var day = date.Day;
-        var daysInTarget = DateTime.DaysInMonth(target.Year, target.Month);
-        if (day > daysInTarget)
-            day = daysInTarget;
-        return new DateTime(target.Year, target.Month, day);
-    }
+        => RecurringScheduleCalculator.AddMonthsPreserveDay(date, months);
 }

--- a/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
+++ b/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
@@ -40,16 +40,28 @@ public static class RecurringScheduleCalculator
         if (recurring.Exceptions is null || recurring.Exceptions.Count == 0)
             return adjusted;
 
-        var exception = recurring.Exceptions.FirstOrDefault(e => e.InstanceDate.Date == adjusted);
-        if (exception is null)
-            return adjusted;
-
-        return exception.Type switch
+        // Loop to handle consecutive Skip exceptions (e.g. two back-to-back skipped dates).
+        // Upper bound prevents infinite loops for pathological configurations.
+        const int maxIterations = 366;
+        for (int i = 0; i < maxIterations; i++)
         {
-            RecurringExceptionType.Skip => GetNextInstance(recurring, adjusted),
-            RecurringExceptionType.Shift when exception.ShiftToDate.HasValue => exception.ShiftToDate.Value.Date,
-            _ => adjusted,
-        };
+            var exception = recurring.Exceptions.FirstOrDefault(e => e.InstanceDate.Date == adjusted);
+            if (exception is null)
+                return adjusted;
+
+            switch (exception.Type)
+            {
+                case RecurringExceptionType.Skip:
+                    adjusted = GetNextInstance(recurring, adjusted);
+                    break;
+                case RecurringExceptionType.Shift when exception.ShiftToDate.HasValue:
+                    return exception.ShiftToDate.Value.Date;
+                default:
+                    return adjusted;
+            }
+        }
+
+        return adjusted; // safety fallback
     }
 
     /// <summary>

--- a/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
+++ b/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
@@ -20,7 +20,7 @@ public static class RecurringScheduleCalculator
         return recurring.Interval switch
         {
             RecurrenceInterval.Daily => fromDate.Date.AddDays(1 * factor),
-            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7L * factor),
+            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7 * factor),
             RecurrenceInterval.Monthly => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
             RecurrenceInterval.Quarterly => AddMonthsPreserveDay(fromDate.Date, 3 * factor),
             RecurrenceInterval.Yearly => AddMonthsPreserveDay(fromDate.Date, 12 * factor),
@@ -41,7 +41,8 @@ public static class RecurringScheduleCalculator
             return adjusted;
 
         // Loop to handle consecutive Skip exceptions (e.g. two back-to-back skipped dates).
-        // Upper bound prevents infinite loops for pathological configurations.
+        // 366 = max days in a leap year; handles the worst-case of a daily recurring with
+        // a full year of consecutive Skips before finding a non-excepted date.
         const int maxIterations = 366;
         for (int i = 0; i < maxIterations; i++)
         {

--- a/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
+++ b/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
@@ -1,0 +1,106 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Services;
+
+/// <summary>
+/// Pure domain component for calculating recurring transaction schedules.
+/// Single source of truth for: next-due calculation, exception application,
+/// and active-range checks. Used by both <see cref="RecurringGenerationService"/>
+/// and <c>GetDueRecurringWithHintsUseCase</c>.
+/// </summary>
+public static class RecurringScheduleCalculator
+{
+    /// <summary>
+    /// Returns the next instance date after <paramref name="fromDate"/> based on
+    /// the recurring transaction's interval and intervalFactor.
+    /// </summary>
+    public static DateTime GetNextInstance(RecurringTransaction recurring, DateTime fromDate)
+    {
+        var factor = Math.Max(1, recurring.IntervalFactor);
+        return recurring.Interval switch
+        {
+            RecurrenceInterval.Daily => fromDate.Date.AddDays(1 * factor),
+            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7L * factor),
+            RecurrenceInterval.Monthly => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
+            RecurrenceInterval.Quarterly => AddMonthsPreserveDay(fromDate.Date, 3 * factor),
+            RecurrenceInterval.Yearly => AddMonthsPreserveDay(fromDate.Date, 12 * factor),
+            _ => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
+        };
+    }
+
+    /// <summary>
+    /// Applies any defined Skip or Shift exceptions to <paramref name="candidate"/>.
+    /// Returns the effective date after applying exceptions.
+    /// For a Skip, advances to the next instance. For a Shift with a ShiftToDate, returns that date.
+    /// </summary>
+    public static DateTime ApplyExceptions(RecurringTransaction recurring, DateTime candidate)
+    {
+        var adjusted = candidate.Date;
+
+        if (recurring.Exceptions is null || recurring.Exceptions.Count == 0)
+            return adjusted;
+
+        var exception = recurring.Exceptions.FirstOrDefault(e => e.InstanceDate.Date == adjusted);
+        if (exception is null)
+            return adjusted;
+
+        return exception.Type switch
+        {
+            RecurringExceptionType.Skip => GetNextInstance(recurring, adjusted),
+            RecurringExceptionType.Shift when exception.ShiftToDate.HasValue => exception.ShiftToDate.Value.Date,
+            _ => adjusted,
+        };
+    }
+
+    /// <summary>
+    /// Returns true if <paramref name="referenceDate"/> falls within the active range of
+    /// the recurring transaction (accounting for ReminderDaysBefore and Enddatum).
+    /// </summary>
+    public static bool IsWithinActiveRange(RecurringTransaction recurring, DateTime referenceDate)
+    {
+        var reference = referenceDate.Date;
+        var start = recurring.Startdatum.Date;
+
+        if (reference < start.AddDays(-recurring.ReminderDaysBefore))
+            return false;
+
+        if (recurring.Enddatum.HasValue && reference > recurring.Enddatum.Value.Date)
+            return false;
+
+        return true;
+    }
+
+    /// <summary>
+    /// Calculates the next due date for a recurring transaction relative to
+    /// <paramref name="referenceDate"/>, with exceptions applied.
+    /// Returns null if the transaction is not active or outside its date range.
+    /// </summary>
+    public static DateTime? GetNextDueDate(RecurringTransaction recurring, DateTime referenceDate)
+    {
+        if (!recurring.Aktiv || !IsWithinActiveRange(recurring, referenceDate))
+            return null;
+
+        var candidate = recurring.LetzteAusfuehrung.HasValue
+            ? GetNextInstance(recurring, recurring.LetzteAusfuehrung.Value)
+            : recurring.Startdatum.Date;
+
+        while (candidate.Date < referenceDate.Date)
+            candidate = GetNextInstance(recurring, candidate);
+
+        return ApplyExceptions(recurring, candidate);
+    }
+
+    /// <summary>
+    /// Adds months to a date while clamping the day to the last day of the target month.
+    /// For example, Jan 31 + 1 month = Feb 28 (or 29 in a leap year).
+    /// </summary>
+    public static DateTime AddMonthsPreserveDay(DateTime date, int months)
+    {
+        var target = date.AddMonths(months);
+        var day = date.Day;
+        var daysInTarget = DateTime.DaysInMonth(target.Year, target.Month);
+        if (day > daysInTarget)
+            day = daysInTarget;
+        return new DateTime(target.Year, target.Month, day);
+    }
+}

--- a/Finanzuebersicht.Core/Services/SettingsService.cs
+++ b/Finanzuebersicht.Core/Services/SettingsService.cs
@@ -7,8 +7,9 @@ namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Verwaltet App-Einstellungen als Key-Value-Paare (JSON-Datei).
+/// File-I/O beim Speichern erfolgt asynchron im Hintergrund um den UI-Thread nicht zu blockieren.
 /// </summary>
-public class SettingsService
+public class SettingsService : ISettingsService
 {
     private readonly string _settingsFile;
     private readonly ILogger<SettingsService>? _logger;

--- a/Finanzuebersicht.Core/Services/SettingsService.cs
+++ b/Finanzuebersicht.Core/Services/SettingsService.cs
@@ -7,7 +7,7 @@ namespace Finanzuebersicht.Services;
 
 /// <summary>
 /// Verwaltet App-Einstellungen als Key-Value-Paare (JSON-Datei).
-/// File-I/O beim Speichern erfolgt asynchron im Hintergrund um den UI-Thread nicht zu blockieren.
+/// Lese- und Schreibzugriffe sind thread-safe über einen internen Lock.
 /// </summary>
 public class SettingsService : ISettingsService
 {

--- a/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -11,7 +11,7 @@ public static class InfrastructureServiceCollectionExtensions
         // Helper to resolve data directory
         string GetDataDir(IServiceProvider sp)
         {
-            var settings = sp.GetRequiredService<SettingsService>();
+            var settings = sp.GetRequiredService<ISettingsService>();
             var customPath = settings.Get("DataPath", "");
             return string.IsNullOrWhiteSpace(customPath) ? AppPaths.GetDefaultDataDir() : customPath;
         }

--- a/Finanzuebersicht.Infrastructure/Services/JsonDataStoreBase.cs
+++ b/Finanzuebersicht.Infrastructure/Services/JsonDataStoreBase.cs
@@ -1,4 +1,5 @@
 using System.Text.Json;
+using Finanzuebersicht.Models;
 using Microsoft.Extensions.Logging;
 
 namespace Finanzuebersicht.Services;
@@ -27,8 +28,9 @@ public abstract class JsonDataStoreBase : IDisposable
     }
 
     /// <summary>
-    /// Loads a list of items from a JSON file. Returns empty list if file doesn't exist
-    /// or JSON is corrupted (with logged warning).
+    /// Loads a list of items from a JSON file. Returns an empty list if the file doesn't exist.
+    /// Throws <see cref="DataCorruptionException"/> if the file exists but cannot be parsed,
+    /// to prevent silent data loss from overwriting a corrupted file with an empty collection.
     /// </summary>
     protected async Task<List<T>> LoadAsync<T>(string path)
     {
@@ -42,8 +44,8 @@ public abstract class JsonDataStoreBase : IDisposable
         }
         catch (JsonException ex)
         {
-            Logger?.LogWarning(ex, "Error deserializing {Path}", path);
-            return [];
+            Logger?.LogError(ex, "Data file is corrupted and cannot be loaded: {Path}", path);
+            throw new DataCorruptionException(path, ex);
         }
     }
 

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -1,5 +1,6 @@
 using Finanzuebersicht.Models;
 
+#pragma warning disable CS0618 // IDataService is intentionally implemented here as the local storage adapter
 namespace Finanzuebersicht.Services;
 
 /// <summary>

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -46,7 +46,7 @@ public class LocalDataService : IDataService, IDisposable
     /// <summary>
     /// Alternative constructor for manual instantiation (e.g., in tests).
     /// </summary>
-    public LocalDataService(SettingsService? settings, IClock clock)
+    public LocalDataService(ISettingsService? settings, IClock clock)
     {
         var defaultDataDir = AppPaths.GetDefaultDataDir();
         var customPath = settings?.Get("DataPath", "");
@@ -127,8 +127,8 @@ public class LocalDataService : IDataService, IDisposable
 
     #region IRecurringGenerationService delegation
 
-    public async Task GeneratePendingRecurringTransactionsAsync()
-        => await _recurringGenerationService.GeneratePendingRecurringTransactionsAsync();
+    public async Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default)
+        => await _recurringGenerationService.GeneratePendingRecurringTransactionsAsync(cancellationToken);
 
     #endregion
 

--- a/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
@@ -1,0 +1,28 @@
+using Finanzuebersicht.ViewModels;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Finanzuebersicht.Presentation.DependencyInjection;
+
+public static class PresentationServiceCollectionExtensions
+{
+    public static IServiceCollection AddPresentationViewModels(this IServiceCollection services)
+    {
+        services.AddTransient<DashboardViewModel>();
+        services.AddTransient<CategoriesViewModel>();
+        services.AddTransient<CategoryDetailViewModel>();
+        services.AddTransient<TransactionsViewModel>();
+        services.AddTransient<TransactionDetailViewModel>();
+        services.AddTransient<RecurringTransactionsViewModel>();
+        services.AddTransient<RecurringTransactionDetailViewModel>();
+        services.AddTransient<RecurringInstanceShiftViewModel>();
+        services.AddTransient<AppearanceViewModel>();
+        services.AddTransient<StorageViewModel>();
+        services.AddTransient<BackupViewModel>();
+        services.AddTransient<AboutViewModel>();
+        services.AddTransient<SettingsViewModel>();
+        services.AddTransient<SparZieleViewModel>();
+        services.AddTransient<BackupListViewModel>();
+
+        return services;
+    }
+}

--- a/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
@@ -1,11 +1,23 @@
 using Finanzuebersicht.ViewModels;
 using Microsoft.Extensions.DependencyInjection;
+using System.Reflection;
 
 namespace Finanzuebersicht.Presentation.DependencyInjection;
 
 public static class PresentationServiceCollectionExtensions
 {
-    public static IServiceCollection AddPresentationViewModels(this IServiceCollection services)
+    /// <summary>
+    /// Registers all presentation ViewModels.
+    /// </summary>
+    /// <param name="services">The service collection.</param>
+    /// <param name="appAssembly">
+    /// The entry assembly of the host application, used by <see cref="AboutViewModel"/>
+    /// to display the correct version string. When <c>null</c>, falls back to
+    /// <see cref="Assembly.GetExecutingAssembly"/> (the Presentation assembly).
+    /// Pass <c>Assembly.GetExecutingAssembly()</c> from <c>MauiProgram</c> so the
+    /// MAUI app assembly version is shown on the About page.
+    /// </param>
+    public static IServiceCollection AddPresentationViewModels(this IServiceCollection services, Assembly? appAssembly = null)
     {
         services.AddTransient<DashboardViewModel>();
         services.AddTransient<CategoriesViewModel>();
@@ -18,7 +30,8 @@ public static class PresentationServiceCollectionExtensions
         services.AddTransient<AppearanceViewModel>();
         services.AddTransient<StorageViewModel>();
         services.AddTransient<BackupViewModel>();
-        services.AddTransient<AboutViewModel>();
+        services.AddTransient<AboutViewModel>(sp =>
+            new AboutViewModel(appAssembly, sp.GetService<Microsoft.Extensions.Logging.ILogger<AboutViewModel>>()));
         services.AddTransient<SettingsViewModel>();
         services.AddTransient<SparZieleViewModel>();
         services.AddTransient<BackupListViewModel>();

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -149,6 +149,8 @@ public static class ResourceKeys
     public const string Msg_RestoreSuccessTitle = nameof(Msg_RestoreSuccessTitle);
     public const string Msg_RestoreSuccessDesc = nameof(Msg_RestoreSuccessDesc);
     public const string Msg_RestoreFailedTitle = nameof(Msg_RestoreFailedTitle);
+    public const string Msg_RestoreInconsistentTitle = nameof(Msg_RestoreInconsistentTitle);
+    public const string Msg_RestoreInconsistentDesc = nameof(Msg_RestoreInconsistentDesc);
     public const string Msg_CSVExportedTitle = nameof(Msg_CSVExportedTitle);
     public const string Msg_CSVExportedBody = nameof(Msg_CSVExportedBody);
     public const string Msg_CSVExportFailedTitle = nameof(Msg_CSVExportFailedTitle);

--- a/Finanzuebersicht.Presentation/ViewModels/BackupListViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/BackupListViewModel.cs
@@ -87,6 +87,13 @@ public partial class BackupListViewModel : ObservableObject, IAutoLoadViewModel
                     _loc.GetString(ResourceKeys.Btn_OK));
                 await _navigationService.GoBackAsync();
             }
+            else if (result.DataMayBeInconsistent)
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_RestoreInconsistentTitle),
+                    _loc.GetString(ResourceKeys.Msg_RestoreInconsistentDesc),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+            }
             else
             {
                 await _dialogService.ShowAlertAsync(

--- a/Finanzuebersicht.Presentation/ViewModels/BackupListViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/BackupListViewModel.cs
@@ -9,7 +9,7 @@ namespace Finanzuebersicht.ViewModels;
 public partial class BackupListViewModel : ObservableObject, IAutoLoadViewModel
 {
     private readonly IBackupService _backupService;
-    private readonly SettingsService _settings;
+    private readonly ISettingsService _settings;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
     private readonly INavigationService _navigationService;
@@ -27,7 +27,7 @@ public partial class BackupListViewModel : ObservableObject, IAutoLoadViewModel
 
     public BackupListViewModel(
         IBackupService backupService,
-        SettingsService settings,
+        ISettingsService settings,
         IDialogService dialogService,
         ILocalizationService localizationService,
         INavigationService navigationService)

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/AppearanceViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/AppearanceViewModel.cs
@@ -6,7 +6,7 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class AppearanceViewModel : ObservableObject
 {
-    private readonly SettingsService _settings;
+    private readonly ISettingsService _settings;
     private readonly IThemeService _themeService;
     private readonly ILocalizationService _loc;
 
@@ -17,7 +17,7 @@ public partial class AppearanceViewModel : ObservableObject
     private int selectedLanguageIndex;
 
     public AppearanceViewModel(
-        SettingsService settings,
+        ISettingsService settings,
         IThemeService themeService,
         ILocalizationService localizationService)
     {

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/BackupViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/BackupViewModel.cs
@@ -9,7 +9,7 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class BackupViewModel : ObservableObject
 {
-    private readonly SettingsService _settings;
+    private readonly ISettingsService _settings;
     private readonly IBackupService? _backupService;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
@@ -22,7 +22,7 @@ public partial class BackupViewModel : ObservableObject
     private string lastBackupInfo = string.Empty;
 
     public BackupViewModel(
-        SettingsService settings,
+        ISettingsService settings,
         IBackupService? backupService,
         IDialogService dialogService,
         ILocalizationService localizationService,

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/StorageViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/StorageViewModel.cs
@@ -7,7 +7,7 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class StorageViewModel : ObservableObject
 {
-    private readonly SettingsService _settings;
+    private readonly ISettingsService _settings;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
     private readonly IFolderPicker? _folderPicker;
@@ -16,7 +16,7 @@ public partial class StorageViewModel : ObservableObject
     private string dataPath = string.Empty;
 
     public StorageViewModel(
-        SettingsService settings,
+        ISettingsService settings,
         IDialogService dialogService,
         ILocalizationService localizationService,
         IFolderPicker? folderPicker = null)

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -406,12 +406,29 @@ public partial class TransactionsViewModel(
             if (result == null) return;
 
             using var stream = await result.OpenReadAsync();
-            var imported = await _importService.ImportFromCsvAsync(stream);
-            var count = imported?.Count() ?? 0;
+            var importResult = await _importService.ImportFromCsvAsync(stream);
 
             var titleDone = _loc?.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Msg_ImportAbgeschlossen_Title) ?? "Import abgeschlossen";
-            var importedMsg = string.Format(_loc?.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Msg_ImportiertCount) ?? "Importiert: {0} Transaktionen", count);
             var okBtn = _loc?.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Btn_OK) ?? "OK";
+
+            string importedMsg;
+            if (!importResult.Success)
+            {
+                importedMsg = importResult.ErrorMessage ?? "Unbekannter Fehler beim Import.";
+            }
+            else
+            {
+                importedMsg = string.Format(
+                    _loc?.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Msg_ImportiertCount) ?? "Importiert: {0} Transaktionen",
+                    importResult.Imported.Count);
+
+                if (importResult.Duplicates.Count > 0)
+                    importedMsg += $"\n{importResult.Duplicates.Count} Duplikate übersprungen";
+                if (importResult.SkippedMalformed > 0)
+                    importedMsg += $"\n{importResult.SkippedMalformed} fehlerhafte Zeilen übersprungen";
+                if (importResult.SaveErrors.Count > 0)
+                    importedMsg += $"\n{importResult.SaveErrors.Count} Transaktionen konnten nicht gespeichert werden";
+            }
 
             if (_dialogService != null)
             {

--- a/Finanzuebersicht.Tests/Core/Services/RecurringScheduleCalculatorTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/RecurringScheduleCalculatorTests.cs
@@ -1,0 +1,207 @@
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Tests.Core.Services;
+
+public class RecurringScheduleCalculatorTests
+{
+    private static RecurringTransaction Make(
+        RecurrenceInterval interval,
+        int factor = 1,
+        DateTime? start = null,
+        DateTime? lastRun = null,
+        DateTime? end = null,
+        int reminderDays = 0,
+        List<RecurringException>? exceptions = null) => new()
+    {
+        Id = "r1",
+        Titel = "Test",
+        Betrag = 10m,
+        Interval = interval,
+        IntervalFactor = factor,
+        Startdatum = start ?? new DateTime(2025, 1, 1),
+        LetzteAusfuehrung = lastRun,
+        Enddatum = end,
+        ReminderDaysBefore = reminderDays,
+        Aktiv = true,
+        Exceptions = exceptions ?? [],
+    };
+
+    // ── GetNextInstance ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetNextInstance_Daily_AddsDays()
+    {
+        var r = Make(RecurrenceInterval.Daily);
+        var result = RecurringScheduleCalculator.GetNextInstance(r, new DateTime(2025, 3, 1));
+        Assert.Equal(new DateTime(2025, 3, 2), result);
+    }
+
+    [Fact]
+    public void GetNextInstance_Daily_WithFactor2_Adds2Days()
+    {
+        var r = Make(RecurrenceInterval.Daily, factor: 2);
+        var result = RecurringScheduleCalculator.GetNextInstance(r, new DateTime(2025, 3, 1));
+        Assert.Equal(new DateTime(2025, 3, 3), result);
+    }
+
+    [Fact]
+    public void GetNextInstance_Weekly_Adds7Days()
+    {
+        var r = Make(RecurrenceInterval.Weekly);
+        var result = RecurringScheduleCalculator.GetNextInstance(r, new DateTime(2025, 3, 1));
+        Assert.Equal(new DateTime(2025, 3, 8), result);
+    }
+
+    [Fact]
+    public void GetNextInstance_Monthly_ClampsToEndOfMonth()
+    {
+        var r = Make(RecurrenceInterval.Monthly);
+        // Jan 31 + 1 month = Feb 28 (2025, not a leap year)
+        var result = RecurringScheduleCalculator.GetNextInstance(r, new DateTime(2025, 1, 31));
+        Assert.Equal(new DateTime(2025, 2, 28), result);
+    }
+
+    [Fact]
+    public void GetNextInstance_Quarterly_Adds3Months()
+    {
+        var r = Make(RecurrenceInterval.Quarterly);
+        var result = RecurringScheduleCalculator.GetNextInstance(r, new DateTime(2025, 1, 15));
+        Assert.Equal(new DateTime(2025, 4, 15), result);
+    }
+
+    [Fact]
+    public void GetNextInstance_Yearly_Adds12Months()
+    {
+        var r = Make(RecurrenceInterval.Yearly);
+        var result = RecurringScheduleCalculator.GetNextInstance(r, new DateTime(2025, 3, 1));
+        Assert.Equal(new DateTime(2026, 3, 1), result);
+    }
+
+    // ── AddMonthsPreserveDay ─────────────────────────────────────────────────
+
+    [Fact]
+    public void AddMonthsPreserveDay_LeapYear_Feb29PlusOneYear()
+    {
+        var result = RecurringScheduleCalculator.AddMonthsPreserveDay(new DateTime(2024, 2, 29), 12);
+        Assert.Equal(new DateTime(2025, 2, 28), result);
+    }
+
+    // ── ApplyExceptions ──────────────────────────────────────────────────────
+
+    [Fact]
+    public void ApplyExceptions_NoExceptions_ReturnsCandidate()
+    {
+        var r = Make(RecurrenceInterval.Monthly);
+        var candidate = new DateTime(2025, 3, 1);
+        Assert.Equal(candidate, RecurringScheduleCalculator.ApplyExceptions(r, candidate));
+    }
+
+    [Fact]
+    public void ApplyExceptions_SkipException_AdvancesToNextInstance()
+    {
+        var candidate = new DateTime(2025, 3, 1);
+        var r = Make(RecurrenceInterval.Monthly, exceptions:
+        [
+            new RecurringException { InstanceDate = candidate, Type = RecurringExceptionType.Skip }
+        ]);
+        var result = RecurringScheduleCalculator.ApplyExceptions(r, candidate);
+        Assert.Equal(new DateTime(2025, 4, 1), result);
+    }
+
+    [Fact]
+    public void ApplyExceptions_ShiftException_ReturnsShiftToDate()
+    {
+        var candidate = new DateTime(2025, 3, 1);
+        var shiftTo = new DateTime(2025, 3, 5);
+        var r = Make(RecurrenceInterval.Monthly, exceptions:
+        [
+            new RecurringException { InstanceDate = candidate, Type = RecurringExceptionType.Shift, ShiftToDate = shiftTo }
+        ]);
+        var result = RecurringScheduleCalculator.ApplyExceptions(r, candidate);
+        Assert.Equal(shiftTo, result);
+    }
+
+    [Fact]
+    public void ApplyExceptions_ExceptionOnDifferentDate_NotApplied()
+    {
+        var candidate = new DateTime(2025, 3, 1);
+        var r = Make(RecurrenceInterval.Monthly, exceptions:
+        [
+            new RecurringException { InstanceDate = new DateTime(2025, 4, 1), Type = RecurringExceptionType.Skip }
+        ]);
+        Assert.Equal(candidate, RecurringScheduleCalculator.ApplyExceptions(r, candidate));
+    }
+
+    // ── IsWithinActiveRange ──────────────────────────────────────────────────
+
+    [Fact]
+    public void IsWithinActiveRange_BeforeStart_ReturnsFalse()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2025, 6, 1));
+        Assert.False(RecurringScheduleCalculator.IsWithinActiveRange(r, new DateTime(2025, 5, 1)));
+    }
+
+    [Fact]
+    public void IsWithinActiveRange_OnStart_ReturnsTrue()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2025, 6, 1));
+        Assert.True(RecurringScheduleCalculator.IsWithinActiveRange(r, new DateTime(2025, 6, 1)));
+    }
+
+    [Fact]
+    public void IsWithinActiveRange_AfterEnd_ReturnsFalse()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2025, 1, 1), end: new DateTime(2025, 3, 31));
+        Assert.False(RecurringScheduleCalculator.IsWithinActiveRange(r, new DateTime(2025, 4, 1)));
+    }
+
+    [Fact]
+    public void IsWithinActiveRange_WithinReminderWindow_ReturnsTrue()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2025, 6, 1), reminderDays: 5);
+        // 3 days before start = still in reminder window
+        Assert.True(RecurringScheduleCalculator.IsWithinActiveRange(r, new DateTime(2025, 5, 29)));
+    }
+
+    [Fact]
+    public void IsWithinActiveRange_OutsideReminderWindow_ReturnsFalse()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2025, 6, 1), reminderDays: 5);
+        // 7 days before start = outside reminder window
+        Assert.False(RecurringScheduleCalculator.IsWithinActiveRange(r, new DateTime(2025, 5, 25)));
+    }
+
+    // ── GetNextDueDate ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void GetNextDueDate_NoLastRun_ReturnsStartDate()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2025, 3, 1));
+        var due = RecurringScheduleCalculator.GetNextDueDate(r, new DateTime(2025, 3, 1));
+        Assert.Equal(new DateTime(2025, 3, 1), due);
+    }
+
+    [Fact]
+    public void GetNextDueDate_WithLastRun_ReturnsNextAfterLastRun()
+    {
+        var r = Make(RecurrenceInterval.Monthly, lastRun: new DateTime(2025, 2, 1));
+        var due = RecurringScheduleCalculator.GetNextDueDate(r, new DateTime(2025, 3, 1));
+        Assert.Equal(new DateTime(2025, 3, 1), due);
+    }
+
+    [Fact]
+    public void GetNextDueDate_InactiveRecurring_ReturnsNull()
+    {
+        var r = Make(RecurrenceInterval.Monthly);
+        r.Aktiv = false;
+        Assert.Null(RecurringScheduleCalculator.GetNextDueDate(r, DateTime.Today));
+    }
+
+    [Fact]
+    public void GetNextDueDate_ExpiredRecurring_ReturnsNull()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2025, 1, 1), end: new DateTime(2025, 3, 31));
+        Assert.Null(RecurringScheduleCalculator.GetNextDueDate(r, new DateTime(2025, 5, 1)));
+    }
+}

--- a/Finanzuebersicht.Tests/Core/Services/RecurringScheduleCalculatorTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/RecurringScheduleCalculatorTests.cs
@@ -133,6 +133,20 @@ public class RecurringScheduleCalculatorTests
         Assert.Equal(candidate, RecurringScheduleCalculator.ApplyExceptions(r, candidate));
     }
 
+    [Fact]
+    public void ApplyExceptions_TwoConsecutiveSkips_SkipsBoth()
+    {
+        // March 1 → Skip, April 1 → Skip, May 1 → no exception → should return May 1
+        var candidate = new DateTime(2025, 3, 1);
+        var r = Make(RecurrenceInterval.Monthly, exceptions:
+        [
+            new RecurringException { InstanceDate = new DateTime(2025, 3, 1), Type = RecurringExceptionType.Skip },
+            new RecurringException { InstanceDate = new DateTime(2025, 4, 1), Type = RecurringExceptionType.Skip }
+        ]);
+        var result = RecurringScheduleCalculator.ApplyExceptions(r, candidate);
+        Assert.Equal(new DateTime(2025, 5, 1), result);
+    }
+
     // ── IsWithinActiveRange ──────────────────────────────────────────────────
 
     [Fact]

--- a/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceEdgeCaseTests.cs
+++ b/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceEdgeCaseTests.cs
@@ -26,12 +26,18 @@ public class LocalDataServiceEdgeCaseTests : IDisposable
     }
 
     [Fact]
-    public async Task LoadAsync_KorrupteJSON_GibtLeereListeZurueck()
+    public async Task LoadAsync_KorrupteJSON_WirftDataCorruptionException()
     {
-        // Korrupte JSON-Datei schreiben
         await File.WriteAllTextAsync(Path.Combine(_tempDir, "categories.json"), "{ not valid json [[[");
 
-        // Soll keine Exception werfen, sondern leere Liste zurückgeben
+        await Assert.ThrowsAsync<DataCorruptionException>(
+            () => _service.GetCategoriesAsync());
+    }
+
+    [Fact]
+    public async Task LoadAsync_DateiExistiertNicht_GibtLeereListeZurueck()
+    {
+        // Datei existiert nicht → leere Liste (kein Fehler)
         var result = await _service.GetCategoriesAsync();
         Assert.Empty(result);
     }

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -263,6 +263,62 @@ namespace Finanzuebersicht.Tests.Services
             Assert.Contains("nicht gefunden", result.ErrorMessage, StringComparison.OrdinalIgnoreCase);
         }
 
+        [Fact]
+        public async Task RestoreBackup_WriteFailsMidway_RollbackSucceeds_OriginalDataPreserved()
+        {
+            // Arrange: create backup with data
+            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var backupPath = Path.Combine(_testDir, "backups");
+
+            var originalCategories = new[] { new Category { Id = "c1", Name = "Groceries" } };
+            var originalTransactions = new[] { new Transaction { Id = "t1", Titel = "Shop", Betrag = 10m, Datum = DateTime.Today } };
+            _mockDataService.SetCategories(originalCategories);
+            _mockDataService.SetTransactions(originalTransactions);
+
+            var metadata = await service.CreateBackupAsync(backupPath);
+
+            // Change the data to something different
+            _mockDataService.SetCategories([new Category { Id = "c2", Name = "New" }]);
+            _mockDataService.SetTransactions([new Transaction { Id = "t2", Titel = "New", Betrag = 99m, Datum = DateTime.Today }]);
+
+            // Break the ZIP so restore fails mid-write by corrupting the zip file
+            var backupFile = Directory.GetFiles(backupPath, "*.zip").First();
+            await File.WriteAllTextAsync(backupFile, "NOT A ZIP FILE");
+
+            // Act
+            var result = await service.RestoreBackupAsync(backupPath, metadata.Id);
+
+            // Assert: restore failed, rollback succeeded, data is still "c2/t2" (the state before restore attempt)
+            Assert.False(result.Success);
+            Assert.False(result.DataMayBeInconsistent);
+
+            var cats = await _mockDataService.GetCategoriesAsync();
+            Assert.Single(cats);
+            Assert.Equal("c2", cats[0].Id);
+        }
+
+        [Fact]
+        public async Task RestoreBackup_WriteFailsAndRollbackFails_DataMayBeInconsistentIsTrue()
+        {
+            // Arrange: create a valid backup
+            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var backupPath = Path.Combine(_testDir, "backups");
+
+            _mockDataService.SetCategories([new Category { Id = "c1", Name = "Original" }]);
+            var metadata = await service.CreateBackupAsync(backupPath);
+
+            // Use a data service that fails on both write AND rollback
+            var failingDataService = new FailingMockDataService();
+            var failingService = new BackupService(failingDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+
+            // Act
+            var result = await failingService.RestoreBackupAsync(backupPath, metadata.Id);
+
+            // Assert
+            Assert.False(result.Success);
+            Assert.True(result.DataMayBeInconsistent);
+        }
+
         // Mock implementations
         private class MockDataService : IDataService
         {
@@ -346,6 +402,41 @@ namespace Finanzuebersicht.Tests.Services
             public MockSettingsService(string testDataDir) : base(Path.Combine(testDataDir, "settings.json"))
             {
             }
+        }
+
+        /// <summary>
+        /// A data service that always throws on ReplaceAll operations (both write and rollback).
+        /// Used to test the scenario where restore fails AND rollback also fails.
+        /// </summary>
+        private class FailingMockDataService : IDataService
+        {
+            public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(new List<Category>());
+            public Task<List<Transaction>> GetTransactionsAsync(DateTime v, DateTime b) => Task.FromResult(new List<Transaction>());
+            public Task<List<RecurringTransaction>> GetRecurringTransactionsAsync() => Task.FromResult(new List<RecurringTransaction>());
+            public Task<List<CategoryBudget>> GetBudgetsAsync() => Task.FromResult(new List<CategoryBudget>());
+            public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(new List<SparZiel>());
+
+            public Task ReplaceAllCategoriesAsync(IEnumerable<Category> c) => Task.FromException(new InvalidOperationException("Simulated write failure"));
+            public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> t) => Task.FromException(new InvalidOperationException("Simulated write failure"));
+            public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> r) => Task.FromException(new InvalidOperationException("Simulated write failure"));
+            public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> b) => Task.FromException(new InvalidOperationException("Simulated write failure"));
+            public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> s) => Task.FromException(new InvalidOperationException("Simulated write failure"));
+
+            public Task SaveCategoryAsync(Category c) => Task.CompletedTask;
+            public Task DeleteCategoryAsync(string id) => Task.CompletedTask;
+            public Task SaveTransactionAsync(Transaction t) => Task.CompletedTask;
+            public Task DeleteTransactionAsync(string id) => Task.CompletedTask;
+            public Task<Category?> GetMostCommonCategoryForPayeeAsync(string p, double c = 0.5, CancellationToken ct = default) => Task.FromResult<Category?>(null);
+            public Task SaveRecurringTransactionAsync(RecurringTransaction r) => Task.CompletedTask;
+            public Task DeleteRecurringTransactionAsync(string id) => Task.CompletedTask;
+            public Task GeneratePendingRecurringTransactionsAsync() => Task.CompletedTask;
+            public Task<YearSummary> GetYearSummaryAsync(int y) => Task.FromResult(new YearSummary());
+            public Task<MonthSummary> GetMonthSummaryAsync(int y, int m) => Task.FromResult(new MonthSummary());
+            public Task SaveBudgetAsync(CategoryBudget b) => Task.CompletedTask;
+            public Task DeleteBudgetAsync(string id) => Task.CompletedTask;
+            public Task<CategoryBudget?> GetBudgetForCategoryAsync(string k, int y, int m) => Task.FromResult<CategoryBudget?>(null);
+            public Task SaveSparZielAsync(SparZiel s) => Task.CompletedTask;
+            public Task DeleteSparZielAsync(string id) => Task.CompletedTask;
         }
     }
 }

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -42,7 +42,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task FullBackupRestoreCycle_PreserveAllData()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
 
             // Setup data
@@ -127,7 +127,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task MultipleBackups_ListsInCorrectOrder()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
             var categories = new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } };
             _mockDataService.SetCategories(categories);
@@ -151,7 +151,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task BackupWithEmptyDatabase_CreatesValidBackup()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
             // No data set
 
@@ -169,7 +169,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task DeleteBackup_RemovesBackupFile()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
             var category = new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" };
             _mockDataService.SetCategories(new[] { category });
@@ -189,7 +189,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ExportAsCSV_ContainsAllTransactionData()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var categories = new[]
             {
                 new Category { Id = "c1", Name = "Food", Icon = "🍕", Color = "#FF0000" }
@@ -229,7 +229,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task BackupSettings_PersistsBackupMetadata()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
             _mockDataService.SetCategories(new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } });
 
@@ -252,7 +252,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreNonexistentBackup_ReturnsFailed()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
 
             // Act
@@ -267,7 +267,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackup_WriteFailsMidway_RollbackSucceeds_OriginalDataPreserved()
         {
             // Arrange: create backup with data
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
 
             var originalCategories = new[] { new Category { Id = "c1", Name = "Groceries" } };
@@ -301,7 +301,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackup_WriteFailsAndRollbackFails_DataMayBeInconsistentIsTrue()
         {
             // Arrange: create a valid backup
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
 
             _mockDataService.SetCategories([new Category { Id = "c1", Name = "Original" }]);
@@ -309,7 +309,7 @@ namespace Finanzuebersicht.Tests.Services
 
             // Use a data service that fails on both write AND rollback
             var failingDataService = new FailingMockDataService();
-            var failingService = new BackupService(failingDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var failingService = new BackupService(failingDataService, failingDataService, failingDataService, failingDataService, failingDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
 
             // Act
             var result = await failingService.RestoreBackupAsync(backupPath, metadata.Id);

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -370,7 +370,7 @@ namespace Finanzuebersicht.Tests.Services
             public Task DeleteRecurringTransactionAsync(string id) { _recurring.RemoveAll(r => r.Id == id); return Task.CompletedTask; }
             public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring) { _recurring = recurring.ToList(); return Task.CompletedTask; }
 
-            public Task GeneratePendingRecurringTransactionsAsync() => Task.CompletedTask;
+            public Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
             public Task<YearSummary> GetYearSummaryAsync(int year) => Task.FromResult(new YearSummary());
             public Task<MonthSummary> GetMonthSummaryAsync(int year, int month) => Task.FromResult(new MonthSummary());
@@ -429,7 +429,7 @@ namespace Finanzuebersicht.Tests.Services
             public Task<Category?> GetMostCommonCategoryForPayeeAsync(string p, double c = 0.5, CancellationToken ct = default) => Task.FromResult<Category?>(null);
             public Task SaveRecurringTransactionAsync(RecurringTransaction r) => Task.CompletedTask;
             public Task DeleteRecurringTransactionAsync(string id) => Task.CompletedTask;
-            public Task GeneratePendingRecurringTransactionsAsync() => Task.CompletedTask;
+            public Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
             public Task<YearSummary> GetYearSummaryAsync(int y) => Task.FromResult(new YearSummary());
             public Task<MonthSummary> GetMonthSummaryAsync(int y, int m) => Task.FromResult(new MonthSummary());
             public Task SaveBudgetAsync(CategoryBudget b) => Task.CompletedTask;

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -264,9 +264,11 @@ namespace Finanzuebersicht.Tests.Services
         }
 
         [Fact]
-        public async Task RestoreBackup_WriteFailsMidway_RollbackSucceeds_OriginalDataPreserved()
+        public async Task RestoreBackup_BackupFileCorrupted_OriginalDataPreserved()
         {
-            // Arrange: create backup with data
+            // Arrange: create backup, then corrupt the ZIP before restoring.
+            // The restore fails at extraction (before any ReplaceAll* write occurs),
+            // so the existing data must remain untouched.
             var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
 

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -397,7 +397,7 @@ namespace Finanzuebersicht.Tests.Services
         public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> recurring) { _recurring = recurring.ToList(); return Task.CompletedTask; }
 
         // IRecurringGenerationService
-        public Task GeneratePendingRecurringTransactionsAsync() => Task.CompletedTask;
+        public Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default) => Task.CompletedTask;
 
         // IReportingService
         public Task<YearSummary> GetYearSummaryAsync(int year) => Task.FromResult(new YearSummary());

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -41,7 +41,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task CreateBackupAsync_CreatesValidZipFile()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             _mockDataService.SetCategories(new[]
             {
                 new Category { Id = "cat1", Name = "Test", Icon = "🏠", Color = "#000" }
@@ -66,7 +66,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task CreateBackupAsync_ZipContainsAllRequiredFiles()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             _mockDataService.SetCategories(new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } });
 
             // Act
@@ -89,7 +89,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task CreateBackupAsync_MetadataHasCorrectEntityCounts()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var categories = new[] { 
                 new Category { Id = "1", Name = "Cat1", Icon = "🏠", Color = "#000" },
                 new Category { Id = "2", Name = "Cat2", Icon = "🛒", Color = "#111" }
@@ -120,7 +120,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task CreateBackupAsync_ZipContainsBudgetsAndSparZiele()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             _mockDataService.SetBudgets(new[]
             {
                 new CategoryBudget { Id = "b1", KategorieId = "cat1", Betrag = 200m, Jahr = 2026, Monat = 1 },
@@ -151,7 +151,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ListBackupsAsync_ReturnsBackupsInReverseChronologicalOrder()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             _mockDataService.SetCategories(new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } });
 
             // Create backups with small delays
@@ -171,7 +171,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ListBackupsAsync_ReturnsEmptyWhenDirectoryDoesNotExist()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var nonExistentPath = Path.Combine(_testBackupDir, "nonexistent");
 
             // Act
@@ -185,7 +185,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackupAsync_FailsWhenFileDoesNotExist()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
 
             // Act
             var result = await service.RestoreBackupAsync(_testBackupDir, "nonexistent_id");
@@ -199,7 +199,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackupAsync_ValidatesZipIntegrity()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var corruptedZipPath = Path.Combine(_testBackupDir, "backup_corrupted.zip");
             File.WriteAllText(corruptedZipPath, "This is not a valid ZIP file");
 
@@ -215,7 +215,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackupAsync_DetectsMissingRequiredFiles()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var incompleteZipPath = Path.Combine(_testBackupDir, "backup_incomplete.zip");
 
             // Create incomplete ZIP (missing files)
@@ -241,7 +241,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackupAsync_ValidatesSchemaVersion()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var wrongVersionZipPath = Path.Combine(_testBackupDir, "backup_wrongversion.zip");
 
             // Create backup with wrong schema version
@@ -274,7 +274,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ExportAsCSVAsync_CreatesValidCsvStream()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var categories = new[] { new Category { Id = "1", Name = "Lebensmittel", Icon = "🛒", Color = "#000" } };
             var transactions = new[] {
                 new Transaction { Id = "t1", Titel = "Supermarkt", Betrag = 50.50m, Datum = new DateTime(2026, 3, 11), 
@@ -303,7 +303,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ExportAsCSVAsync_EscapesCsvSpecialCharacters()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             var categories = new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } };
             var transactions = new[] {
                 new Transaction { Id = "t1", Titel = "Titel \"mit Anführungszeichen\"", Betrag = 100m, 
@@ -328,7 +328,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task DeleteBackupAsync_RemovesBackupFile()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
             _mockDataService.SetCategories(new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } });
             var metadata = await service.CreateBackupAsync(_testBackupDir);
             var zipPath = Path.Combine(_testBackupDir, metadata.FileName);

--- a/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
@@ -364,7 +364,7 @@ namespace Finanzuebersicht.Tests.Services
             }
 
             // IRecurringGenerationService
-            public Task GeneratePendingRecurringTransactionsAsync() =>
+            public Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default) =>
                 Task.CompletedTask;
 
             // IReportingService

--- a/Finanzuebersicht.Tests/Services/ImportServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/ImportServiceTests.cs
@@ -1,33 +1,187 @@
+using Xunit;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Models;
 using Microsoft.Extensions.Logging;
+using NSubstitute.ExceptionExtensions;
 
 namespace Finanzuebersicht.Tests.Services
 {
     public class ImportServiceTests
     {
+        private static ImportService BuildService(
+            IStatementParser parser,
+            ITransactionRepository repo,
+            ICategoryRepository? catRepo = null)
+        {
+            var logger = Substitute.For<ILogger<ImportService>>();
+            return new ImportService([parser], repo, logger, catRepo);
+        }
+
         [Fact]
-        public async Task ImportFromCsv_ShouldUseParserAndPersistTransactions()
+        public async Task ImportFromCsv_ValidRecords_ImportedAndSaved()
         {
             var parser = Substitute.For<IStatementParser>();
             var repo = Substitute.For<ITransactionRepository>();
+            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+                .Returns([]);
 
             var dtos = new List<TransactionDto>
             {
                 new() { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "A" },
                 new() { Buchungsdatum = DateTime.Today, Betrag = -5m, Zahlungsempfaenger = "B" }
             };
-
             parser.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            var svc = BuildService(parser, repo);
+            using var ms = new MemoryStream();
+
+            var result = await svc.ImportFromCsvAsync(ms);
+
+            Assert.True(result.Success);
+            Assert.Equal(2, result.Imported.Count);
+            Assert.Empty(result.Duplicates);
+            Assert.Equal(0, result.SkippedMalformed);
+            Assert.Empty(result.SaveErrors);
+            await repo.Received(2).SaveTransactionAsync(Arg.Any<Transaction>());
+        }
+
+        [Fact]
+        public async Task ImportFromCsv_DuplicateDetected_SkippedNotSaved()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+
+            var dtos = new List<TransactionDto>
+            {
+                new() { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "Shop" }
+            };
+            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            // Simulate existing transaction that matches
+            var existing = new Transaction { Betrag = 10m, Titel = "Shop", Datum = DateTime.Today };
+            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+                .Returns([existing]);
+
+            var svc = BuildService(parser, repo);
+            using var ms = new MemoryStream();
+
+            var result = await svc.ImportFromCsvAsync(ms);
+
+            Assert.True(result.Success);
+            Assert.Empty(result.Imported);
+            Assert.Single(result.Duplicates);
+            await repo.DidNotReceive().SaveTransactionAsync(Arg.Any<Transaction>());
+        }
+
+        [Fact]
+        public async Task ImportFromCsv_MalformedDto_Skipped()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+                .Returns([]);
+
+            var dtos = new List<TransactionDto>
+            {
+                new() { Buchungsdatum = default, Betrag = 5m }, // malformed: no date
+                new() { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "Valid" }
+            };
+            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            var svc = BuildService(parser, repo);
+            using var ms = new MemoryStream();
+
+            var result = await svc.ImportFromCsvAsync(ms);
+
+            Assert.True(result.Success);
+            Assert.Single(result.Imported);
+            Assert.Equal(1, result.SkippedMalformed);
+        }
+
+        [Fact]
+        public async Task ImportFromCsv_SaveFails_ReportedInSaveErrors()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+                .Returns([]);
+            repo.SaveTransactionAsync(Arg.Any<Transaction>())
+                .Returns(Task.FromException(new IOException("disk full")));
+
+            var dtos = new List<TransactionDto>
+            {
+                new() { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "A" }
+            };
+            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            var svc = BuildService(parser, repo);
+            using var ms = new MemoryStream();
+
+            var result = await svc.ImportFromCsvAsync(ms);
+
+            Assert.True(result.Success); // no top-level error
+            Assert.Empty(result.Imported);
+            Assert.Single(result.SaveErrors);
+            Assert.Contains("disk full", result.SaveErrors[0]);
+        }
+
+        [Fact]
+        public async Task ImportFromCsv_NoParserMatches_ErrorMessage()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            parser.Parse(Arg.Any<Stream>()).Returns([]);
+            var repo = Substitute.For<ITransactionRepository>();
+
+            var svc = BuildService(parser, repo);
+            using var ms = new MemoryStream();
+
+            var result = await svc.ImportFromCsvAsync(ms);
+
+            Assert.False(result.Success);
+            Assert.NotNull(result.ErrorMessage);
+        }
+
+        [Fact]
+        public async Task ImportFromCsv_ParserThrows_TriesNextParser()
+        {
+            var failingParser = Substitute.For<IStatementParser>();
+            failingParser.Parse(Arg.Any<Stream>()).Throws(new Exception("parse error"));
+
+            var workingParser = Substitute.For<IStatementParser>();
+            var dtos = new List<TransactionDto>
+            {
+                new() { Buchungsdatum = DateTime.Today, Betrag = 5m, Zahlungsempfaenger = "OK" }
+            };
+            workingParser.Parse(Arg.Any<Stream>()).Returns(dtos);
+
+            var repo = Substitute.For<ITransactionRepository>();
+            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+                .Returns([]);
+
+            var logger = Substitute.For<ILogger<ImportService>>();
+            var svc = new ImportService([failingParser, workingParser], repo, logger);
+            using var ms = new MemoryStream();
+
+            var result = await svc.ImportFromCsvAsync(ms);
+
+            Assert.True(result.Success);
+            Assert.Single(result.Imported);
+        }
+
+        [Fact]
+        public async Task ImportFromCsv_Cancellation_ThrowsOperationCancelled()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+            var cts = new CancellationTokenSource();
+            cts.Cancel();
 
             var logger = Substitute.For<ILogger<ImportService>>();
             var svc = new ImportService([parser], repo, logger);
-
             using var ms = new MemoryStream();
-            var result = await svc.ImportFromCsvAsync(ms);
 
-            Assert.Equal(2, result.ToList().Count);
-            await repo.Received(2).SaveTransactionAsync(Arg.Any<Transaction>());
+            await Assert.ThrowsAsync<OperationCanceledException>(
+                () => svc.ImportFromCsvAsync(ms, cancellationToken: cts.Token));
         }
     }
 }

--- a/Finanzuebersicht/App.xaml.cs
+++ b/Finanzuebersicht/App.xaml.cs
@@ -17,7 +17,7 @@ public partial class App : global::Microsoft.Maui.Controls.Application
 	private readonly ThemeService _themeService;
 	private readonly string _savedTheme;
 
-	public App(InitializationService initService, IRecurringGenerationService recurringGenerationService, SettingsService settings,
+	public App(InitializationService initService, IRecurringGenerationService recurringGenerationService, ISettingsService settings,
 		ThemeService themeService, ILocalizationService localizationService)
 	{
 		// Sprache vor InitializeComponent setzen, damit XAML-Bindings korrekt aufgelöst werden

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -36,7 +36,7 @@ public static class MauiProgram
 #endif
 
 		// Services
-		builder.Services.AddSingleton<SettingsService>();
+		builder.Services.AddSingleton<ISettingsService, SettingsService>();
 		// Clock for testable current time
 		builder.Services.AddSingleton<Finanzuebersicht.Services.IClock, Finanzuebersicht.Services.SystemClock>();
 		builder.Services.AddInfrastructureServices();

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -37,7 +37,10 @@ public static class MauiProgram
 		builder.Services.AddInfrastructureServices();
 		builder.Services.AddSingleton<IRecurringGenerationService, RecurringGenerationService>();
 		builder.Services.AddSingleton<IReportingService, ReportingService>();
+		// IDataService is kept for legacy compatibility; new code uses specific repository interfaces
+#pragma warning disable CS0618
 		builder.Services.AddSingleton<IDataService, DataServiceFacade>();
+#pragma warning restore CS0618
 		builder.Services.AddSingleton<IForecastService, ForecastService>();
 		builder.Services.AddSingleton<ITransactionValidationService, TransactionValidationService>();
 		builder.Services.AddSingleton<IBackupService, BackupService>();

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -1,9 +1,11 @@
-﻿using CommunityToolkit.Maui;
+﻿using System.Reflection;
+using CommunityToolkit.Maui;
 using Finanzuebersicht.Application.DependencyInjection;
 using Finanzuebersicht.Infrastructure;
 using Finanzuebersicht.Presentation.DependencyInjection;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Views;
+
 using Microsoft.Extensions.Logging;
 
 namespace Finanzuebersicht;
@@ -69,7 +71,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IFileSaver, MauiFileSaver>();
 		builder.Services.AddSingleton<IThemeService>(sp => sp.GetRequiredService<ThemeService>());
 
-		builder.Services.AddPresentationViewModels();
+		builder.Services.AddPresentationViewModels(Assembly.GetExecutingAssembly());
 
 		// Pages
 		builder.Services.AddTransient<DashboardPage>();

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -1,13 +1,8 @@
-﻿using System.Reflection;
-using CommunityToolkit.Maui;
-using Finanzuebersicht.Application.UseCases.Categories;
-using Finanzuebersicht.Application.UseCases.Dashboard;
-using Finanzuebersicht.Application.UseCases.RecurringTransactions;
-using Finanzuebersicht.Application.UseCases.SparZiele;
-using Finanzuebersicht.Application.UseCases.Transactions;
+﻿using CommunityToolkit.Maui;
+using Finanzuebersicht.Application.DependencyInjection;
 using Finanzuebersicht.Infrastructure;
+using Finanzuebersicht.Presentation.DependencyInjection;
 using Finanzuebersicht.Services;
-using Finanzuebersicht.ViewModels;
 using Finanzuebersicht.Views;
 using Microsoft.Extensions.Logging;
 
@@ -58,31 +53,8 @@ public static class MauiProgram
 		Microsoft.Extensions.DependencyInjection.ServiceCollectionServiceExtensions.AddSingleton<ICategorizationStrategy, HistoricalCategorizationStrategy>(builder.Services);
 		builder.Services.AddSingleton<CategorizationService>();
 
-		builder.Services.AddTransient<DeleteCategoryUseCase>();
-		builder.Services.AddTransient<LoadCategoriesUseCase>();
-		builder.Services.AddTransient<SaveCategoryDetailUseCase>();
-		builder.Services.AddTransient<SaveCategoryBudgetUseCase>();
-		builder.Services.AddTransient<LoadDashboardMonthUseCase>();
-		builder.Services.AddTransient<LoadDashboardYearUseCase>();
-		builder.Services.AddTransient<LoadForecastUseCase>();
-		builder.Services.AddTransient<DeleteRecurringTransactionUseCase>();
-		builder.Services.AddTransient<LoadRecurringTransactionDetailDataUseCase>();
-		builder.Services.AddTransient<LoadRecurringTransactionsUseCase>();
-		builder.Services.AddTransient<ToggleRecurringTransactionActiveUseCase>();
-		builder.Services.AddTransient<AddRecurringExceptionUseCase>();
-		builder.Services.AddTransient<RemoveRecurringExceptionUseCase>();
-		builder.Services.AddTransient<ShiftRecurringInstanceUseCase>();
-		builder.Services.AddTransient<GetDueRecurringWithHintsUseCase>();
-		builder.Services.AddTransient<LoadTransactionDetailDataUseCase>();
-		builder.Services.AddTransient<DeleteTransactionUseCase>();
-		builder.Services.AddTransient<LoadTransactionsMonthUseCase>();
-		builder.Services.AddTransient<SearchTransactionsUseCase>();
-		builder.Services.AddTransient<SaveRecurringTransactionDetailUseCase>();
-		builder.Services.AddTransient<SaveTransactionDetailUseCase>();
-		builder.Services.AddSingleton<InitializationService>();
-		builder.Services.AddTransient<LoadSparZieleUseCase>();
-		builder.Services.AddTransient<SaveSparZielUseCase>();
-		builder.Services.AddTransient<DeleteSparZielUseCase>();
+		builder.Services.AddApplicationUseCases();
+
 		builder.Services.AddSingleton<ThemeService>();
 		builder.Services.AddSingleton<ILocalizationService, LocalizationService>();
 		builder.Services.AddSingleton<INavigationService, ShellNavigationService>();
@@ -94,23 +66,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IFileSaver, MauiFileSaver>();
 		builder.Services.AddSingleton<IThemeService>(sp => sp.GetRequiredService<ThemeService>());
 
-		// ViewModels
-		builder.Services.AddTransient<DashboardViewModel>();
-		builder.Services.AddTransient<CategoriesViewModel>();
-		builder.Services.AddTransient<CategoryDetailViewModel>();
-		builder.Services.AddTransient<TransactionsViewModel>();
-		builder.Services.AddTransient<TransactionDetailViewModel>();
-		builder.Services.AddTransient<RecurringTransactionsViewModel>();
-		builder.Services.AddTransient<RecurringTransactionDetailViewModel>();
-        builder.Services.AddTransient<RecurringInstanceShiftViewModel>();
-		builder.Services.AddTransient<AppearanceViewModel>();
-		builder.Services.AddTransient<StorageViewModel>();
-		builder.Services.AddTransient<BackupViewModel>();
-		builder.Services.AddTransient<AboutViewModel>(sp =>
-			new AboutViewModel(Assembly.GetExecutingAssembly(), sp.GetService<ILogger<AboutViewModel>>()));
-		builder.Services.AddTransient<SettingsViewModel>();
-		builder.Services.AddTransient<SparZieleViewModel>();
-		builder.Services.AddTransient<BackupListViewModel>();
+		builder.Services.AddPresentationViewModels();
 
 		// Pages
 		builder.Services.AddTransient<DashboardPage>();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -162,6 +162,8 @@ Bitte starte die App neu.</value></data>
   <data name="Msg_RestoreSuccessTitle" xml:space="preserve"><value>Wiederherstellung erfolgreich</value></data>
   <data name="Msg_RestoreSuccessDesc" xml:space="preserve"><value>Die Sicherung wurde erfolgreich wiederhergestellt.</value></data>
   <data name="Msg_RestoreFailedTitle" xml:space="preserve"><value>Wiederherstellung fehlgeschlagen</value></data>
+  <data name="Msg_RestoreInconsistentTitle" xml:space="preserve"><value>⚠️ Daten möglicherweise inkonsistent</value></data>
+  <data name="Msg_RestoreInconsistentDesc" xml:space="preserve"><value>Die Wiederherstellung ist fehlgeschlagen und der Rollback ist ebenfalls fehlgeschlagen. Deine Daten könnten in einem inkonsistenten Zustand sein. Bitte starte die App neu und überprüfe deine Daten. Es wird empfohlen, aus einer anderen Sicherung wiederherzustellen.</value></data>
   <data name="Msg_CSVExportedTitle" xml:space="preserve"><value>CSV exportiert</value></data>
   <data name="Msg_CSVExportedBody" xml:space="preserve"><value>Die Daten wurden zu:
 {0}</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -162,6 +162,8 @@ Please restart the app.</value></data>
   <data name="Msg_RestoreSuccessTitle" xml:space="preserve"><value>Restore successful</value></data>
   <data name="Msg_RestoreSuccessDesc" xml:space="preserve"><value>The backup was restored successfully.</value></data>
   <data name="Msg_RestoreFailedTitle" xml:space="preserve"><value>Restore failed</value></data>
+  <data name="Msg_RestoreInconsistentTitle" xml:space="preserve"><value>⚠️ Data may be inconsistent</value></data>
+  <data name="Msg_RestoreInconsistentDesc" xml:space="preserve"><value>The restore failed and the rollback also failed. Your data may be in an inconsistent state. Please restart the app and check your data. It is recommended to restore from a backup.</value></data>
   <data name="Msg_CSVExportedTitle" xml:space="preserve"><value>CSV exported</value></data>
   <data name="Msg_CSVExportedBody" xml:space="preserve"><value>Data exported to:
 {0}</value></data>

--- a/Finanzuebersicht/Services/LocalizationService.cs
+++ b/Finanzuebersicht/Services/LocalizationService.cs
@@ -8,11 +8,11 @@ namespace Finanzuebersicht.Services;
 /// Verwaltet die App-Sprache. Liest gespeicherte Sprachpräferenz aus SettingsService,
 /// fällt auf Gerätesprache zurück und aktualisiert LocalizationResourceManager live.
 /// </summary>
-public class LocalizationService(SettingsService settings) : ILocalizationService
+public class LocalizationService(ISettingsService settings) : ILocalizationService
 {
     private const string LanguageKey = "LanguageCode";
 
-    private readonly SettingsService _settings = settings;
+    private readonly ISettingsService _settings = settings;
     private string _currentLanguageCode = string.Empty;
 
     public string CurrentLanguageCode => _currentLanguageCode;

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5",
+  "version": "1.6",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## v1.6 Release

Dieser PR merged den v1.6 Milestone in `main`.

## Was ist neu

### Datenrobustheit (#152, #153)
- `DataCorruptionException` bei kaputten JSON-Dateien statt stiller Rückgabe einer leeren Liste
- Atomares Restore via Staging-Verzeichnis — kein partieller Zustand mehr
- `RollbackFailedException` + `RestoreResult.DataMayBeInconsistent` mit UI-Dialog

### Architektur (#159, #160, #161, #163, #168)
- `RecurringScheduleCalculator` als Single Source of Truth für Wiederholungs-Logik
- `ISettingsService` Interface extrahiert (Dependency Inversion, Testbarkeit)
- `IDataService` als `[Obsolete]` markiert — alle UseCases und BackupService nutzen spezifische Repository-Interfaces
- `MauiProgram.cs` aufgeteilt: `ApplicationServiceCollectionExtensions` + `PresentationServiceCollectionExtensions`
- Alle 23 UseCases erhalten `CancellationToken`

### CSV-Import (#155)
- `ImportResult`-Modell mit Imported, Duplicates, SkippedMalformed, SaveErrors
- N+1 Query-Pattern eliminiert (1 DB-Call statt N)
- FileLogger-Seiteneffekte entfernt

## Teststand
- **228 Tests** ✅ (war 201 bei v1.5.11)
- Build für macOS (Mac Catalyst) ✅

## Version
`version.json` auf `1.6` gebumpt — Nerdbank.GitVersioning generiert `1.6.x` automatisch.