### PR TITLE
🔧 chore(config): bump version to 1.7

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5",
+  "version": "1.7",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Version-Bump von 1.5 auf 1.7 in `version.json` für den Milestone-Release v1.7.

Nach Merge in develop → PR develop → main → Tag `v1.7.0` erstellen.