### PR TITLE
🚀 Milestone v1.7 – Build, CI & Wartbarkeit

### DIFF
--- a/.github/workflows/ci-split.yml
+++ b/.github/workflows/ci-split.yml
@@ -55,9 +55,9 @@ jobs:
       matrix:
         include:
           - name: mac-default
-            run-maui: true
+            run_maui: true
           - name: mac-label-only
-            run-maui: false
+            run_maui: false
     steps:
       - uses: actions/checkout@v6
         with:
@@ -65,7 +65,7 @@ jobs:
       - name: Check for label
         id: labelcheck
         run: |
-          echo "run_maui=${{ matrix.run-maui }}" >> "$GITHUB_OUTPUT"
+          echo "run_maui=${{ matrix.run_maui }}" >> "$GITHUB_OUTPUT"
       - name: Setup .NET
         if: steps.labelcheck.outputs.run_maui == 'true'
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/ci-split.yml
+++ b/.github/workflows/ci-split.yml
@@ -62,7 +62,7 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
-      - name: Check for label
+      - name: Forward matrix to output
         id: labelcheck
         run: |
           echo "run_maui=${{ matrix.run_maui }}" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/ci-split.yml
+++ b/.github/workflows/ci-split.yml
@@ -36,7 +36,15 @@ jobs:
       - name: Restore tests only
         run: dotnet restore Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
       - name: Build & Test
-        run: dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj -c Release --no-restore --logger "console;verbosity=minimal"
+        run: dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj -c Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"
+       
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: warn
 
   full-maui-checks:
     name: Full MAUI build (macOS)
@@ -57,7 +65,7 @@ jobs:
       - name: Check for label
         id: labelcheck
         run: |
-          echo "::set-output name=run_maui::${{ matrix.run-maui }}"
+          echo "run_maui=${{ matrix.run-maui }}" >> "$GITHUB_OUTPUT"
       - name: Setup .NET
         if: steps.labelcheck.outputs.run_maui == 'true'
         uses: actions/setup-dotnet@v5

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           dotnet-version: '10.0.100'
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore Finanzuebersicht.Tests
 
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,15 @@ jobs:
           dotnet-version: '10.0.100'
 
       - name: Run tests
-        run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal"
+        run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"
+      
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: warn
 
   build:
     name: Build (Mac Catalyst)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,9 @@ jobs:
         with:
           dotnet-version: '10.0.100'
 
+      - name: Restore dependencies
+        run: dotnet restore
+
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"
       

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
           dotnet-version: '10.0.100'
 
       - name: Restore dependencies
-        run: dotnet restore Finanzuebersicht.Tests
+        run: dotnet restore Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
 
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -12,6 +12,30 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    name: Tests (.NET)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.100'
+
+      - name: Run tests
+        run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: warn
+
   version:
     name: Resolve version
     runs-on: ubuntu-latest
@@ -26,7 +50,7 @@ jobs:
   build-maccatalyst:
     name: Build macOS (Mac Catalyst)
     runs-on: macos-15
-    needs: version
+    needs: [version, test]
     steps:
       - uses: actions/checkout@v6
         with:
@@ -72,7 +96,7 @@ jobs:
   build-windows:
     name: Build Windows
     runs-on: windows-latest
-    needs: version
+    needs: [version, test]
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,7 +26,7 @@ jobs:
           dotnet-version: '10.0.100'
 
       - name: Restore dependencies
-        run: dotnet restore Finanzuebersicht.Tests
+        run: dotnet restore Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
 
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -25,6 +25,9 @@ jobs:
         with:
           dotnet-version: '10.0.100'
 
+      - name: Restore dependencies
+        run: dotnet restore
+
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"
 

--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -26,7 +26,7 @@ jobs:
           dotnet-version: '10.0.100'
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore Finanzuebersicht.Tests
 
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,9 +15,34 @@ permissions:
   contents: write
 
 jobs:
+  test:
+    name: Tests (.NET)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: Setup .NET
+        uses: actions/setup-dotnet@v5
+        with:
+          dotnet-version: '10.0.100'
+
+      - name: Run tests
+        run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v7
+        with:
+          name: coverage-report
+          path: coverage/
+          if-no-files-found: warn
+
   build-maccatalyst:
     name: Build macOS (Mac Catalyst)
     runs-on: macos-15
