### PR TITLE
🧪📝 chore: pre-release cleanup – fix test warnings and update docs

### DIFF
--- a/Finanzuebersicht.Tests/Application/UseCases/Transactions/SearchTransactionsUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/Transactions/SearchTransactionsUseCaseTests.cs
@@ -37,7 +37,7 @@ public class SearchTransactionsUseCaseTests
             Id = id,
             Titel = titel,
             Verwendungszweck = verwendungszweck,
-            KategorieId = kategorieId,
+            KategorieId = kategorieId ?? string.Empty,
             Typ = typ,
             Betrag = 10m,
             Datum = datum ?? new DateTime(2026, 1, 15)

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -320,6 +320,7 @@ namespace Finanzuebersicht.Tests.Services
         }
 
         // Mock implementations
+#pragma warning disable CS0618
         private class MockDataService : IDataService
         {
             private List<Category> _categories = [];
@@ -409,6 +410,7 @@ namespace Finanzuebersicht.Tests.Services
         /// Used to test the scenario where restore fails AND rollback also fails.
         /// </summary>
         private class FailingMockDataService : IDataService
+#pragma warning disable CS0618
         {
             public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(new List<Category>());
             public Task<List<Transaction>> GetTransactionsAsync(DateTime v, DateTime b) => Task.FromResult(new List<Transaction>());

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -397,6 +397,7 @@ namespace Finanzuebersicht.Tests.Services
             public Task DeleteSparZielAsync(string id) { _sparziele.RemoveAll(s => s.Id == id); return Task.CompletedTask; }
             public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) { _sparziele = sparziele.ToList(); return Task.CompletedTask; }
         }
+#pragma warning restore CS0618
 
         private class MockSettingsService : SettingsService
         {
@@ -409,8 +410,8 @@ namespace Finanzuebersicht.Tests.Services
         /// A data service that always throws on ReplaceAll operations (both write and rollback).
         /// Used to test the scenario where restore fails AND rollback also fails.
         /// </summary>
-        private class FailingMockDataService : IDataService
 #pragma warning disable CS0618
+        private class FailingMockDataService : IDataService
         {
             public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(new List<Category>());
             public Task<List<Transaction>> GetTransactionsAsync(DateTime v, DateTime b) => Task.FromResult(new List<Transaction>());
@@ -440,5 +441,6 @@ namespace Finanzuebersicht.Tests.Services
             public Task SaveSparZielAsync(SparZiel s) => Task.CompletedTask;
             public Task DeleteSparZielAsync(string id) => Task.CompletedTask;
         }
+#pragma warning restore CS0618
     }
 }

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -415,6 +415,7 @@ namespace Finanzuebersicht.Tests.Services
         public Task DeleteSparZielAsync(string id) => Task.CompletedTask;
         public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) { _sparziele = sparziele.ToList(); return Task.CompletedTask; }
     }
+#pragma warning restore CS0618
 
     internal class MockSettingsService : SettingsService
     {

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -356,6 +356,7 @@ namespace Finanzuebersicht.Tests.Services
 
     // ========== Mock-Implementierungen ==========
 
+#pragma warning disable CS0618
     internal class MockDataService : IDataService
     {
         private List<Category> _categories = [];

--- a/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
@@ -265,6 +265,7 @@ namespace Finanzuebersicht.Tests.Services
         /// In-memory implementation of IDataService for testing.
         /// Provides isolated test environment without file I/O.
         /// </summary>
+#pragma warning disable CS0618
         private class InMemoryDataService : IDataService
         {
             private readonly List<Category> _categories = [];

--- a/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
@@ -397,5 +397,6 @@ namespace Finanzuebersicht.Tests.Services
             public Task DeleteSparZielAsync(string id) { _sparziele.RemoveAll(s => s.Id == id); return Task.CompletedTask; }
             public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) { _sparziele.Clear(); _sparziele.AddRange(sparziele); return Task.CompletedTask; }
         }
+#pragma warning restore CS0618
     }
 }

