### PR TITLE
chore(config): enable TreatWarningsAsErrors and fix Mvvm version conflict (#166)

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>

--- a/Finanzuebersicht.Presentation/Finanzuebersicht.Presentation.csproj
+++ b/Finanzuebersicht.Presentation/Finanzuebersicht.Presentation.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -84,7 +84,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="14.1.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Description

Implements Issue #166: MSBuild-Qualitätsgate einführen: Warnings als Fehler behandeln

### Changes

**1. TreatWarningsAsErrors – global aktiviert**
```xml
<TreatWarningsAsErrors>true</TreatWarningsAsErrors>
<AnalysisLevel>latest</AnalysisLevel>
```
Gilt für alle 6 Projekte: Core, Application, Infrastructure, Presentation, Tests, MAUI App.

**2. CommunityToolkit.Mvvm Versionskonflikt behoben**
- Updated: `8.2.2` → `8.4.0` (Finanzuebersicht.csproj + Presentation.csproj)
- Grund: CommunityToolkit.Maui 14.1.1 benötigt transitiv Mvvm 8.4.x
- Behebt 44 MSB3277-Warnings im MAUI-Build
- Fixt auch die verbliebene Floating Version `8.*` in Presentation.csproj (#186 Nachzügler)

### Build-Ergebnis nach der Änderung
```
net10.0 (Tests + Libraries): 0 Warnings, 0 Errors ✅
net10.0-maccatalyst (MAUI):  0 Warnings, 0 Errors ✅
Tests:                        228 passed ✅
```

### Acceptance Criteria (from #166)

- [x] Aktueller Build ist warnungsfrei
- [x] Neue Warnings schlagen lokal und in CI fehl
- [x] Policy liegt zentral in `Directory.Build.props`