+    needs: test
     steps:
       - uses: actions/checkout@v6
         with:
@@ -71,6 +96,7 @@ jobs:
   build-windows:
     name: Build Windows
     runs-on: windows-latest
+    needs: test
     steps:
       - uses: actions/checkout@v6
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: '10.0.100'
 
       - name: Restore dependencies
-        run: dotnet restore Finanzuebersicht.Tests
+        run: dotnet restore Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
 
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,11 +22,15 @@ jobs:
       - uses: actions/checkout@v6
         with:
           fetch-depth: 0
+          ref: ${{ github.event.inputs.tag || github.ref }}
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
         with:
           dotnet-version: '10.0.100'
+
+      - name: Restore dependencies
+        run: dotnet restore
 
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,7 +30,7 @@ jobs:
           dotnet-version: '10.0.100'
 
       - name: Restore dependencies
-        run: dotnet restore
+        run: dotnet restore Finanzuebersicht.Tests
 
       - name: Run tests
         run: dotnet test Finanzuebersicht.Tests --configuration Release --no-restore --logger "console;verbosity=minimal" --collect:"XPlat Code Coverage" --results-directory="coverage"

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,5 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="Current" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <AnalysisLevel>latest</AnalysisLevel>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="Nerdbank.GitVersioning" Condition="!Exists('packages.config')">
       <PrivateAssets>all</PrivateAssets>

--- a/Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
+++ b/Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
@@ -14,7 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="*" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.0" />
   </ItemGroup>
 
 </Project>

--- a/Finanzuebersicht.Presentation/Finanzuebersicht.Presentation.csproj
+++ b/Finanzuebersicht.Presentation/Finanzuebersicht.Presentation.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 

--- a/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
+++ b/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0" />
+    <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NSubstitute" Version="5.*" />
     <PackageReference Include="xunit" Version="2.9.3" />

--- a/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
+++ b/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NSubstitute" Version="5.*" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />

--- a/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
+++ b/Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
@@ -10,7 +10,7 @@
   <ItemGroup>
     <PackageReference Include="coverlet.collector" Version="10.0.1" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
-    <PackageReference Include="NSubstitute" Version="5.*" />
+    <PackageReference Include="NSubstitute" Version="5.1.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5" />
   </ItemGroup>

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -82,10 +82,10 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.*" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.*" />
-		<PackageReference Include="CommunityToolkit.Maui" Version="14.*" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+		<PackageReference Include="CommunityToolkit.Maui" Version="14.1.1" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -84,7 +84,7 @@
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.60" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
-		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.2.2" />
+		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.0" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="14.1.1" />
 	</ItemGroup>
 


### PR DESCRIPTION
## Milestone v1.7 – Build, CI & Wartbarkeit

Dieses Release umfasst alle drei Issues des Milestones v1.7:

### Enthaltene Änderungen

- **#167 – CI Coverage & Test Gates** (PR #184)
  - Code-Coverage-Erfassung in allen CI-Workflows (XPlat Code Coverage)
  - Coverage-Reports als Build-Artefakte
  - Test-Jobs als Gate vor Release- und Prerelease-Builds
  - Fix: deprecated `::set-output` → `$GITHUB_OUTPUT`

- **#165 – Floating Package Versions eliminieren** (PR #186)
  - Alle `*`-Versionen durch exakte Versionen ersetzt
  - Reproduzierbare Builds garantiert

- **#166 – MSBuild Warnings als Fehler** (PR #187)
  - `TreatWarningsAsErrors=true` global in Directory.Build.props
  - `AnalysisLevel=latest` für aktuelle Analyzer-Regeln
  - CommunityToolkit.Mvvm 8.2.2 → 8.4.0 (behebt MSB3277-Konflikt)

### Qualität

- ✅ 228 Tests bestanden
- ✅ 0 Warnings, 0 Errors (macOS + Tests)
- ✅ Alle PRs durch Copilot-Review gegangen