--- a/README.md
+++ b/README.md
@@ -88,18 +88,23 @@ Finanzuebersicht/                  ← MAUI App Entry Point (iOS, macOS, Windows
 ├── App.xaml, AppShell.xaml, MauiProgram.cs
 
 Finanzuebersicht.Presentation/     ← Presentation Layer (MVVM)
+├── DependencyInjection/           ← AddPresentationViewModels(...)
 ├── ViewModels/                    ← DashboardVM, TransactionsVM, etc.
 ├── Navigation/                    ← Shell Navigation
-├── Services/                      ← UI Services (ILocalizationService, IDialogService, etc.)
+├── Services/                      ← namespace Finanzuebersicht.Presentation.Services
 └── Resources/                     ← Presentation resource helpers (e.g. string keys)
 
 Finanzuebersicht.Application/      ← Use Cases / Application Layer (net10.0)
+├── DependencyInjection/           ← AddApplicationUseCases()
+└── UseCases/                      ← namespace Finanzuebersicht.Application.UseCases.*
 
-Finanzuebersicht.Infrastructure/   ← DI-Registrierung, Infrastrukturdienste (net10.0)
+Finanzuebersicht.Infrastructure/   ← DI-Registrierung, Persistenz & Infrastrukturdienste (net10.0)
+├── DependencyInjection/           ← AddInfrastructureServices()
+└── Services/                      ← SettingsService, BackupService, LocalDataService, *Store.cs
 
 Finanzuebersicht.Core/             ← Domain Layer (Modelle, Geschäftslogik, Services)
-├── Models/                        ← Transaction, Category, Budget, SparZiel, etc.
-└── Services/                      ← IDataService, LocalDataService, SettingsService, etc.
+├── Models/                        ← namespace Finanzuebersicht.Models
+└── Services/                      ← namespace Finanzuebersicht.Core.Services (Interfaces, Domain Services, AppPaths, Migrations)
 
 Finanzuebersicht.Tests/            ← xUnit Tests (net10.0)
 └── Testet alle Layer (Application, Infrastructure, Presentation, Core)
@@ -109,6 +114,9 @@ Finanzuebersicht.Tests/            ← xUnit Tests (net10.0)
 - Views bleiben in `Finanzuebersicht/Views/` (MAUI App)
 - Converters bleiben in `Finanzuebersicht/Converters/` (MAUI App)
 - ViewModels sind in `Finanzuebersicht.Presentation/ViewModels/`
+- `FileLogger` wurde entfernt; Logging läuft über `ILogger<T>`
+- `IDataService` ist nur noch Legacy-Kompatibilität; neue Features nutzen spezifische Repository-Interfaces
+- `MauiProgram.cs` ist ein schlanker Orchestrator für die layer-spezifischen DI-Extensions
 
 ## Lokalisierung & Ressourcen
 

--- a/docs/ARCHITECTURE_CLEAN_CODE_REVIEW.md
+++ b/docs/ARCHITECTURE_CLEAN_CODE_REVIEW.md
@@ -8,6 +8,21 @@ Clean Code, Testbarkeit, .NET/MAUI-Best-Practices und Wartbarkeit. Es ist so
 strukturiert, dass daraus direkt GitHub-Issues mit Beschreibung,
 Akzeptanzkriterien und betroffenen Dateien erstellt werden können.
 
+## v1.6 Status
+
+Dieses Dokument ist eine Vorab-Analyse. Seit v1.6 sind die zentralen
+Layering-Maßnahmen aus diesem Review umgesetzt:
+
+- ✅ #154 erledigt: `FileLogger` entfernt; Logging läuft über `ILogger<T>`.
+- ✅ `SettingsService` und `BackupService` aus `Core` nach
+  `Finanzuebersicht.Infrastructure.Services` verschoben.
+- ✅ #161 erledigt: DI über `AddInfrastructureServices()`,
+  `AddApplicationUseCases()` und `AddPresentationViewModels()` modularisiert.
+- ✅ #162 erledigt: Layer-Namespaces vereinheitlicht; neue GlobalUsings wurden
+  in den Layer-Projekten ergänzt.
+- ✅ `IDataService` ist nur noch als Legacy-Kompatibilität markiert; neue
+  Features nutzen spezifische Repository-Interfaces.
+
 ## Kurzfazit
 
 Die Codebasis ist funktional stabil und hat bereits wichtige Qualitätsmerkmale:
@@ -20,10 +35,13 @@ Die Codebasis ist funktional stabil und hat bereits wichtige Qualitätsmerkmale:
 - DI-Registrierung und erste Clean-Architecture-Ausrichtung
 - Nerdbank.GitVersioning und CI/CD sind vorhanden
 
-Die größten Architektur-Risiken liegen aktuell aber in unscharfen Layer-Grenzen:
+Die größten Architektur-Risiken lagen zum Erstellungszeitpunkt dieses Reviews
+vor allem in unscharfen Layer-Grenzen:
 
-1. `Finanzuebersicht.Core` enthält noch Infrastruktur-Logik wie Datei-I/O,
-   Backup/Restore, Settings-Persistenz, Import und Logging.
+1. Historischer Befund: `Finanzuebersicht.Core` enthielt Infrastruktur-Logik wie
+   Datei-I/O, Backup/Restore, Settings-Persistenz, Import und Logging.
+   **Status v1.6:** Logging/Settings/Backup wurden bereinigt; offene Punkte
+   betreffen vor allem verbleibende Import-/Legacy-Themen.
 2. ViewModels enthalten teilweise direkte MAUI-/Shell-/Toolkit-Abhängigkeiten.
 3. JSON-Persistenz und Restore sind noch nicht robust genug gegen Korruption
    oder Teilzustände.
@@ -74,7 +92,7 @@ Issues ergänzt:
 |-------|-------|-----------|
 | #152 | JSON-Persistenz: Korruption nicht stillschweigend als leere Daten behandeln | v1.6 – Architektur & Datenrobustheit |
 | #153 | Restore-Prozess transaktional absichern | v1.6 – Architektur & Datenrobustheit |
-| #154 | Refactor Core: I/O-, Logging- und Persistenz-Services aus Core auslagern | v1.6 – Architektur & Datenrobustheit |
+| #154 | Refactor Core: I/O-, Logging- und Persistenz-Services aus Core auslagern | v1.6 – Architektur & Datenrobustheit · ✅ DONE |
 | #155 | CSV-Import: Teilimporte und globale Side-Effects vermeiden | v1.6 – Architektur & Datenrobustheit |
 | #156 | Architektur: UI-nahe MAUI-APIs aus ViewModels herauslösen | v1.5 – Testabdeckung & ViewModel-Tests |
 | #157 | Refactor: SettingsViewModel in fachlich getrennte Komponenten zerlegen | v1.5 – Testabdeckung & ViewModel-Tests |
@@ -82,7 +100,7 @@ Issues ergänzt:
 | #159 | Recurring-Berechnung zentralisieren und CancellationToken unterstützen | v1.6 – Architektur & Datenrobustheit |
 | #160 | DataServiceFacade in fachlich getrennte Interfaces aufteilen | v1.6 – Architektur & Datenrobustheit |
 | #161 | DI-Registrierung in modulare Extensions aufteilen | v1.6 – Architektur & Datenrobustheit |
-| #162 | Namespaces nach Layern trennen und vereinheitlichen | v1.6 – Architektur & Datenrobustheit |
+| #162 | Namespaces nach Layern trennen und vereinheitlichen | v1.6 – Architektur & Datenrobustheit · ✅ DONE |
 | #163 | SettingsService: I/O abstrahieren und async/testbar machen | v1.6 – Architektur & Datenrobustheit |
 | #164 | Refactor: Static Cache aus KategorieIdToIconConverter entfernen | v1.5 – Testabdeckung & ViewModel-Tests |
 | #165 | Build-Reproduzierbarkeit erhöhen: Floating Package-Versionen eliminieren | v1.7 – Build, CI & Wartbarkeit |
@@ -104,23 +122,28 @@ wurden geschlossen, da sie keine offenen Issues mehr enthalten.
 
 ## Priorisierte Issue-Kandidaten
 
-### P0 - Core von Infrastruktur befreien
+### P0 - Core von Infrastruktur befreien ✅ DONE in v1.6
 
 **Titel:** `Refactor Core: I/O-, Logging- und Persistenz-Services aus Core auslagern`
 
 **Labels:** `architecture`, `refactor`, `.NET`, `priority:high`
 
-**Problem:**  
-`Finanzuebersicht.Core` ist aktuell kein reiner Domain-/Abstraktions-Layer. In
-`Core` liegen u. a. Datei-I/O, ZIP/JSON-Serialisierung, Settings-Persistenz,
-Import-Workflow und Datei-Logging.
+**Problem (historischer Befund):**  
+`Finanzuebersicht.Core` war zum Zeitpunkt dieses Reviews kein reiner
+Domain-/Abstraktions-Layer. In `Core` lagen u. a. Datei-I/O,
+ZIP/JSON-Serialisierung, Settings-Persistenz, Import-Workflow und
+Datei-Logging.
 
-**Betroffene Dateien:**
+**Status v1.6:** `FileLogger` wurde gelöscht, `SettingsService` und
+`BackupService` nach `Finanzuebersicht.Infrastructure.Services` verschoben.
+`AppPaths` ist als reiner Pfad-Helper im Core verblieben.
 
-- `Finanzuebersicht.Core/Services/BackupService.cs`
-- `Finanzuebersicht.Core/Services/SettingsService.cs`
+**Betroffene Dateien (historisch / heute):**
+
+- ~~`Finanzuebersicht.Core/Services/BackupService.cs`~~ → `Finanzuebersicht.Infrastructure/Services/BackupService.cs`
+- ~~`Finanzuebersicht.Core/Services/SettingsService.cs`~~ → `Finanzuebersicht.Infrastructure/Services/SettingsService.cs`
 - `Finanzuebersicht.Core/Services/ImportService.cs`
-- `Finanzuebersicht.Core/Services/FileLogger.cs`
+- ~~`Finanzuebersicht.Core/Services/FileLogger.cs`~~ (in v1.6 gelöscht)
 - `Finanzuebersicht.Core/Services/AppPaths.cs`
 - `Finanzuebersicht.Infrastructure/Services/*`
 
@@ -135,7 +158,8 @@ CloudKit/Sync, Multi-Account und alternative Speicherorte.
 - Datei-/ZIP-/JSON-/Settings-/Logging-Implementierungen nach
   `Finanzuebersicht.Infrastructure` verschieben.
 - Falls nötig neue Contracts einführen, z. B. `ISettingsStore`,
-  `IBackupArchiveStore`, `IFileLogger`, `IAppPathProvider`.
+  `IBackupArchiveStore`, `IAppPathProvider` oder eine `ILogger<T>`-basierte
+  Logging-Abstraktion.
 - Bestehende Tests auf Interfaces ausrichten.
 
 **Akzeptanzkriterien:**
@@ -199,7 +223,8 @@ ursprünglichen Zustand überschreiben.
 `BackupService.AtomicRestoreAsync` schreibt Entity-Typen nacheinander und macht
 bei Fehlern ein Best-Effort-Rollback:
 
-- `Finanzuebersicht.Core/Services/BackupService.cs:237-293`
+- `Finanzuebersicht.Infrastructure/Services/BackupService.cs` (seit v1.6; im
+  ursprünglichen Review noch unter `Core` verortet)
 
 Wenn Restore oder Rollback fehlschlägt, kann ein gemischter Datenzustand
 entstehen.
@@ -241,8 +266,9 @@ Verarbeitung einzeln und läuft bei Save-Fehlern weiter:
 - Save-Fehler werden in `ImportService.cs:195-205` geloggt, aber der Import
   wird fortgesetzt.
 
-Zusätzlich gibt es direkte `FileLogger.Append`-Side-Effects und mehrere Stellen,
-an denen Fehler zu `[]` führen.
+Historischer Befund: Zusätzlich gab es direkte `FileLogger.Append`-Side-Effects
+und mehrere Stellen, an denen Fehler zu `[]` führten. Das Logging ist seit
+v1.6 auf `ILogger<T>` umgestellt.
 
 **Impact:**  
 Importe können teilweise erfolgreich sein, ohne dass die App oder der Nutzer
@@ -463,7 +489,7 @@ unnötig viele Klassen betreffen.
 
 ---
 
-### P2 - DI-Registrierung modularisieren
+### P2 - DI-Registrierung modularisieren ✅ DONE in v1.6
 
 **Titel:** `DI-Registrierung in modulare Extensions aufteilen`
 
@@ -481,13 +507,14 @@ führen schnell zu Merge-Konflikten und erschweren Reviews.
 
 **Empfohlener Ansatz:**
 
-- Extension-Methoden einführen:
-  - `AddApplicationServices()`
-  - `AddInfrastructureServices()` existiert bereits und kann erweitert werden
-  - `AddPresentationServices()`
-  - `AddViewModels()`
-  - `AddPages()`
+- Extension-Methoden einführen bzw. nutzen:
+  - `AddInfrastructureServices()`
+  - `AddApplicationUseCases()`
+  - `AddPresentationViewModels()`
 - `MauiProgram` nur als Orchestrator belassen.
+
+**Status v1.6:** umgesetzt; `MauiProgram.cs` orchestriert die layer-spezifischen
+Registrierungen.
 
 **Akzeptanzkriterien:**
 
@@ -497,7 +524,7 @@ führen schnell zu Merge-Konflikten und erschweren Reviews.
 
 ---
 
-### P2 - Namespaces nach Layern vereinheitlichen
+### P2 - Namespaces nach Layern vereinheitlichen ✅ DONE in v1.6
 
 **Titel:** `Namespaces nach Layern trennen und vereinheitlichen`
 
@@ -515,12 +542,16 @@ Layer-Aufgaben haben. Das erschwert Code Reviews, Navigation und Refactorings.
 **Empfohlener Ansatz:**
 
 - Zielstruktur definieren:
-  - `Finanzuebersicht.Domain` oder `Finanzuebersicht.Core`
-  - `Finanzuebersicht.Application`
-  - `Finanzuebersicht.Infrastructure`
-  - `Finanzuebersicht.Presentation` oder MAUI-spezifisch
+  - `Finanzuebersicht.Core.Services`
+  - `Finanzuebersicht.Application.UseCases.*`
+  - `Finanzuebersicht.Infrastructure.Services`
+  - `Finanzuebersicht.Presentation.Services`
+  - MAUI-spezifische App-Typen bleiben unter `Finanzuebersicht.*`
 - Namespaces schrittweise angleichen.
 - Bei großen Umbenennungen kleine PRs bevorzugen.
+
+**Status v1.6:** umgesetzt; Layer-Namespaces sind vereinheitlicht und über
+projektbezogene `GlobalUsings.cs` ergänzt.
 
 **Akzeptanzkriterien:**
 
@@ -530,19 +561,24 @@ Layer-Aufgaben haben. Das erschwert Code Reviews, Navigation und Refactorings.
 
 ---
 
-### P2 - SettingsService async und testbar machen
+### P2 - SettingsService async und testbar machen ✅ DONE in v1.6
 
 **Titel:** `SettingsService: I/O abstrahieren und async/testbar machen`
 
 **Labels:** `refactor`, `settings`, `.NET`, `priority:medium`
 
-**Problem:**  
-`SettingsService` arbeitet synchron und hängt direkt an Pfaden bzw.
+**Problem (historischer Befund):**  
+`SettingsService` arbeitete synchron und hing direkt an Pfaden bzw.
 Dateisystemlogik.
+
+**Status v1.6:** Die konkrete Implementierung lebt jetzt in
+`Finanzuebersicht.Infrastructure.Services.SettingsService`; das Interface bleibt
+in `Finanzuebersicht.Core.Services`.
 
 **Betroffene Dateien:**
 
-- `Finanzuebersicht.Core/Services/SettingsService.cs`
+- `Finanzuebersicht.Infrastructure/Services/SettingsService.cs`
+- `Finanzuebersicht.Core/Services/ISettingsService.cs`
 - `Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs`
 
 **Impact:**  

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -68,9 +68,10 @@ version.json                       ← Nerdbank.GitVersioning config
 Directory.Build.props              ← Shared MSBuild properties
 
 Finanzuebersicht/                  ← MAUI app entry point (net10.0-ios, net10.0-maccatalyst, net10.0-windows)
-├── MauiProgram.cs                ← DI setup, feature registration
+├── MauiProgram.cs                ← thin DI orchestrator; calls Add*() extension methods
 ├── App.xaml / App.xaml.cs         ← App lifecycle
 ├── AppShell.xaml / AppShell.xaml.cs ← Shell navigation
+├── Services/                      ← MAUI-specific concrete services (LocalizationService, ShellDialogService, etc.)
 ├── Views/                         ← XAML pages (DashboardPage, TransactionsPage, etc.)
 ├── Converters/                    ← Value converters (BetragDisplayConverter, etc.)
 ├── Resources/Strings/             ← AppResources.resx (German), AppResources.en.resx (English)
@@ -78,28 +79,33 @@ Finanzuebersicht/                  ← MAUI app entry point (net10.0-ios, net10.
 ├── Charts/                        ← Custom chart implementations
 └── Platforms/                     ← iOS, MacCatalyst, Windows platform code
 
-Finanzuebersicht.Presentation/     ← Presentation Layer (net10.0) - MVVM ViewModels & Services
+Finanzuebersicht.Presentation/     ← Presentation Layer (net10.0) - MVVM ViewModels & UI abstractions
+├── DependencyInjection/           ← AddPresentationViewModels(...)
 ├── ViewModels/                    ← DashboardViewModel, TransactionsViewModel, SettingsViewModel, etc.
 │   └── Settings/                  ← AppearanceViewModel, BackupViewModel, StorageViewModel, AboutViewModel
 ├── Navigation/                    ← Shell navigation helpers
-├── Services/                      ← ILocalizationService, IDialogService, INavigationService implementations
+├── Services/                      ← namespace Finanzuebersicht.Presentation.Services (IDialogService, INavigationService, ILocalizationService, etc.)
 └── Resources/                     ← App-wide resources
 
 Finanzuebersicht.Application/      ← Application / Use Cases Layer (net10.0) - Business logic orchestration
+├── DependencyInjection/           ← AddApplicationUseCases()
+└── UseCases/                      ← namespace Finanzuebersicht.Application.UseCases.*
 
-Finanzuebersicht.Infrastructure/   ← Infrastructure Layer (net10.0) - DI setup, external service integration
-├── DependencyInjection/           ← Service registration (MauiBuilder extensions)
-└── Services/                      ← Infrastructure-level service implementations
+Finanzuebersicht.Infrastructure/   ← Infrastructure Layer (net10.0) - persistence & wiring
+├── DependencyInjection/           ← AddInfrastructureServices()
+└── Services/                      ← namespace Finanzuebersicht.Infrastructure.Services
+    ├── SettingsService            ← implements ISettingsService
+    ├── BackupService              ← implements IBackupService
+    ├── LocalDataService           ← implements repository interfaces (+ legacy IDataService facade)
+    └── *Store.cs                  ← CategoryStore, TransactionStore, RecurringStore, etc.
 
-Finanzuebersicht.Core/             ← Domain Layer (net10.0) - Models & Domain Services
-├── Models/                        ← Transaction, Category, RecurringTransaction, CategoryBudget, SparZiel
-├── Services/
-│   ├── IDataService               ← Data persistence interface
-│   ├── LocalDataService           ← JSON file-based persistence
-│   ├── SettingsService            ← User settings & preferences
-│   ├── BackupService              ← Backup/Restore with ZIP + schema migration
-│   ├── DataMigrationService       ← Schema versioning (v1 → v2+)
-│   └── InitializationService      ← App initialization, recurring transaction auto-generation
+Finanzuebersicht.Core/             ← Domain Layer (net10.0) - Models & domain services
+├── Models/                        ← namespace Finanzuebersicht.Models
+├── Services/                      ← namespace Finanzuebersicht.Core.Services
+│   ├── Interfaces                 ← ISettingsService, IBackupService, ICategoryRepository, etc.
+│   ├── Domain services            ← CategorizationService, RecurringGenerationService, ReportingService, etc.
+│   ├── AppPaths.cs                ← pure path helper (no file I/O)
+│   └── Migrations/                ← namespace Finanzuebersicht.Core.Services.Migrations
 └── Data/                          ← Embedded data files (categorization-rules.json)
 
 Finanzuebersicht.Tests/            ← xUnit tests (net10.0)
@@ -111,7 +117,7 @@ Finanzuebersicht.Tests/            ← xUnit tests (net10.0)
 ### MVVM-Architektur
 
 - **Framework:** CommunityToolkit.Mvvm mit Source Generators (kein manuelles `INotifyPropertyChanged`)
-- **DI:** Alle Services und ViewModels in `MauiProgram.cs` registriert
+- **DI:** `MauiProgram.cs` bleibt schlank und orchestriert `AddInfrastructureServices()`, `AddApplicationUseCases()` und `AddPresentationViewModels()`
 - **Pages:** Erhalten ViewModel via Constructor Injection
 - **Data Loading:** Triggern via Command in `OnAppearing()`
 
@@ -154,7 +160,8 @@ Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
 ## 8. Datenspeicherung
 
 - **Lokal:** JSON-Dateien via `LocalDataService` (Standard, keine externe Abhängigkeit)
-- **Pfad:** Standardmäßig `LocalApplicationData/Finanzuebersicht`, über `SettingsService` anpassbar
+- **Repos:** Neue Features arbeiten gegen spezifische Repository-Interfaces; `IDataService` bleibt nur für Legacy-Kompatibilität erhalten
+- **Pfad:** Standardmäßig `LocalApplicationData/Finanzuebersicht`, konfigurierbar über `ISettingsService` / `Infrastructure.Services.SettingsService`
 - **CloudKit:** Code vorhanden (`CloudKitDataService`), aber deaktiviert (erfordert kostenpflichtiges Apple Developer Account)
 - **Daueraufträge:** Automatische Generierung läuft auf `App.OnStart()` und `Window.Resumed`
 

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -44,10 +44,10 @@ dotnet test Finanzuebersicht.Tests
 | Location | Purpose |
 |----------|---------|
 | `Finanzuebersicht/` | MAUI app entry point (App.xaml, MauiProgram.cs, Views, Converters, Resources) |
-| `Finanzuebersicht.Presentation/` | Presentation layer (ViewModels, Navigation, UI Services) |
-| `Finanzuebersicht.Application/` | Application / Use Cases layer (net10.0) |
-| `Finanzuebersicht.Infrastructure/` | DI registration, infrastructure services (net10.0) |
-| `Finanzuebersicht.Core/` | Domain layer: models & business services (net10.0) |
+| `Finanzuebersicht.Presentation/` | Presentation layer (ViewModels, Navigation, `Finanzuebersicht.Presentation.Services`, `AddPresentationViewModels`) |
+| `Finanzuebersicht.Application/` | Application / Use Cases layer (`UseCases/*`, `AddApplicationUseCases`) |
+| `Finanzuebersicht.Infrastructure/` | Infrastructure layer (`SettingsService`, `BackupService`, `LocalDataService`, `*Store.cs`, `AddInfrastructureServices`) |
+| `Finanzuebersicht.Core/` | Domain layer: `Finanzuebersicht.Models` + `Finanzuebersicht.Core.Services` (interfaces, domain services, migrations) |
 | `Finanzuebersicht.Tests/` | xUnit tests (net10.0) |
 
 ## Key Resources
@@ -61,10 +61,11 @@ dotnet test Finanzuebersicht.Tests
 ## Architecture Overview
 
 - **MVVM** using CommunityToolkit.Mvvm source generators
-- **DI:** Register all services in `MauiProgram.cs`
+- **DI:** `MauiProgram.cs` acts as a thin orchestrator and calls `AddInfrastructureServices()`, `AddApplicationUseCases()` and `AddPresentationViewModels()`
 - **Localization:** German (default) + English support
-- **Data Persistence:** JSON files locally; CloudKit available but not maintained
-- **Backup:** ZIP-based with schema versioning and automatic migration (`DataMigrationService`)
+- **Data Persistence:** JSON files locally via `LocalDataService`; new code prefers specific repository interfaces, `IDataService` remains legacy-only
+- **Backup:** ZIP-based with schema versioning and automatic migration (`DataMigrationService`); `BackupService` lives in Infrastructure
+- **Logging:** `FileLogger` was removed; logging uses `ILogger<T>`
 
 ## Features
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -16,6 +16,27 @@
 
 ---
 
+## ✅ v1.6 — Architektur & Datenrobustheit *(abgeschlossen)*
+
+Fokus: Layering bereinigen, Persistenz robuster machen und DI modularisieren.
+
+| Issue | Thema | Status |
+|-------|-------|--------|
+| [#152](https://github.com/tom4711/finanzuebersicht/issues/152) | JSON-Persistenz: Korruption nicht stillschweigend als leere Daten behandeln | ✅ Closed |
+| [#153](https://github.com/tom4711/finanzuebersicht/issues/153) | Restore-Prozess transaktional absichern | ✅ Closed |
+| [#154](https://github.com/tom4711/finanzuebersicht/issues/154) | Refactor Core: I/O-, Logging- und Persistenz-Services aus Core auslagern | ✅ Closed |
+| [#155](https://github.com/tom4711/finanzuebersicht/issues/155) | CSV-Import: Teilimporte und globale Side-Effects vermeiden | ✅ Closed |
+| [#159](https://github.com/tom4711/finanzuebersicht/issues/159) | Recurring-Berechnung zentralisieren und CancellationToken unterstützen | ✅ Closed |
+| [#160](https://github.com/tom4711/finanzuebersicht/issues/160) | DataServiceFacade in fachlich getrennte Interfaces aufteilen | ✅ Closed |
+| [#161](https://github.com/tom4711/finanzuebersicht/issues/161) | DI-Registrierung in modulare Extensions aufteilen | ✅ Closed |
+| [#162](https://github.com/tom4711/finanzuebersicht/issues/162) | Namespaces nach Layern trennen und vereinheitlichen | ✅ Closed |
+| [#163](https://github.com/tom4711/finanzuebersicht/issues/163) | SettingsService: I/O abstrahieren und async/testbar machen | ✅ Closed |
+| [#168](https://github.com/tom4711/finanzuebersicht/issues/168) | UseCases um CancellationToken und klare Application-Verantwortung erweitern | ✅ Closed |
+
+Alle 10 Issues des Milestones sind geschlossen.
+
+---
+
 ## 🔧 v1.1 — Qualität & Performance *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/5)
 
 Fokus: Code-Qualität, technische Schulden abbauen, Performance verbessern.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,6 +2,8 @@
 
 Übersicht über geplante Releases und Features. Die Roadmap wird fortlaufend aktualisiert.
 
+> **Hinweis:** Die Milestone-Bezeichnungen (v1.1, v1.2, v2.0) sind thematische GitHub-Planungslabels, keine sequenziellen Release-Versionen. Tatsächliche Releases (v1.0, v1.6, v1.6.1 …) werden durch Git-Commit-Höhe via Nerdbank.GitVersioning bestimmt.
+
 ---
 
 ## ✅ v1.0 — Stable Release *(abgeschlossen)*


### PR DESCRIPTION
## Pre-Release Cleanup für v1.6.1

Zwei kleine, aber saubere Bereinigungen vor dem Release.

### Test Warnings behoben (0 Warnings, 0 Errors)

- **CS8601** in `SearchTransactionsUseCaseTests`: `kategorieId ?? string.Empty` statt direkter `string?` → `string` Zuweisung
- **CS0618** in 3 Test-Dateien: `#pragma warning disable CS0618` um Mock-Klassen die `IDataService` (obsolete) implementieren — diese Mocks sind intentional für Legacy-Coverage vorhanden

### Dokumentation aktualisiert

- **README.md**: Projektstruktur, Namespaces, DI-Extension-Methods, ILogger, IDataService-Legacy-Hinweis
- **GUIDE.md**: SettingsService/BackupService in Infrastructure; FileLogger-Entfernung; modulares DI
- **ARCHITECTURE_CLEAN_CODE_REVIEW.md**: v1.6-Statusabschnitt hinzugefügt; #154 und #162 als erledigt markiert
- **ROADMAP.md**: v1.6 Milestone komplett, alle 10 Issues geschlossen
- **QUICK_START.md**: Struktur/Architektur auf v1.6 aktualisiert

228 tests ✅ | 0 warnings ✅