### PR TITLE
🚀 Release v1.7.0 – Version bump

### DIFF
--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.5",
+  "version": "1.7",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
Version-Bump auf 1.7 in `version.json` für den Release-Tag.

Nach Merge wird Tag `v1.7.0` erstellt.