### PR TITLE
chore(deps): pin floating package versions for build reproducibility (#165)

### DIFF
--- a/Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
+++ b/Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
+++ b/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="NSubstitute" Version="5.*" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -82,10 +82,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.*" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="14.*" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="14.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>


### PR DESCRIPTION
## Description

Replaces all floating package versions with specific pinned versions to ensure fully reproducible builds across CI pipelines and local development environments.

### Changes

Floating versions removed:
- `Microsoft.Maui.Controls: 10.0.*` → `10.0.60`
- `CommunityToolkit.Mvvm: 8.*` → `8.2.2`
- `CommunityToolkit.Maui: 14.*` → `14.1.1`
- `Microsoft.Extensions.Logging.Abstractions: *` → `10.0.0`
- `NSubstitute: 5.*` → `5.1.0`

### Benefits

✅ **Reproducible Builds**: Identical package versions across all environments
✅ **Predictable Behavior**: No surprises from automatic patch/minor updates
✅ **Clearer Troubleshooting**: Easier to identify version-related issues
✅ **Dependabot-Ready**: Can still auto-update with Dependabot

### Testing

✓ `dotnet restore` succeeds locally
✓ All projects restore without conflicts
✓ No dependency resolution issues

### Acceptance Criteria (from #165)

- [x] Keine `*`-Versionen in Projektdateien
- [x] Restore ist reproduzierbar
- [x] Dependencies funktionieren korrekt