### PR TITLE
🔧 chore(git): add .github/skills to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,5 @@ Finanzuebersicht.Tests/TestResults/test-results.trx
 Finanzuebersicht.Tests/dotnet-tools.json
 *.lscache
 coverage/
+
+/.github/skills/

--- a/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -32,9 +32,13 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<LoadTransactionDetailDataUseCase>();
         services.AddTransient<DeleteTransactionUseCase>();
         services.AddTransient<LoadTransactionsMonthUseCase>();
+        services.AddTransient<LoadTransactionTemplatesUseCase>();
         services.AddTransient<SearchTransactionsUseCase>();
         services.AddTransient<SaveRecurringTransactionDetailUseCase>();
         services.AddTransient<SaveTransactionDetailUseCase>();
+        services.AddTransient<SaveTransactionTemplateUseCase>();
+        services.AddTransient<DeleteTransactionTemplateUseCase>();
+        services.AddTransient<UseTransactionTemplateUseCase>();
 
         services.AddTransient<LoadSparZieleUseCase>();
         services.AddTransient<SaveSparZielUseCase>();

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
@@ -73,16 +73,52 @@ public class LoadDashboardMonthUseCase(
             .OrderByDescending(k => k.Total)
             .ToList();
 
-        // Enrich with budget data
         var budgets = await _budgetRepository.GetBudgetsAsync() ?? [];
+        var isCurrentMonth = aktuellerMonat.Year == today.Year && aktuellerMonat.Month == today.Month;
+        var verbleibendeTage = isCurrentMonth
+            ? Math.Max(1, (bis.Date - today.Date).Days + 1)
+            : 0;
+
+        // Enrich with budget data
         foreach (var cs in kategorieAusgaben)
         {
-            var budget = budgets.FirstOrDefault(b => b.KategorieId == cs.CategoryId && b.Jahr == aktuellerMonat.Year && b.Monat == aktuellerMonat.Month)
-                ?? budgets.FirstOrDefault(b => b.KategorieId == cs.CategoryId && b.Jahr == null && b.Monat == aktuellerMonat.Month)
-                ?? budgets.FirstOrDefault(b => b.KategorieId == cs.CategoryId && b.Jahr == null && b.Monat == null);
+            var budget = FindBudgetForMonth(budgets, cs.CategoryId, aktuellerMonat.Year, aktuellerMonat.Month);
             if (budget != null)
                 cs.BudgetBetrag = budget.Betrag;
         }
+
+        var ausgabenNachKategorie = transaktionen
+            .Where(t => t.Typ == TransactionType.Ausgabe)
+            .GroupBy(t => t.KategorieId)
+            .ToDictionary(g => g.Key, g => g.Sum(t => Math.Abs(t.Betrag)));
+
+        var budgetHinweise = budgets
+            .Select(b => new
+            {
+                Budget = b,
+                Effective = FindBudgetForMonth(budgets, b.KategorieId, aktuellerMonat.Year, aktuellerMonat.Month)
+            })
+            .Where(x => x.Effective?.Id == x.Budget.Id && x.Budget.Betrag > 0)
+            .Select(x =>
+            {
+                var category = kategorien.FirstOrDefault(k => k.Id == x.Budget.KategorieId) ?? unkategorisiert;
+                ausgabenNachKategorie.TryGetValue(x.Budget.KategorieId, out var verbrauch);
+                return new BudgetHintSummary
+                {
+                    CategoryId = x.Budget.KategorieId,
+                    CategoryName = category.Name,
+                    Color = category.Color,
+                    Icon = category.Icon,
+                    BudgetBetrag = x.Budget.Betrag,
+                    Verbrauch = verbrauch,
+                    IstAktuellerMonat = isCurrentMonth,
+                    VerbleibendeTage = verbleibendeTage
+                };
+            })
+            .OrderByDescending(b => b.IstKritisch)
+            .ThenByDescending(b => b.VerbrauchProzentRaw)
+            .ThenBy(b => b.CategoryName)
+            .ToList();
 
         var kategorieEinnahmen = transaktionen
             .Where(t => t.Typ == TransactionType.Einnahme)
@@ -106,9 +142,15 @@ public class LoadDashboardMonthUseCase(
             GesamtAusgaben = gesamtAusgaben,
             Bilanz = gesamtEinnahmen - gesamtAusgaben,
             KategorieAusgaben = kategorieAusgaben,
-            KategorieEinnahmen = kategorieEinnahmen
+            KategorieEinnahmen = kategorieEinnahmen,
+            BudgetHinweise = budgetHinweise
         };
     }
+
+    private static CategoryBudget? FindBudgetForMonth(IEnumerable<CategoryBudget> budgets, string categoryId, int year, int month)
+        => budgets.FirstOrDefault(b => b.KategorieId == categoryId && b.Jahr == year && b.Monat == month)
+            ?? budgets.FirstOrDefault(b => b.KategorieId == categoryId && b.Jahr == null && b.Monat == month)
+            ?? budgets.FirstOrDefault(b => b.KategorieId == categoryId && b.Jahr == null && b.Monat == null);
 
     private static bool OccursInRange(RecurringTransaction da, DateTime rangeStart, DateTime rangeEnd)
     {
@@ -222,4 +264,5 @@ public class DashboardMonthData
     public decimal Bilanz { get; set; }
     public List<CategorySummary> KategorieAusgaben { get; set; } = new List<CategorySummary>();
     public List<CategorySummary> KategorieEinnahmen { get; set; } = new List<CategorySummary>();
+    public List<BudgetHintSummary> BudgetHinweise { get; set; } = new List<BudgetHintSummary>();
 }

--- a/Finanzuebersicht.Application/UseCases/Transactions/DeleteTransactionTemplateUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/DeleteTransactionTemplateUseCase.cs
@@ -1,0 +1,12 @@
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public class DeleteTransactionTemplateUseCase(ITransactionTemplateRepository repository)
+{
+    private readonly ITransactionTemplateRepository _repository = repository;
+
+    public Task ExecuteAsync(string id, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _repository.DeleteTransactionTemplateAsync(id);
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionTemplatesUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionTemplatesUseCase.cs
@@ -1,0 +1,15 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public class LoadTransactionTemplatesUseCase(ITransactionTemplateRepository repository)
+{
+    private readonly ITransactionTemplateRepository _repository = repository;
+
+    public async Task<List<TransactionTemplate>> ExecuteAsync(int limit = 6, CancellationToken cancellationToken = default)
+    {
+        var templates = await _repository.GetTransactionTemplatesAsync();
+        cancellationToken.ThrowIfCancellationRequested();
+        return [.. templates.Take(limit)];
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionTemplateUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionTemplateUseCase.cs
@@ -1,0 +1,14 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public class SaveTransactionTemplateUseCase(ITransactionTemplateRepository repository)
+{
+    private readonly ITransactionTemplateRepository _repository = repository;
+
+    public Task ExecuteAsync(TransactionTemplate template, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return _repository.SaveTransactionTemplateAsync(template);
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Transactions/UseTransactionTemplateUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/UseTransactionTemplateUseCase.cs
@@ -1,0 +1,20 @@
+using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public class UseTransactionTemplateUseCase(
+    ITransactionTemplateRepository repository,
+    IClock clock)
+{
+    private readonly ITransactionTemplateRepository _repository = repository;
+    private readonly IClock _clock = clock;
+
+    public async Task ExecuteAsync(TransactionTemplate template, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        template.LastUsedAt = _clock.UtcNow;
+        template.UseCount++;
+        await _repository.SaveTransactionTemplateAsync(template);
+    }
+}

--- a/Finanzuebersicht.Core/Models/AggregationModels.cs
+++ b/Finanzuebersicht.Core/Models/AggregationModels.cs
@@ -26,6 +26,32 @@ namespace Finanzuebersicht.Models
             : 0;
     }
 
+    public class BudgetHintSummary
+    {
+        public string CategoryId { get; set; } = string.Empty;
+        public string CategoryName { get; set; } = string.Empty;
+        public string? Color { get; set; }
+        public string Icon { get; set; } = "📁";
+        public decimal BudgetBetrag { get; set; }
+        public decimal Verbrauch { get; set; }
+        public bool IstAktuellerMonat { get; set; }
+        public int VerbleibendeTage { get; set; }
+
+        public decimal Restbudget => BudgetBetrag - Verbrauch;
+        public decimal RestbudgetPositiv => Math.Max(Restbudget, 0);
+        public decimal Tagesbudget => IstAktuellerMonat && VerbleibendeTage > 0
+            ? RestbudgetPositiv / VerbleibendeTage
+            : 0;
+        public decimal VerbrauchProzentRaw => BudgetBetrag > 0
+            ? Verbrauch / BudgetBetrag * 100
+            : 0;
+        public decimal VerbrauchProzent => Math.Min(VerbrauchProzentRaw, 100);
+        public bool IstWarnung => IstAktuellerMonat && VerbrauchProzentRaw >= 80 && VerbrauchProzentRaw < 100;
+        public bool IstAusgeschoepft => IstAktuellerMonat && VerbrauchProzentRaw >= 100;
+        public bool IstKritisch => IstWarnung || IstAusgeschoepft;
+        public bool ZeigeTagesbudget => IstAktuellerMonat && RestbudgetPositiv > 0;
+    }
+
     public class ForecastResult
     {
         public int Year { get; set; }

--- a/Finanzuebersicht.Core/Models/ImportPreviewResult.cs
+++ b/Finanzuebersicht.Core/Models/ImportPreviewResult.cs
@@ -1,0 +1,14 @@
+namespace Finanzuebersicht.Models;
+
+public class ImportPreviewResult
+{
+    public string SessionId { get; init; } = Guid.NewGuid().ToString();
+    public IReadOnlyList<ImportPreviewRow> Rows { get; init; } = [];
+    public string? ErrorMessage { get; init; }
+    public bool Success => ErrorMessage is null;
+    public int ReadyCount => Rows.Count(r => r.Status == ImportPreviewRowStatus.Ready);
+    public int DuplicateCount => Rows.Count(r => r.Status == ImportPreviewRowStatus.Duplicate);
+    public int InvalidCount => Rows.Count(r => r.Status == ImportPreviewRowStatus.Invalid);
+    public int UncategorizedCount => Rows.Count(r => r.Status == ImportPreviewRowStatus.Uncategorized);
+    public int IncludedCount => Rows.Count(r => r.IsIncluded);
+}

--- a/Finanzuebersicht.Core/Models/ImportPreviewRow.cs
+++ b/Finanzuebersicht.Core/Models/ImportPreviewRow.cs
@@ -1,0 +1,11 @@
+namespace Finanzuebersicht.Models;
+
+public class ImportPreviewRow
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public int SourceIndex { get; set; }
+    public bool IsIncluded { get; set; }
+    public ImportPreviewRowStatus Status { get; set; }
+    public string? StatusMessage { get; set; }
+    public Transaction Transaction { get; set; } = new();
+}

--- a/Finanzuebersicht.Core/Models/ImportPreviewRowStatus.cs
+++ b/Finanzuebersicht.Core/Models/ImportPreviewRowStatus.cs
@@ -1,0 +1,10 @@
+namespace Finanzuebersicht.Models;
+
+public enum ImportPreviewRowStatus
+{
+    Ready,
+    Duplicate,
+    Invalid,
+    Uncategorized,
+    SaveError
+}

--- a/Finanzuebersicht.Core/Models/TransactionTemplate.cs
+++ b/Finanzuebersicht.Core/Models/TransactionTemplate.cs
@@ -1,0 +1,14 @@
+namespace Finanzuebersicht.Models;
+
+public class TransactionTemplate
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = string.Empty;
+    public string Titel { get; set; } = string.Empty;
+    public decimal Betrag { get; set; }
+    public string KategorieId { get; set; } = string.Empty;
+    public TransactionType Typ { get; set; } = TransactionType.Ausgabe;
+    public string Verwendungszweck { get; set; } = string.Empty;
+    public DateTime? LastUsedAt { get; set; }
+    public int UseCount { get; set; }
+}

--- a/Finanzuebersicht.Core/Services/CategorizationService.cs
+++ b/Finanzuebersicht.Core/Services/CategorizationService.cs
@@ -29,8 +29,24 @@ public class CategorizationService(
         IEnumerable<Category> availableCategories,
         CancellationToken cancellationToken = default)
     {
-        ArgumentNullException.ThrowIfNull(dto);
+        var category = await TryCategorizAsync(
+            dto,
+            availableCategories,
+            allowFallback: true,
+            strategyFilter: null,
+            cancellationToken).ConfigureAwait(false);
 
+        return category ?? throw new InvalidOperationException("Unkategorisiert category not found in available categories");
+    }
+
+    public async Task<Category?> TryCategorizAsync(
+        TransactionDto dto,
+        IEnumerable<Category> availableCategories,
+        bool allowFallback = true,
+        Func<ICategorizationStrategy, bool>? strategyFilter = null,
+        CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(dto);
         ArgumentNullException.ThrowIfNull(availableCategories);
 
         var categories = availableCategories.ToList();
@@ -38,7 +54,10 @@ public class CategorizationService(
             ?? categories.FirstOrDefault(c => c.Name == "Unkategorisiert");
 
         // Execute strategies in priority order
-        var sortedStrategies = _strategies.OrderBy(s => s.Priority).ToList();
+        var sortedStrategies = _strategies
+            .Where(strategyFilter ?? (_ => true))
+            .OrderBy(s => s.Priority)
+            .ToList();
 
         foreach (var strategy in sortedStrategies)
         {
@@ -65,7 +84,7 @@ public class CategorizationService(
         }
 
         // Fallback to Unkategorisiert
-        if (uncategorizedCategory != null)
+        if (allowFallback && uncategorizedCategory != null)
         {
             _logger?.LogInformation(
                 "Transaction '{Title}' fell back to Unkategorisiert (no strategy matched)",
@@ -73,6 +92,6 @@ public class CategorizationService(
             return uncategorizedCategory;
         }
 
-        throw new InvalidOperationException("Unkategorisiert category not found in available categories");
+        return null;
     }
 }

--- a/Finanzuebersicht.Core/Services/ITransactionTemplateRepository.cs
+++ b/Finanzuebersicht.Core/Services/ITransactionTemplateRepository.cs
@@ -1,0 +1,11 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Core.Services;
+
+public interface ITransactionTemplateRepository
+{
+    Task<List<TransactionTemplate>> GetTransactionTemplatesAsync();
+    Task SaveTransactionTemplateAsync(TransactionTemplate template);
+    Task DeleteTransactionTemplateAsync(string id);
+    Task ReplaceAllTransactionTemplatesAsync(IEnumerable<TransactionTemplate> templates);
+}

--- a/Finanzuebersicht.Core/Services/ImportMessageKeys.cs
+++ b/Finanzuebersicht.Core/Services/ImportMessageKeys.cs
@@ -1,0 +1,11 @@
+namespace Finanzuebersicht.Core.Services;
+
+/// <summary>
+/// ResX key names for import preview status detail messages (resolved via ILocalizationService in UI).
+/// </summary>
+public static class ImportMessageKeys
+{
+    public const string MissingBookingDate = "Msg_ImportStatusMissingDate";
+    public const string PossibleDuplicate = "Msg_ImportStatusPossibleDuplicate";
+    public const string CategoryUnresolved = "Msg_ImportStatusCategoryUnresolved";
+}

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -96,7 +96,7 @@ namespace Finanzuebersicht.Core.Services
                         SourceIndex = index,
                         IsIncluded = false,
                         Status = ImportPreviewRowStatus.Invalid,
-                        StatusMessage = "Missing booking date",
+                        StatusMessage = ImportMessageKeys.MissingBookingDate,
                         Transaction = placeholderTransaction
                     });
                     continue;
@@ -110,7 +110,7 @@ namespace Finanzuebersicht.Core.Services
                         SourceIndex = index,
                         IsIncluded = false,
                         Status = ImportPreviewRowStatus.Duplicate,
-                        StatusMessage = "Possible duplicate",
+                        StatusMessage = ImportMessageKeys.PossibleDuplicate,
                         Transaction = transaction
                     });
                     continue;
@@ -131,7 +131,9 @@ namespace Finanzuebersicht.Core.Services
                     SourceIndex = index,
                     IsIncluded = true,
                     Status = status,
-                    StatusMessage = status == ImportPreviewRowStatus.Uncategorized ? "Category unresolved" : null,
+                    StatusMessage = status == ImportPreviewRowStatus.Uncategorized
+                        ? ImportMessageKeys.CategoryUnresolved
+                        : null,
                     Transaction = transaction
                 });
 

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -276,7 +276,7 @@ namespace Finanzuebersicht.Core.Services
             CancellationToken cancellationToken)
         {
             if (_categoryRepository is null || categories.Count == 0)
-                return [];
+                return new Dictionary<string, Category>(StringComparer.Ordinal);
 
             var categoriesById = categories.ToDictionary(c => c.Id, c => c);
             var uncategorizedIds = categories
@@ -292,28 +292,38 @@ namespace Finanzuebersicht.Core.Services
                 .ToList();
 
             if (payees.Count == 0)
-                return [];
+                return new Dictionary<string, Category>(StringComparer.Ordinal);
 
+            // Limit timeframe to recent period to avoid scanning entire DB
+            var since = DateTime.Today.AddMonths(-24);
             List<Transaction> transactions;
             try
             {
                 transactions = await _transactionRepository
-                    .GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue)
+                    .GetTransactionsAsync(since, DateTime.MaxValue)
                     .ConfigureAwait(false);
             }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex, "ImportService: failed to load historical transactions for categorization");
-                return [];
+                return new Dictionary<string, Category>(StringComparer.Ordinal);
             }
+
+            // Build index by normalized title to reduce repeated scans
+            var transactionsByKey = transactions
+                .Select(t => new { Key = Normalize(t.Titel), Tx = t })
+                .Where(x => !string.IsNullOrWhiteSpace(x.Key))
+                .GroupBy(x => x.Key)
+                .ToDictionary(g => g.Key, g => g.Select(x => x.Tx).ToList(), StringComparer.Ordinal);
 
             var result = new Dictionary<string, Category>(StringComparer.Ordinal);
             foreach (var normalizedPayee in payees)
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var matchingTransactions = transactions
-                    .Where(t => IsPayeeMatch(t.Titel, normalizedPayee))
+                var matchingTransactions = transactionsByKey
+                    .Where(kv => kv.Key == normalizedPayee || kv.Key.Contains(normalizedPayee))
+                    .SelectMany(kv => kv.Value)
                     .ToList();
 
                 if (matchingTransactions.Count == 0)

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -79,12 +79,25 @@ namespace Finanzuebersicht.Core.Services
 
                 if (dto is null || dto.Buchungsdatum == default)
                 {
+                    var placeholderTransaction = new Transaction
+                    {
+                        Id = Guid.NewGuid().ToString(),
+                        Betrag = 0m,
+                        Datum = dto?.Buchungsdatum ?? default,
+                        Titel = dto is not null ? BuildTitle(dto) : string.Empty,
+                        Verwendungszweck = dto?.Verwendungszweck ?? string.Empty,
+                        KategorieId = string.Empty,
+                        Typ = TransactionType.Ausgabe,
+                        AccountId = accountId ?? dto?.SourceAccountId ?? string.Empty
+                    };
+
                     rows.Add(new ImportPreviewRow
                     {
                         SourceIndex = index,
                         IsIncluded = false,
                         Status = ImportPreviewRowStatus.Invalid,
-                        StatusMessage = "Missing booking date"
+                        StatusMessage = "Missing booking date",
+                        Transaction = placeholderTransaction
                     });
                     continue;
                 }
@@ -484,11 +497,6 @@ namespace Finanzuebersicht.Core.Services
                 && Normalize(existing.Titel) == Normalize(candidate.Titel);
         }
 
-        private static bool IsPayeeMatch(string? title, string normalizedPayee)
-        {
-            var normalizedTitle = Normalize(title);
-            return normalizedTitle == normalizedPayee || normalizedTitle.Contains(normalizedPayee, StringComparison.Ordinal);
-        }
 
         private static bool IsUncategorizedCategory(Category category)
             => category.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -1,11 +1,6 @@
-using System;
-using System.Collections.Generic;
-using System.IO;
-using System.Linq;
+using System.Globalization;
 using System.Text;
 using System.Text.RegularExpressions;
-using System.Globalization;
-using System.Threading;
 using Microsoft.Extensions.Logging;
 using Finanzuebersicht.Models;
 
@@ -18,28 +13,205 @@ namespace Finanzuebersicht.Core.Services
         ICategoryRepository? categoryRepository = null,
         CategorizationService? categorizationService = null)
     {
+        private const double HistoricalConfidenceThreshold = 0.5;
+
         private readonly IEnumerable<IStatementParser> _parsers = parsers;
         private readonly ITransactionRepository _transactionRepository = transactionRepository;
         private readonly ILogger<ImportService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         private readonly ICategoryRepository? _categoryRepository = categoryRepository;
         private readonly CategorizationService? _categorizationService = categorizationService;
 
-        public async System.Threading.Tasks.Task<ImportResult> ImportFromCsvAsync(
-            System.IO.Stream csvStream,
+        public async Task<ImportResult> ImportFromCsvAsync(
+            Stream csvStream,
             string? accountId = null,
-            System.Threading.CancellationToken cancellationToken = default)
+            CancellationToken cancellationToken = default)
+        {
+            var preview = await AnalyzeCsvAsync(csvStream, accountId, cancellationToken).ConfigureAwait(false);
+            if (!preview.Success)
+            {
+                return new ImportResult { ErrorMessage = preview.ErrorMessage };
+            }
+
+            var previewDuplicates = preview.Rows
+                .Where(r => r.Status == ImportPreviewRowStatus.Duplicate)
+                .Select(r => CloneTransaction(r.Transaction))
+                .ToList();
+
+            var commitResult = await CommitImportAsync(preview, cancellationToken: cancellationToken).ConfigureAwait(false);
+            var allDuplicates = previewDuplicates.Concat(commitResult.Duplicates).ToList();
+
+            return new ImportResult
+            {
+                Imported = commitResult.Imported,
+                Duplicates = allDuplicates,
+                SkippedMalformed = preview.InvalidCount,
+                SaveErrors = commitResult.SaveErrors,
+                ErrorMessage = commitResult.ErrorMessage
+            };
+        }
+
+        public async Task<ImportPreviewResult> AnalyzeCsvAsync(
+            Stream csvStream,
+            string? accountId = null,
+            CancellationToken cancellationToken = default)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            _logger.LogInformation("ImportService: starting import (accountId={AccountId})", accountId ?? "(none)");
+            _logger.LogInformation("ImportService: starting analysis (accountId={AccountId})", accountId ?? "(none)");
 
-            // 1. Read stream into memory
+            var parseResult = await ParseDtosAsync(csvStream, cancellationToken).ConfigureAwait(false);
+            if (parseResult.ErrorMessage is not null)
+            {
+                return new ImportPreviewResult { ErrorMessage = parseResult.ErrorMessage };
+            }
+
+            var dtos = parseResult.Dtos!;
+            var categories = await LoadCategoriesAsync().ConfigureAwait(false);
+            var existingInRange = await LoadExistingTransactionsForDtosAsync(dtos).ConfigureAwait(false);
+            var historicalCategories = await BuildHistoricalCategoryMapAsync(dtos, categories, cancellationToken).ConfigureAwait(false);
+
+            var rows = new List<ImportPreviewRow>();
+            var batchTransactions = new List<Transaction>();
+
+            for (var index = 0; index < dtos.Count; index++)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+                var dto = dtos[index];
+
+                if (dto is null || dto.Buchungsdatum == default)
+                {
+                    rows.Add(new ImportPreviewRow
+                    {
+                        SourceIndex = index,
+                        IsIncluded = false,
+                        Status = ImportPreviewRowStatus.Invalid,
+                        StatusMessage = "Missing booking date"
+                    });
+                    continue;
+                }
+
+                var transaction = CreateTransaction(dto, accountId);
+                if (ContainsDuplicate(existingInRange, transaction) || ContainsDuplicate(batchTransactions, transaction))
+                {
+                    rows.Add(new ImportPreviewRow
+                    {
+                        SourceIndex = index,
+                        IsIncluded = false,
+                        Status = ImportPreviewRowStatus.Duplicate,
+                        StatusMessage = "Possible duplicate",
+                        Transaction = transaction
+                    });
+                    continue;
+                }
+
+                transaction.KategorieId = await ResolveCategoryIdForAnalyzeAsync(
+                    dto,
+                    categories,
+                    historicalCategories,
+                    cancellationToken).ConfigureAwait(false);
+
+                var status = string.IsNullOrWhiteSpace(transaction.KategorieId)
+                    ? ImportPreviewRowStatus.Uncategorized
+                    : ImportPreviewRowStatus.Ready;
+
+                rows.Add(new ImportPreviewRow
+                {
+                    SourceIndex = index,
+                    IsIncluded = true,
+                    Status = status,
+                    StatusMessage = status == ImportPreviewRowStatus.Uncategorized ? "Category unresolved" : null,
+                    Transaction = transaction
+                });
+
+                batchTransactions.Add(transaction);
+            }
+
+            _logger.LogInformation(
+                "ImportService: analysis finished — ready={Ready}, duplicates={Duplicates}, invalid={Invalid}, uncategorized={Uncategorized}",
+                rows.Count(r => r.Status == ImportPreviewRowStatus.Ready),
+                rows.Count(r => r.Status == ImportPreviewRowStatus.Duplicate),
+                rows.Count(r => r.Status == ImportPreviewRowStatus.Invalid),
+                rows.Count(r => r.Status == ImportPreviewRowStatus.Uncategorized));
+
+            return new ImportPreviewResult { Rows = rows };
+        }
+
+        public async Task<ImportResult> CommitImportAsync(
+            ImportPreviewResult preview,
+            IEnumerable<string>? selectedRowIds = null,
+            CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(preview);
+            cancellationToken.ThrowIfCancellationRequested();
+
+            if (!preview.Success)
+            {
+                return new ImportResult { ErrorMessage = preview.ErrorMessage };
+            }
+
+            var selectedIds = selectedRowIds?.ToHashSet(StringComparer.Ordinal)
+                ?? preview.Rows.Where(r => r.IsIncluded).Select(r => r.Id).ToHashSet(StringComparer.Ordinal);
+
+            var rowsToCommit = preview.Rows
+                .Where(r => selectedIds.Contains(r.Id) && r.IsIncluded && IsCommittableStatus(r.Status))
+                .ToList();
+
+            var existingInRange = await LoadExistingTransactionsForRowsAsync(rowsToCommit).ConfigureAwait(false);
+            var imported = new List<Transaction>();
+            var duplicates = new List<Transaction>();
+            var saveErrors = new List<string>();
+            var committedBatch = new List<Transaction>();
+            string? uncategorizedCategoryId = null;
+
+            foreach (var row in rowsToCommit)
+            {
+                cancellationToken.ThrowIfCancellationRequested();
+
+                var transaction = CloneTransaction(row.Transaction);
+                if (string.IsNullOrWhiteSpace(transaction.KategorieId))
+                {
+                    uncategorizedCategoryId ??= await EnsureUncategorizedCategoryAsync(cancellationToken).ConfigureAwait(false);
+                    transaction.KategorieId = uncategorizedCategoryId;
+                }
+
+                if (ContainsDuplicate(existingInRange, transaction) || ContainsDuplicate(committedBatch, transaction))
+                {
+                    duplicates.Add(transaction);
+                    continue;
+                }
+
+                try
+                {
+                    await _transactionRepository.SaveTransactionAsync(transaction).ConfigureAwait(false);
+                    imported.Add(transaction);
+                    existingInRange.Add(transaction);
+                    committedBatch.Add(transaction);
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "ImportService: failed to save transaction '{Title}' {Amount} on {Date}",
+                        transaction.Titel, transaction.Betrag, transaction.Datum);
+                    saveErrors.Add($"{transaction.Titel} ({transaction.Datum:dd.MM.yyyy}): {ex.Message}");
+                }
+            }
+
+            return new ImportResult
+            {
+                Imported = imported,
+                Duplicates = duplicates,
+                SaveErrors = saveErrors
+            };
+        }
+
+        private async Task<(List<TransactionDto>? Dtos, string? ErrorMessage)> ParseDtosAsync(
+            Stream csvStream,
+            CancellationToken cancellationToken)
+        {
             byte[] buffer;
             try
             {
                 using var ms = new MemoryStream();
                 await csvStream.CopyToAsync(ms, cancellationToken).ConfigureAwait(false);
                 buffer = ms.ToArray();
-                _logger.LogDebug("ImportService: read input stream {Bytes} bytes", buffer.Length);
             }
             catch (OperationCanceledException)
             {
@@ -48,13 +220,10 @@ namespace Finanzuebersicht.Core.Services
             catch (Exception ex)
             {
                 _logger.LogError(ex, "ImportService: failed to read input stream");
-                return new ImportResult { ErrorMessage = $"Fehler beim Lesen der Datei: {ex.Message}" };
+                return (null, $"Fehler beim Lesen der Datei: {ex.Message}");
             }
 
-            // 2. Find a parser that returns records
             var parserList = _parsers?.ToList() ?? [];
-            _logger.LogInformation("ImportService: available parsers={Count}", parserList.Count);
-
             List<TransactionDto>? dtosList = null;
             foreach (var parser in parserList)
             {
@@ -75,126 +244,267 @@ namespace Finanzuebersicht.Core.Services
                 {
                     _logger.LogInformation("ImportService: parser {Parser} matched with {Count} records",
                         parser.GetType().Name, dtosList.Count);
-                    break;
+                    return (dtosList, null);
                 }
 
                 dtosList = null;
             }
 
-            if (dtosList is null or { Count: 0 })
+            _logger.LogInformation("ImportService: no parser matched or no records found");
+            return (null, "Kein passender Parser gefunden oder keine Datensätze in der Datei.");
+        }
+
+        private async Task<List<Category>> LoadCategoriesAsync()
+        {
+            if (_categoryRepository is null)
+                return [];
+
+            try
             {
-                _logger.LogInformation("ImportService: no parser matched or no records found");
-                return new ImportResult { ErrorMessage = "Kein passender Parser gefunden oder keine Datensätze in der Datei." };
+                return await _categoryRepository.GetCategoriesAsync().ConfigureAwait(false);
             }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to load categories during analysis");
+                return [];
+            }
+        }
 
-            // 3. Validate and build transaction list (no saves yet)
-            var toImport = new List<Transaction>();
-            var duplicates = new List<Transaction>();
-            var skippedMalformed = 0;
+        private async Task<Dictionary<string, Category>> BuildHistoricalCategoryMapAsync(
+            IReadOnlyList<TransactionDto> dtos,
+            IReadOnlyList<Category> categories,
+            CancellationToken cancellationToken)
+        {
+            if (_categoryRepository is null || categories.Count == 0)
+                return [];
 
-            // Load existing transactions once for the full import date range (avoids N+1 queries).
-            // Only consider DTOs with a valid Buchungsdatum — malformed ones (default/MinValue) are
-            // skipped later in the loop and must not distort the date range.
-            List<Transaction>? existingInRange = null;
-            var validDates = dtosList
-                .Where(d => d?.Buchungsdatum != null && d.Buchungsdatum != default)
-                .Select(d => d!.Buchungsdatum)
+            var categoriesById = categories.ToDictionary(c => c.Id, c => c);
+            var uncategorizedIds = categories
+                .Where(IsUncategorizedCategory)
+                .Select(c => c.Id)
+                .ToHashSet(StringComparer.Ordinal);
+
+            var payees = dtos
+                .Select(GetPayee)
+                .Where(p => !string.IsNullOrWhiteSpace(p))
+                .Select(p => Normalize(p!))
+                .Distinct(StringComparer.Ordinal)
                 .ToList();
-            if (validDates.Count > 0)
+
+            if (payees.Count == 0)
+                return [];
+
+            List<Transaction> transactions;
+            try
             {
-                try
-                {
-                    var minDate = validDates.Min().Date.AddDays(-1);
-                    var maxDate = validDates.Max().Date.AddDays(1);
-                    existingInRange = await _transactionRepository
-                        .GetTransactionsAsync(minDate, maxDate).ConfigureAwait(false);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "ImportService: failed to load existing transactions for duplicate check; duplicates won't be detected");
-                }
-            }
-
-            foreach (var dto in dtosList)
-            {
-                cancellationToken.ThrowIfCancellationRequested();
-
-                if (dto is null || dto.Buchungsdatum == default)
-                {
-                    skippedMalformed++;
-                    _logger.LogDebug("ImportService: skipping malformed DTO");
-                    continue;
-                }
-
-                var title = BuildTitle(dto);
-                var transaction = new Transaction
-                {
-                    Betrag = dto.Betrag,
-                    Datum = dto.Buchungsdatum,
-                    Titel = title,
-                    Verwendungszweck = dto.Verwendungszweck ?? string.Empty,
-                    KategorieId = string.Empty,
-                    Typ = dto.Betrag >= 0 ? TransactionType.Einnahme : TransactionType.Ausgabe,
-                    AccountId = accountId ?? dto.SourceAccountId
-                };
-
-                // Duplicate check (against in-memory snapshot loaded once before the loop)
-                bool isDuplicate = false;
-                if (existingInRange is not null)
-                {
-                    var from = dto.Buchungsdatum.Date.AddDays(-1);
-                    var to = dto.Buchungsdatum.Date.AddDays(1);
-                    isDuplicate = existingInRange.Any(e =>
-                        e.Datum.Date >= from && e.Datum.Date <= to &&
-                        e.Betrag == dto.Betrag &&
-                        Normalize(e.Titel) == Normalize(title));
-                }
-
-                if (isDuplicate)
-                {
-                    _logger.LogDebug("ImportService: duplicate detected for '{Title}' {Amount} on {Date}",
-                        title, dto.Betrag, dto.Buchungsdatum);
-                    duplicates.Add(transaction);
-                    continue;
-                }
-
-                // Auto-categorize
-                transaction.KategorieId = await ResolveCategoryAsync(dto, transaction, cancellationToken)
+                transactions = await _transactionRepository
+                    .GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue)
                     .ConfigureAwait(false);
-
-                toImport.Add(transaction);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to load historical transactions for categorization");
+                return [];
             }
 
-            // 4. Save all valid transactions (bulk — fail individually but continue for others)
-            var saveErrors = new List<string>();
-            var imported = new List<Transaction>();
-
-            foreach (var transaction in toImport)
+            var result = new Dictionary<string, Category>(StringComparer.Ordinal);
+            foreach (var normalizedPayee in payees)
             {
                 cancellationToken.ThrowIfCancellationRequested();
-                try
-                {
-                    await _transactionRepository.SaveTransactionAsync(transaction).ConfigureAwait(false);
-                    imported.Add(transaction);
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogError(ex, "ImportService: failed to save transaction '{Title}' {Amount} on {Date}",
-                        transaction.Titel, transaction.Betrag, transaction.Datum);
-                    saveErrors.Add($"{transaction.Titel} ({transaction.Datum:dd.MM.yyyy}): {ex.Message}");
-                }
+
+                var matchingTransactions = transactions
+                    .Where(t => IsPayeeMatch(t.Titel, normalizedPayee))
+                    .ToList();
+
+                if (matchingTransactions.Count == 0)
+                    continue;
+
+                var categoryCounts = matchingTransactions
+                    .Where(t => !string.IsNullOrWhiteSpace(t.KategorieId) && !uncategorizedIds.Contains(t.KategorieId))
+                    .GroupBy(t => t.KategorieId)
+                    .Select(g => new { CategoryId = g.Key, Count = g.Count() })
+                    .OrderByDescending(x => x.Count)
+                    .ToList();
+
+                if (categoryCounts.Count == 0)
+                    continue;
+
+                var top = categoryCounts[0];
+                var confidence = (double)top.Count / matchingTransactions.Count;
+                if (confidence < HistoricalConfidenceThreshold)
+                    continue;
+
+                if (!categoriesById.TryGetValue(top.CategoryId, out var category))
+                    continue;
+
+                result[normalizedPayee] = category;
             }
 
-            _logger.LogInformation(
-                "ImportService: finished — imported={I}, duplicates={D}, malformed={M}, saveErrors={E}",
-                imported.Count, duplicates.Count, skippedMalformed, saveErrors.Count);
+            return result;
+        }
 
-            return new ImportResult
+        private async Task<string> ResolveCategoryIdForAnalyzeAsync(
+            TransactionDto dto,
+            IReadOnlyList<Category> categories,
+            IReadOnlyDictionary<string, Category> historicalCategories,
+            CancellationToken cancellationToken)
+        {
+            if (categories.Count == 0)
+                return string.Empty;
+
+            if (_categorizationService is not null)
             {
-                Imported = imported,
-                Duplicates = duplicates,
-                SkippedMalformed = skippedMalformed,
-                SaveErrors = saveErrors,
+                var category = await _categorizationService.TryCategorizAsync(
+                    dto,
+                    categories,
+                    allowFallback: false,
+                    strategyFilter: strategy => strategy is not HistoricalCategorizationStrategy,
+                    cancellationToken: cancellationToken).ConfigureAwait(false);
+
+                if (category is not null)
+                    return category.Id;
+            }
+
+            var payee = GetPayee(dto);
+            if (string.IsNullOrWhiteSpace(payee))
+                return string.Empty;
+
+            return historicalCategories.TryGetValue(Normalize(payee), out var historicalCategory)
+                ? historicalCategory.Id
+                : string.Empty;
+        }
+
+        private async Task<List<Transaction>> LoadExistingTransactionsForDtosAsync(IReadOnlyList<TransactionDto> dtos)
+        {
+            var validDates = dtos
+                .Where(d => d?.Buchungsdatum != null && d.Buchungsdatum != default)
+                .Select(d => d!.Buchungsdatum.Date)
+                .ToList();
+
+            if (validDates.Count == 0)
+                return [];
+
+            try
+            {
+                return await _transactionRepository
+                    .GetTransactionsAsync(validDates.Min().AddDays(-1), validDates.Max().AddDays(1))
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to load existing transactions for duplicate check");
+                return [];
+            }
+        }
+
+        private async Task<List<Transaction>> LoadExistingTransactionsForRowsAsync(IReadOnlyList<ImportPreviewRow> rows)
+        {
+            var validDates = rows
+                .Select(r => r.Transaction.Datum.Date)
+                .ToList();
+
+            if (validDates.Count == 0)
+                return [];
+
+            try
+            {
+                return await _transactionRepository
+                    .GetTransactionsAsync(validDates.Min().AddDays(-1), validDates.Max().AddDays(1))
+                    .ConfigureAwait(false);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to reload transactions for commit duplicate check");
+                return [];
+            }
+        }
+
+        private async Task<string> EnsureUncategorizedCategoryAsync(CancellationToken cancellationToken)
+        {
+            if (_categoryRepository is null)
+                return string.Empty;
+
+            var categories = await _categoryRepository.GetCategoriesAsync().ConfigureAwait(false);
+            var uncategorized = categories.FirstOrDefault(IsUncategorizedCategory);
+            if (uncategorized is not null)
+                return uncategorized.Id;
+
+            uncategorized = new Category
+            {
+                Name = "Unkategorisiert",
+                Icon = "❓",
+                Color = "#A2845E",
+                Typ = TransactionType.Ausgabe,
+                SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert
+            };
+
+            cancellationToken.ThrowIfCancellationRequested();
+            await _categoryRepository.SaveCategoryAsync(uncategorized).ConfigureAwait(false);
+            return uncategorized.Id;
+        }
+
+        private static Transaction CreateTransaction(TransactionDto dto, string? accountId)
+        {
+            return new Transaction
+            {
+                Betrag = dto.Betrag,
+                Datum = dto.Buchungsdatum,
+                Titel = BuildTitle(dto),
+                Verwendungszweck = dto.Verwendungszweck ?? string.Empty,
+                KategorieId = string.Empty,
+                Typ = dto.Betrag >= 0 ? TransactionType.Einnahme : TransactionType.Ausgabe,
+                AccountId = accountId ?? dto.SourceAccountId
+            };
+        }
+
+        private static bool IsCommittableStatus(ImportPreviewRowStatus status)
+            => status is ImportPreviewRowStatus.Ready or ImportPreviewRowStatus.Uncategorized or ImportPreviewRowStatus.SaveError;
+
+        private static bool ContainsDuplicate(IEnumerable<Transaction> candidates, Transaction transaction)
+            => candidates.Any(candidate => IsDuplicate(candidate, transaction));
+
+        private static bool IsDuplicate(Transaction existing, Transaction candidate)
+        {
+            var from = candidate.Datum.Date.AddDays(-1);
+            var to = candidate.Datum.Date.AddDays(1);
+            return existing.Datum.Date >= from
+                && existing.Datum.Date <= to
+                && existing.Betrag == candidate.Betrag
+                && Normalize(existing.Titel) == Normalize(candidate.Titel);
+        }
+
+        private static bool IsPayeeMatch(string? title, string normalizedPayee)
+        {
+            var normalizedTitle = Normalize(title);
+            return normalizedTitle == normalizedPayee || normalizedTitle.Contains(normalizedPayee, StringComparison.Ordinal);
+        }
+
+        private static bool IsUncategorizedCategory(Category category)
+            => category.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert
+               || string.Equals(category.Name, "Unkategorisiert", StringComparison.OrdinalIgnoreCase);
+
+        private static string? GetPayee(TransactionDto dto)
+        {
+            return !string.IsNullOrWhiteSpace(dto.Zahlungsempfaenger)
+                ? dto.Zahlungsempfaenger.Trim()
+                : !string.IsNullOrWhiteSpace(dto.Zahlungspflichtige)
+                    ? dto.Zahlungspflichtige.Trim()
+                    : null;
+        }
+
+        private static Transaction CloneTransaction(Transaction transaction)
+        {
+            return new Transaction
+            {
+                Id = transaction.Id,
+                Betrag = transaction.Betrag,
+                Titel = transaction.Titel,
+                Datum = transaction.Datum,
+                KategorieId = transaction.KategorieId,
+                Typ = transaction.Typ,
+                DauerauftragId = transaction.DauerauftragId,
+                AccountId = transaction.AccountId,
+                Verwendungszweck = transaction.Verwendungszweck
             };
         }
 
@@ -213,73 +523,6 @@ namespace Finanzuebersicht.Core.Services
                 : title;
         }
 
-        private async System.Threading.Tasks.Task<string> ResolveCategoryAsync(
-            TransactionDto dto,
-            Transaction transaction,
-            CancellationToken cancellationToken)
-        {
-            if (_categoryRepository is null)
-                return string.Empty;
-
-            List<Category>? categories = null;
-            try
-            {
-                categories = await _categoryRepository.GetCategoriesAsync().ConfigureAwait(false);
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "ImportService: failed to load categories for auto-categorization; attempting Unkategorisiert fallback");
-                // categories stays null — fall through to Unkategorisiert fallback below
-            }
-
-            if (categories is { Count: > 0 } && _categorizationService is not null)
-            {
-                try
-                {
-                    var category = await _categorizationService
-                        .CategorizAsync(dto, categories, cancellationToken).ConfigureAwait(false);
-                    if (category is not null)
-                    {
-                        _logger.LogDebug("ImportService: auto-categorized '{Title}' → {Category}",
-                            transaction.Titel, category.Name);
-                        return category.Id;
-                    }
-                }
-                catch (Exception ex)
-                {
-                    _logger.LogWarning(ex, "ImportService: categorization failed for '{Title}'", transaction.Titel);
-                }
-            }
-
-            // Fallback to "Unkategorisiert" system category
-            try
-            {
-                var unclassified = categories?.FirstOrDefault(c =>
-                    c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert ||
-                    c.Name == "Unkategorisiert");
-
-                if (unclassified is null)
-                {
-                    unclassified = new Category
-                    {
-                        Name = "Unkategorisiert",
-                        Icon = "❓",
-                        Color = "#A2845E",
-                        Typ = TransactionType.Ausgabe,
-                        SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert
-                    };
-                    await _categoryRepository.SaveCategoryAsync(unclassified).ConfigureAwait(false);
-                }
-
-                return unclassified.Id;
-            }
-            catch (Exception ex)
-            {
-                _logger.LogWarning(ex, "ImportService: failed to ensure default category");
-                return string.Empty;
-            }
-        }
-
         private static string Normalize(string? input)
         {
             if (string.IsNullOrWhiteSpace(input)) return string.Empty;
@@ -291,6 +534,7 @@ namespace Finanzuebersicht.Core.Services
                 if (CharUnicodeInfo.GetUnicodeCategory(c) != UnicodeCategory.NonSpacingMark)
                     sb.Append(c);
             }
+
             var cleaned = new string([.. sb.ToString().Where(c => char.IsLetterOrDigit(c) || char.IsWhiteSpace(c))]);
             return Regex.Replace(cleaned, "\\s+", " ").Trim();
         }

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -334,10 +334,19 @@ namespace Finanzuebersicht.Core.Services
             {
                 cancellationToken.ThrowIfCancellationRequested();
 
-                var matchingTransactions = transactionsByKey
-                    .Where(kv => kv.Key == normalizedPayee || kv.Key.Contains(normalizedPayee))
-                    .SelectMany(kv => kv.Value)
-                    .ToList();
+                // Prefer exact lookup, fallback to contains-scan only when needed
+                List<Transaction> matchingTransactions;
+                if (transactionsByKey.TryGetValue(normalizedPayee, out var exactList))
+                {
+                    matchingTransactions = exactList;
+                }
+                else
+                {
+                    matchingTransactions = transactionsByKey
+                        .Where(kv => kv.Key.Contains(normalizedPayee, StringComparison.Ordinal))
+                        .SelectMany(kv => kv.Value)
+                        .ToList();
+                }
 
                 if (matchingTransactions.Count == 0)
                     continue;

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -457,7 +457,8 @@ namespace Finanzuebersicht.Core.Services
         {
             return new Transaction
             {
-                Betrag = dto.Betrag,
+                // Normalize amount to positive value; sign represented by Typ
+                Betrag = Math.Abs(dto.Betrag),
                 Datum = dto.Buchungsdatum,
                 Titel = BuildTitle(dto),
                 Verwendungszweck = dto.Verwendungszweck ?? string.Empty,
@@ -479,7 +480,7 @@ namespace Finanzuebersicht.Core.Services
             var to = candidate.Datum.Date.AddDays(1);
             return existing.Datum.Date >= from
                 && existing.Datum.Date <= to
-                && existing.Betrag == candidate.Betrag
+                && Math.Abs(existing.Betrag) == Math.Abs(candidate.Betrag)
                 && Normalize(existing.Titel) == Normalize(candidate.Titel);
         }
 

--- a/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -52,6 +52,11 @@ public static class InfrastructureServiceCollectionExtensions
                 GetDataDir(sp),
                 sp.GetService<ILogger<SparZielStore>>()));
 
+        services.AddSingleton<TransactionTemplateStore>(sp =>
+            new TransactionTemplateStore(
+                GetDataDir(sp),
+                sp.GetService<ILogger<TransactionTemplateStore>>()));
+
         // Register composite LocalDataService which coordinates all stores
         // Stores are injected, not manually constructed
         services.AddSingleton<LocalDataService>(sp =>
@@ -61,6 +66,7 @@ public static class InfrastructureServiceCollectionExtensions
                 sp.GetRequiredService<RecurringStore>(),
                 sp.GetRequiredService<BudgetStore>(),
                 sp.GetRequiredService<SparZielStore>(),
+                sp.GetRequiredService<TransactionTemplateStore>(),
                 sp.GetRequiredService<Finanzuebersicht.Core.Services.IClock>()));
 
         // Expose the LocalDataService instance via the repository interfaces it implements
@@ -69,6 +75,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<IRecurringTransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
         services.AddSingleton<IBudgetRepository>(sp => sp.GetRequiredService<LocalDataService>());
         services.AddSingleton<ISparZielRepository>(sp => sp.GetRequiredService<LocalDataService>());
+        services.AddSingleton<ITransactionTemplateRepository>(sp => sp.GetRequiredService<LocalDataService>());
 
         return services;
     }

--- a/Finanzuebersicht.Infrastructure/Services/BackupService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/BackupService.cs
@@ -20,6 +20,7 @@ namespace Finanzuebersicht.Infrastructure.Services
         private readonly IRecurringTransactionRepository _recurringRepository;
         private readonly IBudgetRepository _budgetRepository;
         private readonly ISparZielRepository _sparZielRepository;
+        private readonly ITransactionTemplateRepository? _transactionTemplateRepository;
         private readonly ISettingsService _settingsService;
         private readonly ILogger<BackupService>? _logger;
         private readonly Finanzuebersicht.Core.Services.IClock _clock;
@@ -42,6 +43,7 @@ namespace Finanzuebersicht.Infrastructure.Services
             ISparZielRepository sparZielRepository,
             ISettingsService settingsService,
             DataMigrationService migrationService,
+            ITransactionTemplateRepository? transactionTemplateRepository = null,
             ILogger<BackupService>? logger = null,
             Finanzuebersicht.Core.Services.IClock? clock = null)
         {
@@ -50,6 +52,7 @@ namespace Finanzuebersicht.Infrastructure.Services
             _recurringRepository = recurringRepository ?? throw new ArgumentNullException(nameof(recurringRepository));
             _budgetRepository = budgetRepository ?? throw new ArgumentNullException(nameof(budgetRepository));
             _sparZielRepository = sparZielRepository ?? throw new ArgumentNullException(nameof(sparZielRepository));
+            _transactionTemplateRepository = transactionTemplateRepository;
             _settingsService = settingsService ?? throw new ArgumentNullException(nameof(settingsService));
             _migrationService = migrationService ?? throw new ArgumentNullException(nameof(migrationService));
             _logger = logger;
@@ -77,6 +80,9 @@ namespace Finanzuebersicht.Infrastructure.Services
                 var recurring = await _recurringRepository.GetRecurringTransactionsAsync();
                 var budgets = await _budgetRepository.GetBudgetsAsync();
                 var sparziele = await _sparZielRepository.GetSparZieleAsync();
+                List<TransactionTemplate> transactionTemplates = _transactionTemplateRepository is null
+                    ? []
+                    : await _transactionTemplateRepository.GetTransactionTemplatesAsync();
 
                 // Erstelle Metadaten
                 var metadata = new BackupMetadata
@@ -91,7 +97,8 @@ namespace Finanzuebersicht.Infrastructure.Services
                         { "transactions", transactions.Count() },
                         { "recurring", recurring.Count() },
                         { "budgets", budgets.Count },
-                        { "sparziele", sparziele.Count }
+                        { "sparziele", sparziele.Count },
+                        { "transactionTemplates", transactionTemplates.Count }
                     }
                 };
 
@@ -104,11 +111,12 @@ namespace Finanzuebersicht.Infrastructure.Services
                     WriteJsonToZip(zipArchive, "recurring.json", recurring);
                     WriteJsonToZip(zipArchive, "budgets.json", budgets);
                     WriteJsonToZip(zipArchive, "sparziele.json", sparziele);
+                    WriteJsonToZip(zipArchive, "transaction-templates.json", transactionTemplates);
                     WriteJsonToZip(zipArchive, BackupMetadataFileName, metadata);
                 }
 
-                _logger?.LogInformation("Backup erstellt: {FileName} mit {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträgen, {BudCount} Budgets, {SparCount} Sparzielen",
-                    fileName, metadata.EntityCounts["categories"], metadata.EntityCounts["transactions"], metadata.EntityCounts["recurring"], metadata.EntityCounts["budgets"], metadata.EntityCounts["sparziele"]);
+                _logger?.LogInformation("Backup erstellt: {FileName} mit {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträgen, {BudCount} Budgets, {SparCount} Sparzielen, {TemplateCount} Vorlagen",
+                    fileName, metadata.EntityCounts["categories"], metadata.EntityCounts["transactions"], metadata.EntityCounts["recurring"], metadata.EntityCounts["budgets"], metadata.EntityCounts["sparziele"], metadata.EntityCounts["transactionTemplates"]);
 
                 // Speichere Zeitstempel in Settings
                 _settingsService.SetLastBackupTime(_clock.UtcNow);
@@ -213,12 +221,13 @@ namespace Finanzuebersicht.Infrastructure.Services
                 var recurring = DeserializeFile<List<RecurringTransaction>>(archiveData, "recurring.json");
                 var budgets = DeserializeFile<List<CategoryBudget>>(archiveData, "budgets.json");
                 var sparziele = DeserializeFile<List<SparZiel>>(archiveData, "sparziele.json");
+                var transactionTemplates = DeserializeFile<List<TransactionTemplate>>(archiveData, "transaction-templates.json") ?? [];
 
                 if (categories == null || transactions == null || recurring == null || budgets == null || sparziele == null)
                     return new RestoreResult { Success = false, ErrorMessage = "ZIP-Datei ist beschädigt oder unvollständig" };
 
                 // Atomare Restore mit Rollback-Capability
-                var restoreSuccess = await AtomicRestoreAsync(categories, transactions, recurring, budgets, sparziele);
+                var restoreSuccess = await AtomicRestoreAsync(categories, transactions, recurring, budgets, sparziele, transactionTemplates);
 
                 if (!restoreSuccess)
                     return new RestoreResult { Success = false, ErrorMessage = "Fehler beim Speichern der wiederhergestellten Daten" };
@@ -231,7 +240,8 @@ namespace Finanzuebersicht.Infrastructure.Services
                     Success = true,
                     Details = $"Wiederhergestellt: {counts.GetValueOrDefault("categories")} Kategorien, " +
                               $"{counts.GetValueOrDefault("transactions")} Transaktionen, " +
-                              $"{counts.GetValueOrDefault("recurring")} Daueraufträge",
+                              $"{counts.GetValueOrDefault("recurring")} Daueraufträge, " +
+                              $"{counts.GetValueOrDefault("transactionTemplates")} Vorlagen",
                     RestoredMetadata = archiveData.Metadata
                 };
             }
@@ -266,7 +276,8 @@ namespace Finanzuebersicht.Infrastructure.Services
             List<Transaction> transactions,
             List<RecurringTransaction> recurring,
             List<CategoryBudget> budgets,
-            List<SparZiel> sparziele)
+            List<SparZiel> sparziele,
+            List<TransactionTemplate> transactionTemplates)
         {
             // Snapshot des aktuellen Zustands laden (für Rollback).
             // Wenn dieser Schritt fehlschlägt (z.B. DataCorruptionException), bricht der Restore
@@ -276,24 +287,29 @@ namespace Finanzuebersicht.Infrastructure.Services
             var snapshotRecurring = await _recurringRepository.GetRecurringTransactionsAsync();
             var snapshotBudgets = await _budgetRepository.GetBudgetsAsync();
             var snapshotSparziele = await _sparZielRepository.GetSparZieleAsync();
+            List<TransactionTemplate> snapshotTransactionTemplates = _transactionTemplateRepository is null
+                ? []
+                : await _transactionTemplateRepository.GetTransactionTemplatesAsync();
 
             try
             {
-                _logger?.LogInformation("Starte Wiederherstellung: {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträge, {BudCount} Budgets, {SparCount} Sparziele",
-                    categories.Count, transactions.Count, recurring.Count, budgets.Count, sparziele.Count);
+                _logger?.LogInformation("Starte Wiederherstellung: {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträge, {BudCount} Budgets, {SparCount} Sparziele, {TemplateCount} Vorlagen",
+                    categories.Count, transactions.Count, recurring.Count, budgets.Count, sparziele.Count, transactionTemplates.Count);
 
                 await _categoryRepository.ReplaceAllCategoriesAsync(categories);
                 await _transactionRepository.ReplaceAllTransactionsAsync(transactions);
                 await _recurringRepository.ReplaceAllRecurringTransactionsAsync(recurring);
                 await _budgetRepository.ReplaceAllBudgetsAsync(budgets);
                 await _sparZielRepository.ReplaceAllSparZieleAsync(sparziele);
+                if (_transactionTemplateRepository is not null)
+                    await _transactionTemplateRepository.ReplaceAllTransactionTemplatesAsync(transactionTemplates);
 
                 return true;
             }
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Fehler bei der Wiederherstellung – starte Rollback");
-                await RollbackAsync(snapshotCategories, snapshotTransactions, snapshotRecurring, snapshotBudgets, snapshotSparziele);
+                await RollbackAsync(snapshotCategories, snapshotTransactions, snapshotRecurring, snapshotBudgets, snapshotSparziele, snapshotTransactionTemplates);
                 return false;
             }
         }
@@ -303,7 +319,8 @@ namespace Finanzuebersicht.Infrastructure.Services
             List<Transaction> transactions,
             List<RecurringTransaction> recurring,
             List<CategoryBudget> budgets,
-            List<SparZiel> sparziele)
+            List<SparZiel> sparziele,
+            List<TransactionTemplate> transactionTemplates)
         {
             try
             {
@@ -312,6 +329,8 @@ namespace Finanzuebersicht.Infrastructure.Services
                 await _recurringRepository.ReplaceAllRecurringTransactionsAsync(recurring);
                 await _budgetRepository.ReplaceAllBudgetsAsync(budgets);
                 await _sparZielRepository.ReplaceAllSparZieleAsync(sparziele);
+                if (_transactionTemplateRepository is not null)
+                    await _transactionTemplateRepository.ReplaceAllTransactionTemplatesAsync(transactionTemplates);
 
                 _logger?.LogInformation("Rollback erfolgreich abgeschlossen");
             }

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -14,13 +14,14 @@ namespace Finanzuebersicht.Infrastructure.Services;
 /// - ReportingService: Transaction aggregations
 /// - RecurringGenerationService: Auto-generation of recurring transactions
 /// </summary>
-public class LocalDataService : IDataService, IDisposable
+public class LocalDataService : IDataService, ITransactionTemplateRepository, IDisposable
 {
     private readonly CategoryStore _categoryStore;
     private readonly TransactionStore _transactionStore;
     private readonly RecurringStore _recurringStore;
     private readonly BudgetStore _budgetStore;
     private readonly SparZielStore _sparZielStore;
+    private readonly TransactionTemplateStore _transactionTemplateStore;
     private readonly ReportingService _reportingService;
     private readonly RecurringGenerationService _recurringGenerationService;
 
@@ -33,6 +34,7 @@ public class LocalDataService : IDataService, IDisposable
         RecurringStore recurringStore,
         BudgetStore budgetStore,
         SparZielStore sparZielStore,
+        TransactionTemplateStore transactionTemplateStore,
         IClock clock)
     {
         _categoryStore = categoryStore;
@@ -40,6 +42,7 @@ public class LocalDataService : IDataService, IDisposable
         _recurringStore = recurringStore;
         _budgetStore = budgetStore;
         _sparZielStore = sparZielStore;
+        _transactionTemplateStore = transactionTemplateStore;
         _reportingService = new ReportingService(_transactionStore, _categoryStore);
         _recurringGenerationService = new RecurringGenerationService(_recurringStore, _transactionStore, clock);
     }
@@ -58,6 +61,7 @@ public class LocalDataService : IDataService, IDisposable
         _recurringStore = new RecurringStore(dataDir);
         _budgetStore = new BudgetStore(dataDir);
         _sparZielStore = new SparZielStore(dataDir);
+        _transactionTemplateStore = new TransactionTemplateStore(dataDir);
         _reportingService = new ReportingService(_transactionStore, _categoryStore);
         _recurringGenerationService = new RecurringGenerationService(_recurringStore, _transactionStore, clock);
     }
@@ -152,6 +156,22 @@ public class LocalDataService : IDataService, IDisposable
     public Task DeleteSparZielAsync(string id) => _sparZielStore.DeleteSparZielAsync(id);
     public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele)
         => _sparZielStore.ReplaceAllSparZieleAsync(sparziele);
+
+    #endregion
+
+    #region ITransactionTemplateRepository delegation
+
+    public Task<List<TransactionTemplate>> GetTransactionTemplatesAsync()
+        => _transactionTemplateStore.GetTransactionTemplatesAsync();
+
+    public Task SaveTransactionTemplateAsync(TransactionTemplate template)
+        => _transactionTemplateStore.SaveTransactionTemplateAsync(template);
+
+    public Task DeleteTransactionTemplateAsync(string id)
+        => _transactionTemplateStore.DeleteTransactionTemplateAsync(id);
+
+    public Task ReplaceAllTransactionTemplatesAsync(IEnumerable<TransactionTemplate> templates)
+        => _transactionTemplateStore.ReplaceAllTransactionTemplatesAsync(templates);
 
     #endregion
 

--- a/Finanzuebersicht.Infrastructure/Services/TransactionTemplateStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/TransactionTemplateStore.cs
@@ -1,0 +1,64 @@
+using Finanzuebersicht.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Finanzuebersicht.Infrastructure.Services;
+
+public class TransactionTemplateStore(string dataDir, ILogger<TransactionTemplateStore>? logger = null)
+    : JsonDataStoreBase(dataDir, logger), ITransactionTemplateRepository
+{
+    private string TemplatesFile => Path.Combine(DataDir, "transaction-templates.json");
+
+    public async Task<List<TransactionTemplate>> GetTransactionTemplatesAsync()
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            var items = await LoadAsync<TransactionTemplate>(TemplatesFile);
+            return [.. items
+                .OrderByDescending(t => t.LastUsedAt ?? DateTime.MinValue)
+                .ThenByDescending(t => t.UseCount)
+                .ThenBy(t => t.Name)];
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
+    public async Task SaveTransactionTemplateAsync(TransactionTemplate template)
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            var items = await LoadAsync<TransactionTemplate>(TemplatesFile);
+            var idx = items.FindIndex(t => t.Id == template.Id);
+            if (idx >= 0)
+                items[idx] = template;
+            else
+                items.Add(template);
+            await SaveAsync(TemplatesFile, items);
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
+    public async Task DeleteTransactionTemplateAsync(string id)
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            var items = await LoadAsync<TransactionTemplate>(TemplatesFile);
+            items.RemoveAll(t => t.Id == id);
+            await SaveAsync(TemplatesFile, items);
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
+    public Task ReplaceAllTransactionTemplatesAsync(IEnumerable<TransactionTemplate> templates)
+        => ReplaceAllAsync(TemplatesFile, templates);
+}

--- a/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
@@ -35,6 +35,7 @@ public static class PresentationServiceCollectionExtensions
         services.AddTransient<SettingsViewModel>();
         services.AddTransient<SparZieleViewModel>();
         services.AddTransient<BackupListViewModel>();
+        services.AddTransient<ImportPreviewViewModel>();
 
         return services;
     }

--- a/Finanzuebersicht.Presentation/Navigation/Routes.cs
+++ b/Finanzuebersicht.Presentation/Navigation/Routes.cs
@@ -12,4 +12,5 @@ public static class Routes
     public static readonly string RecurringInstanceShift = "RecurringInstanceShiftPage";
     public static readonly string Settings = "SettingsPage";
     public static readonly string BackupList = "BackupListPage";
+    public static readonly string ImportPreview = "ImportPreviewPage";
 }

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -65,6 +65,9 @@ public static class ResourceKeys
     public const string Btn_Ja = nameof(Btn_Ja);
     public const string Btn_Nein = nameof(Btn_Nein);
     public const string Btn_AktivInaktiv = nameof(Btn_AktivInaktiv);
+    public const string Btn_Duplizieren = nameof(Btn_Duplizieren);
+    public const string Btn_Verwenden = nameof(Btn_Verwenden);
+    public const string Btn_AlsVorlageSpeichern = nameof(Btn_AlsVorlageSpeichern);
 
     // Hints / Placeholders
     public const string Hint_Kategoriename = nameof(Hint_Kategoriename);
@@ -103,6 +106,8 @@ public static class ResourceKeys
     public const string Dlg_DauerauftragLoeschenFrage = nameof(Dlg_DauerauftragLoeschenFrage);
     public const string Dlg_TransaktionLoeschen = nameof(Dlg_TransaktionLoeschen);
     public const string Dlg_TransaktionLoeschenFrage = nameof(Dlg_TransaktionLoeschenFrage);
+    public const string Dlg_VorlageLoeschen = nameof(Dlg_VorlageLoeschen);
+    public const string Dlg_VorlageLoeschenFrage = nameof(Dlg_VorlageLoeschenFrage);
     public const string Dlg_SparZielLoeschen = nameof(Dlg_SparZielLoeschen);
     public const string Dlg_SparZielLoeschenFrage = nameof(Dlg_SparZielLoeschenFrage);
 
@@ -161,6 +166,14 @@ public static class ResourceKeys
     public const string Msg_ImportAbgeschlossen_Title = nameof(Msg_ImportAbgeschlossen_Title);
     public const string Msg_ImportiertCount = nameof(Msg_ImportiertCount);
     public const string Msg_ImportFehler_Title = nameof(Msg_ImportFehler_Title);
+    public const string Msg_ImportDuplikateCount = nameof(Msg_ImportDuplikateCount);
+    public const string Msg_ImportFehlerCount = nameof(Msg_ImportFehlerCount);
+    public const string Msg_ImportVorschauNichtVerfuegbar_Title = nameof(Msg_ImportVorschauNichtVerfuegbar_Title);
+    public const string Msg_ImportVorschauNichtVerfuegbar_Body = nameof(Msg_ImportVorschauNichtVerfuegbar_Body);
+    public const string Msg_ImportVorschauNichtsAusgewaehlt_Title = nameof(Msg_ImportVorschauNichtsAusgewaehlt_Title);
+    public const string Msg_ImportVorschauNichtsAusgewaehlt_Body = nameof(Msg_ImportVorschauNichtsAusgewaehlt_Body);
+    public const string Msg_VorlageGespeichert_Title = nameof(Msg_VorlageGespeichert_Title);
+    public const string Msg_VorlageGespeichert_Body = nameof(Msg_VorlageGespeichert_Body);
 
     // Additional keys found during XAML scan
     public const string Lbl_OriginalDatum = nameof(Lbl_OriginalDatum);
@@ -209,9 +222,30 @@ public static class ResourceKeys
     public const string A11y_FilterUmschalten = nameof(A11y_FilterUmschalten);
     public const string Lbl_DauerauftraegeFaellig = nameof(Lbl_DauerauftraegeFaellig);
     public const string Lbl_DauerauftraegeFaellig_Singular = nameof(Lbl_DauerauftraegeFaellig_Singular);
+    public const string Lbl_OhneKategorie = nameof(Lbl_OhneKategorie);
     public const string Lbl_BudgetVon = nameof(Lbl_BudgetVon);
     public const string Lbl_Von = nameof(Lbl_Von);
     public const string Lbl_UeberBudget = nameof(Lbl_UeberBudget);
+    public const string Lbl_BudgetHinweise = nameof(Lbl_BudgetHinweise);
+    public const string Lbl_BudgetVerbraucht = nameof(Lbl_BudgetVerbraucht);
+    public const string Lbl_TagesbudgetBisMonatsende = nameof(Lbl_TagesbudgetBisMonatsende);
+    public const string Lbl_BudgetWarnung80 = nameof(Lbl_BudgetWarnung80);
+    public const string Lbl_BudgetAufgebraucht = nameof(Lbl_BudgetAufgebraucht);
+    public const string Lbl_HaeufigVerwendet = nameof(Lbl_HaeufigVerwendet);
+    public const string Lbl_ImportFilterAlle = nameof(Lbl_ImportFilterAlle);
+    public const string Lbl_ImportFilterBereit = nameof(Lbl_ImportFilterBereit);
+    public const string Lbl_ImportFilterDuplikate = nameof(Lbl_ImportFilterDuplikate);
+    public const string Lbl_ImportFilterProbleme = nameof(Lbl_ImportFilterProbleme);
+    public const string Lbl_ImportFilterAusgeschlossen = nameof(Lbl_ImportFilterAusgeschlossen);
+    public const string Lbl_ImportStatusBereit = nameof(Lbl_ImportStatusBereit);
+    public const string Lbl_ImportStatusDuplikat = nameof(Lbl_ImportStatusDuplikat);
+    public const string Lbl_ImportStatusUngueltig = nameof(Lbl_ImportStatusUngueltig);
+    public const string Lbl_ImportStatusUnkategorisiert = nameof(Lbl_ImportStatusUnkategorisiert);
+    public const string Lbl_ImportStatusSpeicherfehler = nameof(Lbl_ImportStatusSpeicherfehler);
+    public const string Lbl_ImportBereitCount = nameof(Lbl_ImportBereitCount);
+    public const string Lbl_ImportDuplikateCount = nameof(Lbl_ImportDuplikateCount);
+    public const string Lbl_ImportProblemeCount = nameof(Lbl_ImportProblemeCount);
+    public const string Lbl_ImportAusgewaehltCount = nameof(Lbl_ImportAusgewaehltCount);
     public const string Hint_BudgetOptional = nameof(Hint_BudgetOptional);
     public const string Hint_BudgetNull = nameof(Hint_BudgetNull);
     public const string Hint_ZielTitel = nameof(Hint_ZielTitel);
@@ -225,6 +259,8 @@ public static class ResourceKeys
     public const string Lbl_BackupDatum = nameof(Lbl_BackupDatum);
     public const string Btn_BackupWiederherstellen = nameof(Btn_BackupWiederherstellen);
     public const string Empty_KeineBackupsVorhanden = nameof(Empty_KeineBackupsVorhanden);
+    public const string Empty_ImportVorschauLeer = nameof(Empty_ImportVorschauLeer);
+    public const string Ttl_ImportVorschau = nameof(Ttl_ImportVorschau);
     public const string Msg_BackupRestoreConfirmTitle = nameof(Msg_BackupRestoreConfirmTitle);
     public const string Msg_BackupRestoreConfirmBody = nameof(Msg_BackupRestoreConfirmBody);
 

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -246,6 +246,9 @@ public static class ResourceKeys
     public const string Lbl_ImportDuplikateCount = nameof(Lbl_ImportDuplikateCount);
     public const string Lbl_ImportProblemeCount = nameof(Lbl_ImportProblemeCount);
     public const string Lbl_ImportAusgewaehltCount = nameof(Lbl_ImportAusgewaehltCount);
+    public const string Msg_ImportStatusMissingDate = nameof(Msg_ImportStatusMissingDate);
+    public const string Msg_ImportStatusPossibleDuplicate = nameof(Msg_ImportStatusPossibleDuplicate);
+    public const string Msg_ImportStatusCategoryUnresolved = nameof(Msg_ImportStatusCategoryUnresolved);
     public const string Hint_BudgetOptional = nameof(Hint_BudgetOptional);
     public const string Hint_BudgetNull = nameof(Hint_BudgetNull);
     public const string Hint_ZielTitel = nameof(Hint_ZielTitel);

--- a/Finanzuebersicht.Presentation/Services/IImportSessionStore.cs
+++ b/Finanzuebersicht.Presentation/Services/IImportSessionStore.cs
@@ -1,0 +1,10 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Presentation.Services;
+
+public interface IImportSessionStore
+{
+    void SetActiveSession(ImportPreviewResult preview);
+    ImportPreviewResult? GetActiveSession();
+    void Clear();
+}

--- a/Finanzuebersicht.Presentation/Services/ImportSessionStore.cs
+++ b/Finanzuebersicht.Presentation/Services/ImportSessionStore.cs
@@ -1,0 +1,20 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Presentation.Services;
+
+public class ImportSessionStore : IImportSessionStore
+{
+    private ImportPreviewResult? _activeSession;
+
+    public void SetActiveSession(ImportPreviewResult preview)
+    {
+        _activeSession = preview;
+    }
+
+    public ImportPreviewResult? GetActiveSession() => _activeSession;
+
+    public void Clear()
+    {
+        _activeSession = null;
+    }
+}

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -42,6 +42,28 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private ObservableCollection<CategorySummary> kategorieEinnahmen = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasMonthData))]
+    [NotifyPropertyChangedFor(nameof(HasBudgetHinweise))]
+    private ObservableCollection<BudgetHintSummary> budgetHinweise = [];
+
+    [ObservableProperty]
+    private decimal budgetGesamt;
+
+    [ObservableProperty]
+    private decimal budgetVerbraucht;
+
+    [ObservableProperty]
+    private decimal budgetRest;
+
+    [ObservableProperty]
+    private decimal budgetTagesbudget;
+
+    [ObservableProperty]
+    private bool showBudgetTagesbudget;
+
+    public bool HasBudgetHinweise => BudgetHinweise.Count > 0;
+
+    [ObservableProperty]
     private bool istPrognose;
 
     [ObservableProperty]
@@ -100,7 +122,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     public bool IsYearView => !IsMonthView;
 
-    public bool HasMonthData => KategorieAusgaben.Count > 0 || KategorieEinnahmen.Count > 0;
+    public bool HasMonthData => KategorieAusgaben.Count > 0 || KategorieEinnahmen.Count > 0 || BudgetHinweise.Count > 0;
 
     public bool HasYearData => JahrMonate.Count > 0 || JahrKategorien.Count > 0;
 
@@ -179,7 +201,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
                 await LadeJahrAsync();
             }
             await LadeFaelligeDauerauftraegeAsync();
-            HasAnyDataLoaded = _foundTransactions;
+            HasAnyDataLoaded = _foundTransactions || HasMonthData || HasYearData;
         }
         finally
         {
@@ -221,6 +243,15 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         Bilanz = data.Bilanz;
         KategorieAusgaben = new ObservableCollection<CategorySummary>(data.KategorieAusgaben);
         KategorieEinnahmen = new ObservableCollection<CategorySummary>(data.KategorieEinnahmen);
+        BudgetHinweise = new ObservableCollection<BudgetHintSummary>(data.BudgetHinweise);
+        BudgetGesamt = data.BudgetHinweise.Sum(b => b.BudgetBetrag);
+        BudgetVerbraucht = data.BudgetHinweise.Sum(b => b.Verbrauch);
+        BudgetRest = data.BudgetHinweise.Sum(b => b.Restbudget);
+        ShowBudgetTagesbudget = data.BudgetHinweise.Any(b => b.ZeigeTagesbudget);
+        var remainingDays = data.BudgetHinweise.FirstOrDefault(b => b.IstAktuellerMonat)?.VerbleibendeTage ?? 0;
+        BudgetTagesbudget = remainingDays > 0
+            ? data.BudgetHinweise.Sum(b => b.RestbudgetPositiv) / remainingDays
+            : 0;
 
         // Vormonatsvergleich: nur Gesamt-Ausgaben via ReportingService (keine Kategorien nötig)
         var prevMonth = AktuellerMonat.AddMonths(-1);

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -297,16 +297,6 @@ public partial class ImportPreviewRowItemViewModel : ObservableObject
         _ => Status.ToString()
     };
 
-    public string StatusColorHex => Status switch
-    {
-        ImportPreviewRowStatus.Ready => "#34C759",
-        ImportPreviewRowStatus.Duplicate => "#FF9500",
-        ImportPreviewRowStatus.Invalid => "#FF3B30",
-        ImportPreviewRowStatus.Uncategorized => "#FFCC00",
-        ImportPreviewRowStatus.SaveError => "#FF3B30",
-        _ => "#8E8E93"
-    };
-
     partial void OnIsIncludedChanged(bool value)
     {
         _row.IsIncluded = value;
@@ -317,7 +307,6 @@ public partial class ImportPreviewRowItemViewModel : ObservableObject
     {
         _row.Status = value;
         OnPropertyChanged(nameof(StatusText));
-        OnPropertyChanged(nameof(StatusColorHex));
         OnPropertyChanged(nameof(CanCommit));
         OnPropertyChanged(nameof(IsProblem));
     }

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -203,7 +203,10 @@ public partial class ImportPreviewViewModel(
             new ImportPreviewFilterOption(ImportPreviewFilter.Excluded, _loc.GetString(ResourceKeys.Lbl_ImportFilterAusgeschlossen))
         ];
 
-        SelectedFilter = FilterOptions.FirstOrDefault(f => f.Filter == selectedFilterKind) ?? FilterOptions.FirstOrDefault();
+        // Reset SelectedFilter to instance from new list to ensure Picker shows selection
+        var newSelected = FilterOptions.FirstOrDefault(f => f.Filter == selectedFilterKind) ?? FilterOptions.FirstOrDefault();
+        SelectedFilter = null;
+        SelectedFilter = newSelected;
     }
 
     private void ApplyFilter()

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -260,7 +260,19 @@ public partial class ImportPreviewRowItemViewModel : ObservableObject
     public string Title => _row.Transaction.Titel;
     public string Purpose => _row.Transaction.Verwendungszweck;
     public string DateText => _row.Transaction.Datum == default ? "—" : _row.Transaction.Datum.ToString("dd.MM.yyyy");
-    public string AmountText => _row.Transaction.Betrag.ToString("C", CultureInfo.CurrentCulture);
+    public string AmountText
+    {
+        get
+        {
+            var tx = _row.Transaction;
+            if (tx == null) return "—";
+            var ci = CultureInfo.CurrentCulture;
+            var abs = Math.Abs(tx.Betrag);
+            var formatted = abs.ToString("C", ci);
+            var sign = tx.Typ == TransactionType.Einnahme ? "+" : "-";
+            return $"{sign}{formatted}";
+        }
+    }
     public bool CanCommit => Status is ImportPreviewRowStatus.Ready or ImportPreviewRowStatus.Uncategorized or ImportPreviewRowStatus.SaveError;
     public bool IsProblem => Status is ImportPreviewRowStatus.Duplicate or ImportPreviewRowStatus.Invalid or ImportPreviewRowStatus.Uncategorized;
     public bool CanEditCategory => Status != ImportPreviewRowStatus.Invalid;

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -181,9 +181,10 @@ public partial class ImportPreviewViewModel(
 
     private void RefreshState()
     {
-        HasRows = Rows.Count > 0;
         RefreshFilterOptions();
         ApplyFilter();
+        // HasRows should reflect currently visible rows after filtering
+        HasRows = FilteredRows.Count > 0;
         SummaryText = string.Join(" · ",
             string.Format(_loc.GetString(ResourceKeys.Lbl_ImportBereitCount), Rows.Count(r => r.Status == ImportPreviewRowStatus.Ready)),
             string.Format(_loc.GetString(ResourceKeys.Lbl_ImportDuplikateCount), Rows.Count(r => r.Status == ImportPreviewRowStatus.Duplicate)),
@@ -259,7 +260,7 @@ public partial class ImportPreviewRowItemViewModel : ObservableObject
     public ObservableCollection<ImportPreviewCategoryOption> CategoryOptions { get; }
     public string Title => _row.Transaction.Titel;
     public string Purpose => _row.Transaction.Verwendungszweck;
-    public string DateText => _row.Transaction.Datum == default ? "—" : _row.Transaction.Datum.ToString("dd.MM.yyyy");
+    public string DateText => _row.Transaction.Datum == default ? "—" : _row.Transaction.Datum.ToString("d", CultureInfo.CurrentCulture);
     public string AmountText
     {
         get

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -1,0 +1,338 @@
+using System.Collections.ObjectModel;
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.Resources.Strings;
+using Microsoft.Extensions.Logging;
+
+namespace Finanzuebersicht.ViewModels;
+
+public partial class ImportPreviewViewModel(
+    ImportService importService,
+    IImportSessionStore importSessionStore,
+    ICategoryRepository categoryRepository,
+    INavigationService navigationService,
+    IDialogService dialogService,
+    ILocalizationService localizationService,
+    IAppEvents appEvents,
+    ILogger<ImportPreviewViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel
+{
+    private readonly ImportService _importService = importService;
+    private readonly IImportSessionStore _importSessionStore = importSessionStore;
+    private readonly ICategoryRepository _categoryRepository = categoryRepository;
+    private readonly INavigationService _navigationService = navigationService;
+    private readonly IDialogService _dialogService = dialogService;
+    private readonly ILocalizationService _loc = localizationService;
+    private readonly IAppEvents _appEvents = appEvents;
+    private readonly ILogger<ImportPreviewViewModel>? _logger = logger;
+
+    private ImportPreviewResult? _activeSession;
+    private bool _loadedPreview;
+    private List<ImportPreviewCategoryOption> _categoryOptions = [];
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadPreviewCommand;
+    public bool ShouldAutoLoad => !_loadedPreview;
+
+    [ObservableProperty]
+    private ObservableCollection<ImportPreviewRowItemViewModel> rows = [];
+
+    [ObservableProperty]
+    private ObservableCollection<ImportPreviewRowItemViewModel> filteredRows = [];
+
+    [ObservableProperty]
+    private ObservableCollection<ImportPreviewFilterOption> filterOptions = [];
+
+    [ObservableProperty]
+    private ImportPreviewFilterOption? selectedFilter;
+
+    [ObservableProperty]
+    private bool isLoading;
+
+    [ObservableProperty]
+    private bool hasRows;
+
+    [ObservableProperty]
+    private string summaryText = string.Empty;
+
+    partial void OnSelectedFilterChanged(ImportPreviewFilterOption? value) => ApplyFilter();
+
+    [RelayCommand]
+    private async Task LoadPreview()
+    {
+        if (IsLoading) return;
+
+        IsLoading = true;
+        try
+        {
+            _activeSession = _importSessionStore.GetActiveSession();
+            if (_activeSession is null)
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_ImportVorschauNichtVerfuegbar_Title),
+                    _loc.GetString(ResourceKeys.Msg_ImportVorschauNichtVerfuegbar_Body),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+                await _navigationService.GoBackAsync();
+                return;
+            }
+
+            var categories = await _categoryRepository.GetCategoriesAsync();
+            _categoryOptions =
+            [
+                new ImportPreviewCategoryOption(string.Empty, _loc.GetString(ResourceKeys.Lbl_OhneKategorie)),
+                .. categories
+                    .OrderBy(c => c.Name)
+                    .Select(c => new ImportPreviewCategoryOption(c.Id, $"{c.Icon} {c.Name}"))
+            ];
+
+            Rows = new ObservableCollection<ImportPreviewRowItemViewModel>(
+                _activeSession.Rows.Select(row =>
+                    new ImportPreviewRowItemViewModel(row, _categoryOptions, _loc, OnRowsChanged)));
+
+            _loadedPreview = true;
+            RefreshState();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "ImportPreviewViewModel: failed to load preview");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                ex.Message,
+                _loc.GetString(ResourceKeys.Btn_OK));
+            await _navigationService.GoBackAsync();
+        }
+        finally
+        {
+            IsLoading = false;
+        }
+    }
+
+    [RelayCommand]
+    private async Task CommitImport()
+    {
+        if (_activeSession is null)
+            return;
+
+        var selectedRowIds = Rows
+            .Where(r => r.IsIncluded && r.CanCommit)
+            .Select(r => r.Id)
+            .ToList();
+
+        if (selectedRowIds.Count == 0)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Msg_ImportVorschauNichtsAusgewaehlt_Title),
+                _loc.GetString(ResourceKeys.Msg_ImportVorschauNichtsAusgewaehlt_Body),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        try
+        {
+            var result = await _importService.CommitImportAsync(_activeSession, selectedRowIds);
+            var summaryLines = new List<string>
+            {
+                string.Format(_loc.GetString(ResourceKeys.Msg_ImportiertCount), result.Imported.Count)
+            };
+
+            if (result.Duplicates.Count > 0)
+                summaryLines.Add(string.Format(_loc.GetString(ResourceKeys.Msg_ImportDuplikateCount), result.Duplicates.Count));
+            if (result.SaveErrors.Count > 0)
+                summaryLines.Add(string.Format(_loc.GetString(ResourceKeys.Msg_ImportFehlerCount), result.SaveErrors.Count));
+
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Msg_ImportAbgeschlossen_Title),
+                string.Join("\n", summaryLines),
+                _loc.GetString(ResourceKeys.Btn_OK));
+
+            try { _appEvents.NotifyDataChanged(); } catch { }
+
+            _importSessionStore.Clear();
+            _loadedPreview = false;
+            await _navigationService.GoBackAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "ImportPreviewViewModel: commit failed");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Msg_ImportFehler_Title),
+                ex.Message,
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    [RelayCommand]
+    private async Task CancelImport()
+    {
+        _importSessionStore.Clear();
+        _loadedPreview = false;
+        await _navigationService.GoBackAsync();
+    }
+
+    public void HandlePageDisappearing()
+    {
+        _importSessionStore.Clear();
+        _loadedPreview = false;
+    }
+
+    private void OnRowsChanged() => RefreshState();
+
+    private void RefreshState()
+    {
+        HasRows = Rows.Count > 0;
+        RefreshFilterOptions();
+        ApplyFilter();
+        SummaryText = string.Join(" · ",
+            string.Format(_loc.GetString(ResourceKeys.Lbl_ImportBereitCount), Rows.Count(r => r.Status == ImportPreviewRowStatus.Ready)),
+            string.Format(_loc.GetString(ResourceKeys.Lbl_ImportDuplikateCount), Rows.Count(r => r.Status == ImportPreviewRowStatus.Duplicate)),
+            string.Format(_loc.GetString(ResourceKeys.Lbl_ImportProblemeCount), Rows.Count(r => r.IsProblem)),
+            string.Format(_loc.GetString(ResourceKeys.Lbl_ImportAusgewaehltCount), Rows.Count(r => r.IsIncluded && r.CanCommit)));
+    }
+
+    private void RefreshFilterOptions()
+    {
+        var selectedFilterKind = SelectedFilter?.Filter ?? ImportPreviewFilter.All;
+        FilterOptions =
+        [
+            new ImportPreviewFilterOption(ImportPreviewFilter.All, _loc.GetString(ResourceKeys.Lbl_ImportFilterAlle)),
+            new ImportPreviewFilterOption(ImportPreviewFilter.Ready, _loc.GetString(ResourceKeys.Lbl_ImportFilterBereit)),
+            new ImportPreviewFilterOption(ImportPreviewFilter.Duplicates, _loc.GetString(ResourceKeys.Lbl_ImportFilterDuplikate)),
+            new ImportPreviewFilterOption(ImportPreviewFilter.Problems, _loc.GetString(ResourceKeys.Lbl_ImportFilterProbleme)),
+            new ImportPreviewFilterOption(ImportPreviewFilter.Excluded, _loc.GetString(ResourceKeys.Lbl_ImportFilterAusgeschlossen))
+        ];
+
+        SelectedFilter = FilterOptions.FirstOrDefault(f => f.Filter == selectedFilterKind) ?? FilterOptions.FirstOrDefault();
+    }
+
+    private void ApplyFilter()
+    {
+        IEnumerable<ImportPreviewRowItemViewModel> filtered = Rows;
+        switch (SelectedFilter?.Filter ?? ImportPreviewFilter.All)
+        {
+            case ImportPreviewFilter.Ready:
+                filtered = Rows.Where(r => r.Status == ImportPreviewRowStatus.Ready || r.Status == ImportPreviewRowStatus.Uncategorized);
+                break;
+            case ImportPreviewFilter.Duplicates:
+                filtered = Rows.Where(r => r.Status == ImportPreviewRowStatus.Duplicate);
+                break;
+            case ImportPreviewFilter.Problems:
+                filtered = Rows.Where(r => r.IsProblem);
+                break;
+            case ImportPreviewFilter.Excluded:
+                filtered = Rows.Where(r => !r.IsIncluded);
+                break;
+        }
+
+        FilteredRows = new ObservableCollection<ImportPreviewRowItemViewModel>(filtered);
+    }
+}
+
+public partial class ImportPreviewRowItemViewModel : ObservableObject
+{
+    private readonly ImportPreviewRow _row;
+    private readonly Action _onChanged;
+    private readonly ILocalizationService _loc;
+
+    public ImportPreviewRowItemViewModel(
+        ImportPreviewRow row,
+        IReadOnlyList<ImportPreviewCategoryOption> categoryOptions,
+        ILocalizationService localizationService,
+        Action onChanged)
+    {
+        _row = row;
+        _loc = localizationService;
+        _onChanged = onChanged;
+        CategoryOptions = new ObservableCollection<ImportPreviewCategoryOption>(
+            categoryOptions.Select(option => new ImportPreviewCategoryOption(option.Id, option.DisplayName)));
+        status = row.Status;
+        isIncluded = row.IsIncluded;
+        selectedCategoryOption = CategoryOptions.FirstOrDefault(c => c.Id == row.Transaction.KategorieId)
+            ?? CategoryOptions.FirstOrDefault();
+    }
+
+    public string Id => _row.Id;
+    public ObservableCollection<ImportPreviewCategoryOption> CategoryOptions { get; }
+    public string Title => _row.Transaction.Titel;
+    public string Purpose => _row.Transaction.Verwendungszweck;
+    public string DateText => _row.Transaction.Datum == default ? "—" : _row.Transaction.Datum.ToString("dd.MM.yyyy");
+    public string AmountText => _row.Transaction.Betrag.ToString("C", CultureInfo.CurrentCulture);
+    public bool CanCommit => Status is ImportPreviewRowStatus.Ready or ImportPreviewRowStatus.Uncategorized or ImportPreviewRowStatus.SaveError;
+    public bool IsProblem => Status is ImportPreviewRowStatus.Duplicate or ImportPreviewRowStatus.Invalid or ImportPreviewRowStatus.Uncategorized;
+    public bool CanEditCategory => Status != ImportPreviewRowStatus.Invalid;
+
+    [ObservableProperty]
+    private bool isIncluded;
+
+    [ObservableProperty]
+    private ImportPreviewRowStatus status;
+
+    [ObservableProperty]
+    private ImportPreviewCategoryOption? selectedCategoryOption;
+
+    public string StatusText => Status switch
+    {
+        ImportPreviewRowStatus.Ready => _loc.GetString(ResourceKeys.Lbl_ImportStatusBereit),
+        ImportPreviewRowStatus.Duplicate => _loc.GetString(ResourceKeys.Lbl_ImportStatusDuplikat),
+        ImportPreviewRowStatus.Invalid => _loc.GetString(ResourceKeys.Lbl_ImportStatusUngueltig),
+        ImportPreviewRowStatus.Uncategorized => _loc.GetString(ResourceKeys.Lbl_ImportStatusUnkategorisiert),
+        ImportPreviewRowStatus.SaveError => _loc.GetString(ResourceKeys.Lbl_ImportStatusSpeicherfehler),
+        _ => Status.ToString()
+    };
+
+    public string StatusColorHex => Status switch
+    {
+        ImportPreviewRowStatus.Ready => "#34C759",
+        ImportPreviewRowStatus.Duplicate => "#FF9500",
+        ImportPreviewRowStatus.Invalid => "#FF3B30",
+        ImportPreviewRowStatus.Uncategorized => "#FFCC00",
+        ImportPreviewRowStatus.SaveError => "#FF3B30",
+        _ => "#8E8E93"
+    };
+
+    partial void OnIsIncludedChanged(bool value)
+    {
+        _row.IsIncluded = value;
+        _onChanged();
+    }
+
+    partial void OnStatusChanged(ImportPreviewRowStatus value)
+    {
+        _row.Status = value;
+        OnPropertyChanged(nameof(StatusText));
+        OnPropertyChanged(nameof(StatusColorHex));
+        OnPropertyChanged(nameof(CanCommit));
+        OnPropertyChanged(nameof(IsProblem));
+    }
+
+    partial void OnSelectedCategoryOptionChanged(ImportPreviewCategoryOption? value)
+    {
+        if (value is null)
+            return;
+
+        _row.Transaction.KategorieId = value.Id;
+
+        if (Status is not ImportPreviewRowStatus.Invalid and not ImportPreviewRowStatus.Duplicate)
+        {
+            Status = string.IsNullOrWhiteSpace(value.Id)
+                ? ImportPreviewRowStatus.Uncategorized
+                : ImportPreviewRowStatus.Ready;
+        }
+
+        _onChanged();
+    }
+}
+
+public enum ImportPreviewFilter
+{
+    All,
+    Ready,
+    Duplicates,
+    Problems,
+    Excluded
+}
+
+public record ImportPreviewFilterOption(ImportPreviewFilter Filter, string DisplayName);
+
+public record ImportPreviewCategoryOption(string Id, string DisplayName);

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
@@ -17,17 +17,20 @@ public partial class TransactionDetailViewModel(
     INavigationService navigationService,
     IDialogService dialogService,
     ILogger<TransactionDetailViewModel>? logger = null,
-    Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel, IApplyQueryAttributes
+    Finanzuebersicht.Core.Services.IClock? clock = null,
+    SaveTransactionTemplateUseCase? saveTransactionTemplateUseCase = null) : ObservableObject, IAutoLoadViewModel, IApplyQueryAttributes
 {
     private readonly SaveTransactionDetailUseCase _saveTransactionDetailUseCase = saveTransactionDetailUseCase;
     private readonly LoadTransactionDetailDataUseCase _loadTransactionDetailDataUseCase = loadTransactionDetailDataUseCase;
     private readonly ITransactionValidationService _validationService = validationService;
     private Transaction? _existingTransaction;
+    private string? _selectedKategorieId;
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILogger<TransactionDetailViewModel>? _logger = logger;
     private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+    private readonly SaveTransactionTemplateUseCase? _saveTransactionTemplateUseCase = saveTransactionTemplateUseCase;
 
     public System.Windows.Input.ICommand AutoLoadCommand => LoadKategorienCommand;
 
@@ -59,6 +62,7 @@ public partial class TransactionDetailViewModel(
             if (value != null)
             {
                 _existingTransaction = value;
+                _selectedKategorieId = value.KategorieId;
                 BetragText = value.Betrag.ToString("F2", System.Globalization.CultureInfo.CurrentCulture);
                 Titel = value.Titel;
                 Verwendungszweck = value.Verwendungszweck ?? string.Empty;
@@ -74,13 +78,23 @@ public partial class TransactionDetailViewModel(
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
         if (query.TryGetValue("Transaction", out var val) && val is Transaction t)
+        {
             Transaction = t;
+        }
+        else if (query.TryGetValue("DuplicateTransaction", out var duplicateVal) && duplicateVal is Transaction duplicate)
+        {
+            ApplyTransactionDraft(duplicate, _clock.Today);
+        }
+        else if (query.TryGetValue("TransactionTemplate", out var templateVal) && templateVal is TransactionTemplate template)
+        {
+            ApplyTemplateDraft(template);
+        }
     }
 
     [RelayCommand]
     private async Task LoadKategorien()
     {
-        var data = await _loadTransactionDetailDataUseCase.ExecuteAsync(_existingTransaction?.KategorieId);
+        var data = await _loadTransactionDetailDataUseCase.ExecuteAsync(_selectedKategorieId ?? _existingTransaction?.KategorieId);
         Kategorien = new ObservableCollection<Category>(data.Kategorien);
         SelectedKategorie = data.SelectedKategorie;
     }
@@ -140,8 +154,56 @@ public partial class TransactionDetailViewModel(
         }
     }
 
+    [RelayCommand]
+    private async Task SaveAsTemplate()
+    {
+        if (_saveTransactionTemplateUseCase == null) return;
+
+        if (!_validationService.TryValidate(
+                BetragText,
+                Titel,
+                SelectedKategorie != null,
+                System.Globalization.CultureInfo.CurrentCulture,
+                out var betrag,
+                out var error))
+        {
+            var message = error switch
+            {
+                TransactionInputError.InvalidAmountFormat => _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                TransactionInputError.AmountMustBePositive => _loc.GetString(ResourceKeys.Err_BetragGroesserNull),
+                TransactionInputError.TitleRequired => _loc.GetString(ResourceKeys.Err_TitelErforderlich),
+                TransactionInputError.CategoryRequired => _loc.GetString(ResourceKeys.Err_KategorieErforderlich),
+                _ => _loc.GetString(ResourceKeys.Err_UngueltigerBetrag)
+            };
+
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                message,
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        var template = new TransactionTemplate
+        {
+            Name = Titel,
+            Titel = Titel,
+            Betrag = betrag,
+            KategorieId = SelectedKategorie!.Id,
+            Typ = Typ,
+            Verwendungszweck = Verwendungszweck ?? string.Empty
+        };
+
+        await _saveTransactionTemplateUseCase.ExecuteAsync(template);
+        await _dialogService.ShowAlertAsync(
+            _loc.GetString(ResourceKeys.Msg_VorlageGespeichert_Title),
+            _loc.GetString(ResourceKeys.Msg_VorlageGespeichert_Body),
+            _loc.GetString(ResourceKeys.Btn_OK));
+    }
+
     private async Task SetKategorieAsync(string kategorieId)
     {
+        _selectedKategorieId = kategorieId;
+
         try
         {
             if (Kategorien.Count == 0)
@@ -155,5 +217,29 @@ public partial class TransactionDetailViewModel(
         {
             _logger?.LogWarning(ex, "Fehler beim Laden der Kategorie");
         }
+    }
+
+    private void ApplyTransactionDraft(Transaction source, DateTime datum)
+    {
+        _existingTransaction = null;
+        BetragText = source.Betrag.ToString("F2", System.Globalization.CultureInfo.CurrentCulture);
+        Titel = source.Titel;
+        Verwendungszweck = source.Verwendungszweck ?? string.Empty;
+        Datum = datum;
+        Typ = source.Typ;
+        _selectedKategorieId = source.KategorieId;
+        _ = SetKategorieAsync(source.KategorieId);
+    }
+
+    private void ApplyTemplateDraft(TransactionTemplate template)
+    {
+        _existingTransaction = null;
+        BetragText = template.Betrag.ToString("F2", System.Globalization.CultureInfo.CurrentCulture);
+        Titel = template.Titel;
+        Verwendungszweck = template.Verwendungszweck ?? string.Empty;
+        Datum = _clock.Today;
+        Typ = template.Typ;
+        _selectedKategorieId = template.KategorieId;
+        _ = SetKategorieAsync(template.KategorieId);
     }
 }

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -492,8 +492,17 @@ public partial class TransactionsViewModel(
                 return;
             }
 
-            _importSessionStore?.Clear();
-            _importSessionStore?.SetActiveSession(preview);
+            if (_importSessionStore == null)
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_ImportVorschauNichtVerfuegbar_Title),
+                    _loc.GetString(ResourceKeys.Msg_ImportVorschauNichtVerfuegbar_Body),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+                return;
+            }
+
+            _importSessionStore.Clear();
+            _importSessionStore.SetActiveSession(preview);
             await _navigationService.GoToAsync(Routes.ImportPreview);
         }
         catch (System.Exception ex)

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 using System.Linq;
 using Microsoft.Extensions.Logging;
@@ -22,7 +23,11 @@ public partial class TransactionsViewModel(
     IMainThreadDispatcher dispatcher,
     IFilePicker filePicker,
     IAppEvents appEvents,
-    ILogger<TransactionsViewModel> logger) : MonthNavigationViewModel, IAutoLoadViewModel
+    ILogger<TransactionsViewModel> logger,
+    IImportSessionStore? importSessionStore = null,
+    LoadTransactionTemplatesUseCase? loadTransactionTemplatesUseCase = null,
+    DeleteTransactionTemplateUseCase? deleteTransactionTemplateUseCase = null,
+    UseTransactionTemplateUseCase? useTransactionTemplateUseCase = null) : MonthNavigationViewModel, IAutoLoadViewModel
 {
     private readonly DeleteTransactionUseCase _deleteTransactionUseCase = deleteTransactionUseCase;
     private readonly LoadTransactionsMonthUseCase _loadTransactionsMonthUseCase = loadTransactionsMonthUseCase;
@@ -38,6 +43,10 @@ public partial class TransactionsViewModel(
     private readonly IFilePicker _filePicker = filePicker;
     private readonly IAppEvents _appEvents = appEvents;
     private readonly ILogger<TransactionsViewModel> _logger = logger;
+    private readonly IImportSessionStore? _importSessionStore = importSessionStore;
+    private readonly LoadTransactionTemplatesUseCase? _loadTransactionTemplatesUseCase = loadTransactionTemplatesUseCase;
+    private readonly DeleteTransactionTemplateUseCase? _deleteTransactionTemplateUseCase = deleteTransactionTemplateUseCase;
+    private readonly UseTransactionTemplateUseCase? _useTransactionTemplateUseCase = useTransactionTemplateUseCase;
 
     private CancellationTokenSource? _searchDebounce;
     private int _searchVersion;
@@ -59,6 +68,14 @@ public partial class TransactionsViewModel(
     private Dictionary<string, string> iconMap = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasTransactionTemplates))]
+    [NotifyPropertyChangedFor(nameof(ShowTransactionTemplates))]
+    private ObservableCollection<TransactionTemplate> transactionTemplates = [];
+
+    public bool HasTransactionTemplates => TransactionTemplates.Count > 0;
+    public bool ShowTransactionTemplates => HasTransactionTemplates && IsMonthMode;
+
+    [ObservableProperty]
     private bool isLoading;
 
     // --- Suche & Filter ---
@@ -66,30 +83,35 @@ public partial class TransactionsViewModel(
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsSearchActive))]
     [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    [NotifyPropertyChangedFor(nameof(ShowTransactionTemplates))]
     private string searchText = string.Empty;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsFilterActive))]
     [NotifyPropertyChangedFor(nameof(IsSearchActive))]
     [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    [NotifyPropertyChangedFor(nameof(ShowTransactionTemplates))]
     private string? selectedKategorieId = null;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsFilterActive))]
     [NotifyPropertyChangedFor(nameof(IsSearchActive))]
     [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    [NotifyPropertyChangedFor(nameof(ShowTransactionTemplates))]
     private TransactionTypeFilter selectedTypFilter = TransactionTypeFilter.Alle;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsFilterActive))]
     [NotifyPropertyChangedFor(nameof(IsSearchActive))]
     [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    [NotifyPropertyChangedFor(nameof(ShowTransactionTemplates))]
     private DateTime? vonDatum = null;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsFilterActive))]
     [NotifyPropertyChangedFor(nameof(IsSearchActive))]
     [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    [NotifyPropertyChangedFor(nameof(ShowTransactionTemplates))]
     private DateTime? bisDatum = null;
 
     [ObservableProperty]
@@ -136,6 +158,7 @@ public partial class TransactionsViewModel(
     [NotifyPropertyChangedFor(nameof(IsFilterActive))]
     [NotifyPropertyChangedFor(nameof(IsSearchActive))]
     [NotifyPropertyChangedFor(nameof(IsMonthMode))]
+    [NotifyPropertyChangedFor(nameof(ShowTransactionTemplates))]
     private bool isDateFilterEnabled;
 
     [ObservableProperty]
@@ -304,6 +327,8 @@ public partial class TransactionsViewModel(
 
             if (AvailableKategorien.Count == 0)
                 await LoadKategorienAsync();
+
+            await LoadTemplatesAsync();
         }
         catch (Exception ex)
         {
@@ -317,6 +342,14 @@ public partial class TransactionsViewModel(
         {
             IsLoading = false;
         }
+    }
+
+    private async Task LoadTemplatesAsync()
+    {
+        if (_loadTransactionTemplatesUseCase == null) return;
+
+        var templates = await _loadTransactionTemplatesUseCase.ExecuteAsync();
+        TransactionTemplates = new ObservableCollection<TransactionTemplate>(templates);
     }
 
     [RelayCommand]
@@ -377,6 +410,50 @@ public partial class TransactionsViewModel(
     }
 
     [RelayCommand]
+    private async Task DuplicateTransaktion(Transaction transaktion)
+    {
+        if (transaktion == null) return;
+
+        await _navigationService.GoToAsync(Routes.TransactionDetail, new Dictionary<string, object>
+        {
+            ["DuplicateTransaction"] = transaktion
+        });
+    }
+
+    [RelayCommand]
+    private async Task CreateFromTemplate(TransactionTemplate template)
+    {
+        if (template == null) return;
+
+        if (_useTransactionTemplateUseCase != null)
+        {
+            await _useTransactionTemplateUseCase.ExecuteAsync(template);
+            await LoadTemplatesAsync();
+        }
+
+        await _navigationService.GoToAsync(Routes.TransactionDetail, new Dictionary<string, object>
+        {
+            ["TransactionTemplate"] = template
+        });
+    }
+
+    [RelayCommand]
+    private async Task DeleteTemplate(TransactionTemplate template)
+    {
+        if (template == null || _deleteTransactionTemplateUseCase == null) return;
+
+        var confirm = await _dialogService.ShowConfirmationAsync(
+            _loc.GetString(ResourceKeys.Dlg_VorlageLoeschen),
+            _loc.GetString(ResourceKeys.Dlg_VorlageLoeschenFrage, template.Name),
+            _loc.GetString(ResourceKeys.Btn_Ja),
+            _loc.GetString(ResourceKeys.Btn_Nein));
+        if (!confirm) return;
+
+        await _deleteTransactionTemplateUseCase.ExecuteAsync(template.Id);
+        await LoadTemplatesAsync();
+    }
+
+    [RelayCommand]
     private async Task ImportCsv()
     {
         // Defensive checks to avoid NullReferenceExceptions when DI failed
@@ -404,43 +481,20 @@ public partial class TransactionsViewModel(
             if (result == null) return;
 
             using var stream = await result.OpenReadAsync();
-            var importResult = await _importService.ImportFromCsvAsync(stream);
+            var preview = await _importService.AnalyzeCsvAsync(stream);
 
-            var titleDone = _loc?.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Msg_ImportAbgeschlossen_Title) ?? "Import abgeschlossen";
-            var okBtn = _loc?.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Btn_OK) ?? "OK";
-
-            string importedMsg;
-            if (!importResult.Success)
+            if (!preview.Success)
             {
-                importedMsg = importResult.ErrorMessage ?? "Unbekannter Fehler beim Import.";
-            }
-            else
-            {
-                importedMsg = string.Format(
-                    _loc?.GetString(Finanzuebersicht.Resources.Strings.ResourceKeys.Msg_ImportiertCount) ?? "Importiert: {0} Transaktionen",
-                    importResult.Imported.Count);
-
-                if (importResult.Duplicates.Count > 0)
-                    importedMsg += $"\n{importResult.Duplicates.Count} Duplikate übersprungen";
-                if (importResult.SkippedMalformed > 0)
-                    importedMsg += $"\n{importResult.SkippedMalformed} fehlerhafte Zeilen übersprungen";
-                if (importResult.SaveErrors.Count > 0)
-                    importedMsg += $"\n{importResult.SaveErrors.Count} Transaktionen konnten nicht gespeichert werden";
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Msg_ImportFehlgeschlagen_Title),
+                    preview.ErrorMessage ?? "Unbekannter Fehler beim Import.",
+                    _loc.GetString(ResourceKeys.Btn_OK));
+                return;
             }
 
-            if (_dialogService != null)
-            {
-                await _dialogService.ShowAlertAsync(titleDone, importedMsg, okBtn);
-            }
-            else
-            {
-                LogError("ImportCsv: DialogService is null after successful import");
-            }
-
-            await LoadTransaktionen();
-
-            // notify other parts of the app (dashboard/year views) that data changed
-            try { _appEvents.NotifyDataChanged(); } catch { }
+            _importSessionStore?.Clear();
+            _importSessionStore?.SetActiveSession(preview);
+            await _navigationService.GoToAsync(Routes.ImportPreview);
         }
         catch (System.Exception ex)
         {

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardMonthUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardMonthUseCaseTests.cs
@@ -78,4 +78,137 @@ public class LoadDashboardMonthUseCaseTests
         Assert.Single(result.KategorieAusgaben);
         await recurringRepository.Received(1).GetRecurringTransactionsAsync();
     }
+
+    [Fact]
+    public async Task ExecuteAsync_CurrentMonthComputesBudgetHints()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var budgetRepository = Substitute.For<IBudgetRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-food", Name = "Food", Typ = TransactionType.Ausgabe }
+        });
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Typ = TransactionType.Ausgabe, Betrag = 150m, KategorieId = "cat-food" }
+            });
+        budgetRepository.GetBudgetsAsync().Returns(new List<CategoryBudget>
+        {
+            new() { Id = "budget-food", KategorieId = "cat-food", Betrag = 300m }
+        });
+
+        var useCase = new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringRepository, budgetRepository);
+
+        var result = await useCase.ExecuteAsync(new DateTime(2026, 3, 1), new DateTime(2026, 3, 15));
+
+        var hint = Assert.Single(result.BudgetHinweise);
+        Assert.Equal(300m, hint.BudgetBetrag);
+        Assert.Equal(150m, hint.Verbrauch);
+        Assert.Equal(150m, hint.Restbudget);
+        Assert.Equal(17, hint.VerbleibendeTage);
+        Assert.Equal(150m / 17m, hint.Tagesbudget);
+        Assert.False(hint.IstWarnung);
+        Assert.False(hint.IstAusgeschoepft);
+    }
+
+    [Theory]
+    [InlineData(240, true, false)]
+    [InlineData(300, false, true)]
+    [InlineData(330, false, true)]
+    public async Task ExecuteAsync_CurrentMonthAppliesFixedBudgetThresholds(decimal spent, bool warning, bool exceeded)
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var budgetRepository = Substitute.For<IBudgetRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-food", Name = "Food", Typ = TransactionType.Ausgabe }
+        });
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Typ = TransactionType.Ausgabe, Betrag = spent, KategorieId = "cat-food" }
+            });
+        budgetRepository.GetBudgetsAsync().Returns(new List<CategoryBudget>
+        {
+            new() { Id = "budget-food", KategorieId = "cat-food", Betrag = 300m }
+        });
+
+        var useCase = new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringRepository, budgetRepository);
+
+        var result = await useCase.ExecuteAsync(new DateTime(2026, 3, 1), new DateTime(2026, 3, 15));
+
+        var hint = Assert.Single(result.BudgetHinweise);
+        Assert.Equal(warning, hint.IstWarnung);
+        Assert.Equal(exceeded, hint.IstAusgeschoepft);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_BudgetedCategoryWithoutSpendingAppearsOnlyInBudgetHints()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var budgetRepository = Substitute.For<IBudgetRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-food", Name = "Food", Typ = TransactionType.Ausgabe }
+        });
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+        budgetRepository.GetBudgetsAsync().Returns(new List<CategoryBudget>
+        {
+            new() { Id = "budget-food", KategorieId = "cat-food", Betrag = 300m }
+        });
+
+        var useCase = new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringRepository, budgetRepository);
+
+        var result = await useCase.ExecuteAsync(new DateTime(2026, 3, 1), new DateTime(2026, 3, 15));
+
+        Assert.Empty(result.KategorieAusgaben);
+        var hint = Assert.Single(result.BudgetHinweise);
+        Assert.Equal("cat-food", hint.CategoryId);
+        Assert.Equal(0m, hint.Verbrauch);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_PastMonthDoesNotExposeActionOrDailyBudgetHints()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var budgetRepository = Substitute.For<IBudgetRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-food", Name = "Food", Typ = TransactionType.Ausgabe }
+        });
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Typ = TransactionType.Ausgabe, Betrag = 300m, KategorieId = "cat-food" }
+            });
+        budgetRepository.GetBudgetsAsync().Returns(new List<CategoryBudget>
+        {
+            new() { Id = "budget-food", KategorieId = "cat-food", Betrag = 300m }
+        });
+
+        var useCase = new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringRepository, budgetRepository);
+
+        var result = await useCase.ExecuteAsync(new DateTime(2026, 2, 1), new DateTime(2026, 3, 15));
+
+        var hint = Assert.Single(result.BudgetHinweise);
+        Assert.False(hint.IstAktuellerMonat);
+        Assert.False(hint.ZeigeTagesbudget);
+        Assert.Equal(0m, hint.Tagesbudget);
+        Assert.False(hint.IstWarnung);
+        Assert.False(hint.IstAusgeschoepft);
+    }
 }

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -40,7 +40,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task FullBackupRestoreCycle_PreserveAllData()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]), _mockDataService);
             var backupPath = Path.Combine(_testDir, "backups");
 
             // Setup data
@@ -76,6 +76,16 @@ namespace Finanzuebersicht.Tests.Services
             _mockDataService.SetRecurring(originalRecurring);
             _mockDataService.SetBudgets([new CategoryBudget { Id = "b1", KategorieId = "c1", Betrag = 300m }]);
             _mockDataService.SetSparZiele([new SparZiel { Id = "s1", Titel = "Urlaub", ZielBetrag = 2000m }]);
+            _mockDataService.SetTransactionTemplates([new TransactionTemplate
+            {
+                Id = "tpl1",
+                Name = "Wocheneinkauf",
+                Titel = "Supermarket",
+                Betrag = 50.5m,
+                KategorieId = "c1",
+                Typ = TransactionType.Ausgabe,
+                UseCount = 3
+            }]);
 
             // Act 1: Create backup
             var backup = await service.CreateBackupAsync(backupPath);
@@ -87,6 +97,7 @@ namespace Finanzuebersicht.Tests.Services
             Assert.Equal(1, backup.EntityCounts["recurring"]);
             Assert.Equal(1, backup.EntityCounts["budgets"]);
             Assert.Equal(1, backup.EntityCounts["sparziele"]);
+            Assert.Equal(1, backup.EntityCounts["transactionTemplates"]);
             Assert.True(File.Exists(Path.Combine(backupPath, backup.FileName)));
 
             // Act 2: Restore backup — clear state first to verify data is re-saved
@@ -95,6 +106,7 @@ namespace Finanzuebersicht.Tests.Services
             _mockDataService.SetRecurring([]);
             _mockDataService.SetBudgets([]);
             _mockDataService.SetSparZiele([]);
+            _mockDataService.SetTransactionTemplates([]);
 
             var restoreResult = await service.RestoreBackupAsync(backupPath, backup.Id);
 
@@ -108,17 +120,20 @@ namespace Finanzuebersicht.Tests.Services
             var restoredRecurring = await _mockDataService.GetRecurringTransactionsAsync();
             var restoredBudgets = await _mockDataService.GetBudgetsAsync();
             var restoredSparziele = await _mockDataService.GetSparZieleAsync();
+            var restoredTemplates = await _mockDataService.GetTransactionTemplatesAsync();
 
             Assert.Equal(2, restoredCategories.Count);
             Assert.Equal(2, restoredTransactions.Count);
             Assert.Single(restoredRecurring);
             Assert.Single(restoredBudgets);
             Assert.Single(restoredSparziele);
+            Assert.Single(restoredTemplates);
             Assert.Contains(restoredCategories, c => c.Id == "c1" && c.Name == "Groceries");
             Assert.Contains(restoredTransactions, t => t.Id == "t1" && t.Betrag == 50.5m);
             Assert.Contains(restoredRecurring, r => r.Id == "r1" && r.Titel == "Rent");
             Assert.Contains(restoredBudgets, b => b.Id == "b1" && b.Betrag == 300m);
             Assert.Contains(restoredSparziele, s => s.Id == "s1" && s.Titel == "Urlaub");
+            Assert.Contains(restoredTemplates, t => t.Id == "tpl1" && t.Name == "Wocheneinkauf" && t.UseCount == 3);
         }
 
         [Fact]
@@ -321,19 +336,21 @@ namespace Finanzuebersicht.Tests.Services
 
         // Mock implementations
 #pragma warning disable CS0618
-        private class MockDataService : IDataService
+        private class MockDataService : IDataService, ITransactionTemplateRepository
         {
             private List<Category> _categories = [];
             private List<Transaction> _transactions = [];
             private List<RecurringTransaction> _recurring = [];
             private List<CategoryBudget> _budgets = [];
             private List<SparZiel> _sparziele = [];
+            private List<TransactionTemplate> _transactionTemplates = [];
 
             public void SetCategories(IEnumerable<Category> categories) => _categories = categories.ToList();
             public void SetTransactions(IEnumerable<Transaction> transactions) => _transactions = transactions.ToList();
             public void SetRecurring(IEnumerable<RecurringTransaction> recurring) => _recurring = recurring.ToList();
             public void SetBudgets(IEnumerable<CategoryBudget> budgets) => _budgets = budgets.ToList();
             public void SetSparZiele(IEnumerable<SparZiel> sparziele) => _sparziele = sparziele.ToList();
+            public void SetTransactionTemplates(IEnumerable<TransactionTemplate> templates) => _transactionTemplates = templates.ToList();
 
             public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(_categories.ToList());
             public Task SaveCategoryAsync(Category category)
@@ -396,6 +413,16 @@ namespace Finanzuebersicht.Tests.Services
             }
             public Task DeleteSparZielAsync(string id) { _sparziele.RemoveAll(s => s.Id == id); return Task.CompletedTask; }
             public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> sparziele) { _sparziele = sparziele.ToList(); return Task.CompletedTask; }
+
+            public Task<List<TransactionTemplate>> GetTransactionTemplatesAsync() => Task.FromResult(_transactionTemplates.ToList());
+            public Task SaveTransactionTemplateAsync(TransactionTemplate template)
+            {
+                var idx = _transactionTemplates.FindIndex(t => t.Id == template.Id);
+                if (idx >= 0) _transactionTemplates[idx] = template; else _transactionTemplates.Add(template);
+                return Task.CompletedTask;
+            }
+            public Task DeleteTransactionTemplateAsync(string id) { _transactionTemplates.RemoveAll(t => t.Id == id); return Task.CompletedTask; }
+            public Task ReplaceAllTransactionTemplatesAsync(IEnumerable<TransactionTemplate> templates) { _transactionTemplates = templates.ToList(); return Task.CompletedTask; }
         }
 #pragma warning restore CS0618
 

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -79,6 +79,7 @@ namespace Finanzuebersicht.Tests.Services
                 Assert.NotNull(zipArchive.GetEntry("recurring.json"));
                 Assert.NotNull(zipArchive.GetEntry("budgets.json"));
                 Assert.NotNull(zipArchive.GetEntry("sparziele.json"));
+                Assert.NotNull(zipArchive.GetEntry("transaction-templates.json"));
                 Assert.NotNull(zipArchive.GetEntry("backup.metadata.json"));
             }
         }

--- a/Finanzuebersicht.Tests/Services/ImportServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/ImportServiceTests.cs
@@ -1,4 +1,3 @@
-using Xunit;
 using Finanzuebersicht.Models;
 using Microsoft.Extensions.Logging;
 using NSubstitute.ExceptionExtensions;
@@ -10,148 +9,216 @@ namespace Finanzuebersicht.Tests.Services
         private static ImportService BuildService(
             IStatementParser parser,
             ITransactionRepository repo,
-            ICategoryRepository? catRepo = null)
+            ICategoryRepository? catRepo = null,
+            CategorizationService? categorizationService = null)
         {
             var logger = Substitute.For<ILogger<ImportService>>();
-            return new ImportService([parser], repo, logger, catRepo);
+            return new ImportService([parser], repo, logger, catRepo, categorizationService);
         }
 
         [Fact]
-        public async Task ImportFromCsv_ValidRecords_ImportedAndSaved()
+        public async Task AnalyzeCsvAsync_ValidRecords_BuildsPreviewWithoutSaving()
         {
             var parser = Substitute.For<IStatementParser>();
             var repo = Substitute.For<ITransactionRepository>();
             repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
                 .Returns([]);
 
-            var dtos = new List<TransactionDto>
-            {
-                new() { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "A" },
-                new() { Buchungsdatum = DateTime.Today, Betrag = -5m, Zahlungsempfaenger = "B" }
-            };
-            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
+            var categories = Substitute.For<ICategoryRepository>();
+            categories.GetCategoriesAsync().Returns([
+                new Category { Id = "cat-food", Name = "Lebensmittel", Icon = "🛒" }
+            ]);
 
-            var svc = BuildService(parser, repo);
-            using var ms = new MemoryStream();
+            parser.Parse(Arg.Any<Stream>()).Returns([
+                new TransactionDto { Buchungsdatum = DateTime.Today, Betrag = -10m, Zahlungsempfaenger = "Supermarkt" }
+            ]);
 
-            var result = await svc.ImportFromCsvAsync(ms);
+            var preview = await BuildService(parser, repo, categories).AnalyzeCsvAsync(new MemoryStream());
 
-            Assert.True(result.Success);
-            Assert.Equal(2, result.Imported.Count);
-            Assert.Empty(result.Duplicates);
-            Assert.Equal(0, result.SkippedMalformed);
-            Assert.Empty(result.SaveErrors);
-            await repo.Received(2).SaveTransactionAsync(Arg.Any<Transaction>());
-        }
-
-        [Fact]
-        public async Task ImportFromCsv_DuplicateDetected_SkippedNotSaved()
-        {
-            var parser = Substitute.For<IStatementParser>();
-            var repo = Substitute.For<ITransactionRepository>();
-
-            var dtos = new List<TransactionDto>
-            {
-                new() { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "Shop" }
-            };
-            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
-
-            // Simulate existing transaction that matches
-            var existing = new Transaction { Betrag = 10m, Titel = "Shop", Datum = DateTime.Today };
-            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
-                .Returns([existing]);
-
-            var svc = BuildService(parser, repo);
-            using var ms = new MemoryStream();
-
-            var result = await svc.ImportFromCsvAsync(ms);
-
-            Assert.True(result.Success);
-            Assert.Empty(result.Imported);
-            Assert.Single(result.Duplicates);
+            Assert.True(preview.Success);
+            Assert.Single(preview.Rows);
+            Assert.Equal(ImportPreviewRowStatus.Uncategorized, preview.Rows[0].Status);
             await repo.DidNotReceive().SaveTransactionAsync(Arg.Any<Transaction>());
+            await categories.DidNotReceive().SaveCategoryAsync(Arg.Any<Category>());
         }
 
         [Fact]
-        public async Task ImportFromCsv_MalformedDto_Skipped()
+        public async Task AnalyzeCsvAsync_DuplicateWithinBatch_MarksLaterRowAsDuplicate()
         {
             var parser = Substitute.For<IStatementParser>();
             var repo = Substitute.For<ITransactionRepository>();
             repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
                 .Returns([]);
 
-            var dtos = new List<TransactionDto>
+            parser.Parse(Arg.Any<Stream>()).Returns([
+                new TransactionDto { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "Shop" },
+                new TransactionDto { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "Shop" }
+            ]);
+
+            var preview = await BuildService(parser, repo).AnalyzeCsvAsync(new MemoryStream());
+
+            Assert.Equal(2, preview.Rows.Count);
+            Assert.Equal(ImportPreviewRowStatus.Uncategorized, preview.Rows[0].Status);
+            Assert.Equal(ImportPreviewRowStatus.Duplicate, preview.Rows[1].Status);
+        }
+
+        [Fact]
+        public async Task CommitImportAsync_OnlySelectedRowsAreSaved()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+                .Returns([]);
+
+            var categories = Substitute.For<ICategoryRepository>();
+            categories.GetCategoriesAsync().Returns([
+                new Category
+                {
+                    Id = "uncat",
+                    Name = "Unkategorisiert",
+                    SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert
+                }
+            ]);
+
+            var service = BuildService(parser, repo, categories);
+            var preview = new ImportPreviewResult
             {
-                new() { Buchungsdatum = default, Betrag = 5m }, // malformed: no date
-                new() { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "Valid" }
+                Rows =
+                [
+                    new ImportPreviewRow
+                    {
+                        Id = "r1",
+                        IsIncluded = true,
+                        Status = ImportPreviewRowStatus.Uncategorized,
+                        Transaction = new Transaction
+                        {
+                            Id = "t1",
+                            Datum = DateTime.Today,
+                            Betrag = 10m,
+                            Titel = "A"
+                        }
+                    },
+                    new ImportPreviewRow
+                    {
+                        Id = "r2",
+                        IsIncluded = true,
+                        Status = ImportPreviewRowStatus.Uncategorized,
+                        Transaction = new Transaction
+                        {
+                            Id = "t2",
+                            Datum = DateTime.Today,
+                            Betrag = 20m,
+                            Titel = "B"
+                        }
+                    }
+                ]
             };
-            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
 
-            var svc = BuildService(parser, repo);
-            using var ms = new MemoryStream();
+            var result = await service.CommitImportAsync(preview, ["r2"]);
 
-            var result = await svc.ImportFromCsvAsync(ms);
+            Assert.Single(result.Imported);
+            Assert.Equal("t2", result.Imported[0].Id);
+            await repo.Received(1).SaveTransactionAsync(Arg.Is<Transaction>(t => t.Id == "t2"));
+            await repo.DidNotReceive().SaveTransactionAsync(Arg.Is<Transaction>(t => t.Id == "t1"));
+        }
+
+        [Fact]
+        public async Task CommitImportAsync_CreatesFallbackCategoryOnlyDuringCommit()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+                .Returns([]);
+
+            var categories = Substitute.For<ICategoryRepository>();
+            categories.GetCategoriesAsync().Returns([]);
+
+            Category? savedCategory = null;
+            categories.SaveCategoryAsync(Arg.Do<Category>(c => savedCategory = c))
+                .Returns(Task.CompletedTask);
+
+            var preview = new ImportPreviewResult
+            {
+                Rows =
+                [
+                    new ImportPreviewRow
+                    {
+                        Id = "r1",
+                        IsIncluded = true,
+                        Status = ImportPreviewRowStatus.Uncategorized,
+                        Transaction = new Transaction
+                        {
+                            Id = "t1",
+                            Datum = DateTime.Today,
+                            Betrag = 11m,
+                            Titel = "Fallback"
+                        }
+                    }
+                ]
+            };
+
+            var result = await BuildService(parser, repo, categories).CommitImportAsync(preview);
+
+            Assert.Single(result.Imported);
+            Assert.NotNull(savedCategory);
+            await categories.Received(1).SaveCategoryAsync(Arg.Any<Category>());
+            await repo.Received(1).SaveTransactionAsync(Arg.Is<Transaction>(t => t.KategorieId == savedCategory!.Id));
+        }
+
+        [Fact]
+        public async Task ImportFromCsvAsync_CompatibilityWrapper_ImportsAndReportsInvalidRows()
+        {
+            var parser = Substitute.For<IStatementParser>();
+            var repo = Substitute.For<ITransactionRepository>();
+            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+                .Returns([]);
+
+            var categories = Substitute.For<ICategoryRepository>();
+            categories.GetCategoriesAsync().Returns([
+                new Category
+                {
+                    Id = "uncat",
+                    Name = "Unkategorisiert",
+                    SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Unkategorisiert
+                }
+            ]);
+
+            parser.Parse(Arg.Any<Stream>()).Returns([
+                new TransactionDto { Buchungsdatum = default, Betrag = 5m },
+                new TransactionDto { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "Valid" }
+            ]);
+
+            var result = await BuildService(parser, repo, categories).ImportFromCsvAsync(new MemoryStream());
 
             Assert.True(result.Success);
             Assert.Single(result.Imported);
             Assert.Equal(1, result.SkippedMalformed);
+            await repo.Received(1).SaveTransactionAsync(Arg.Any<Transaction>());
         }
 
         [Fact]
-        public async Task ImportFromCsv_SaveFails_ReportedInSaveErrors()
-        {
-            var parser = Substitute.For<IStatementParser>();
-            var repo = Substitute.For<ITransactionRepository>();
-            repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
-                .Returns([]);
-            repo.SaveTransactionAsync(Arg.Any<Transaction>())
-                .Returns(Task.FromException(new IOException("disk full")));
-
-            var dtos = new List<TransactionDto>
-            {
-                new() { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "A" }
-            };
-            parser.Parse(Arg.Any<Stream>()).Returns(dtos);
-
-            var svc = BuildService(parser, repo);
-            using var ms = new MemoryStream();
-
-            var result = await svc.ImportFromCsvAsync(ms);
-
-            Assert.True(result.Success); // no top-level error
-            Assert.Empty(result.Imported);
-            Assert.Single(result.SaveErrors);
-            Assert.Contains("disk full", result.SaveErrors[0]);
-        }
-
-        [Fact]
-        public async Task ImportFromCsv_NoParserMatches_ErrorMessage()
+        public async Task ImportFromCsvAsync_NoParserMatches_ReturnsError()
         {
             var parser = Substitute.For<IStatementParser>();
             parser.Parse(Arg.Any<Stream>()).Returns([]);
             var repo = Substitute.For<ITransactionRepository>();
 
-            var svc = BuildService(parser, repo);
-            using var ms = new MemoryStream();
-
-            var result = await svc.ImportFromCsvAsync(ms);
+            var result = await BuildService(parser, repo).ImportFromCsvAsync(new MemoryStream());
 
             Assert.False(result.Success);
             Assert.NotNull(result.ErrorMessage);
         }
 
         [Fact]
-        public async Task ImportFromCsv_ParserThrows_TriesNextParser()
+        public async Task ImportFromCsvAsync_ParserThrows_TriesNextParser()
         {
             var failingParser = Substitute.For<IStatementParser>();
             failingParser.Parse(Arg.Any<Stream>()).Throws(new Exception("parse error"));
 
             var workingParser = Substitute.For<IStatementParser>();
-            var dtos = new List<TransactionDto>
-            {
-                new() { Buchungsdatum = DateTime.Today, Betrag = 5m, Zahlungsempfaenger = "OK" }
-            };
-            workingParser.Parse(Arg.Any<Stream>()).Returns(dtos);
+            workingParser.Parse(Arg.Any<Stream>()).Returns([
+                new TransactionDto { Buchungsdatum = DateTime.Today, Betrag = 5m, Zahlungsempfaenger = "OK" }
+            ]);
 
             var repo = Substitute.For<ITransactionRepository>();
             repo.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
@@ -159,16 +226,15 @@ namespace Finanzuebersicht.Tests.Services
 
             var logger = Substitute.For<ILogger<ImportService>>();
             var svc = new ImportService([failingParser, workingParser], repo, logger);
-            using var ms = new MemoryStream();
 
-            var result = await svc.ImportFromCsvAsync(ms);
+            var result = await svc.ImportFromCsvAsync(new MemoryStream());
 
             Assert.True(result.Success);
             Assert.Single(result.Imported);
         }
 
         [Fact]
-        public async Task ImportFromCsv_Cancellation_ThrowsOperationCancelled()
+        public async Task ImportFromCsvAsync_Cancellation_ThrowsOperationCancelled()
         {
             var parser = Substitute.For<IStatementParser>();
             var repo = Substitute.For<ITransactionRepository>();
@@ -177,10 +243,9 @@ namespace Finanzuebersicht.Tests.Services
 
             var logger = Substitute.For<ILogger<ImportService>>();
             var svc = new ImportService([parser], repo, logger);
-            using var ms = new MemoryStream();
 
             await Assert.ThrowsAsync<OperationCanceledException>(
-                () => svc.ImportFromCsvAsync(ms, cancellationToken: cts.Token));
+                () => svc.ImportFromCsvAsync(new MemoryStream(), cancellationToken: cts.Token));
         }
     }
 }

--- a/Finanzuebersicht.Tests/ViewModels/ImportPreviewViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/ImportPreviewViewModelTests.cs
@@ -1,0 +1,114 @@
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.ViewModels;
+using Microsoft.Extensions.Logging;
+
+namespace Finanzuebersicht.Tests.ViewModels;
+
+public class ImportPreviewViewModelTests
+{
+    [Fact]
+    public async Task LoadPreview_LoadsRowsAndAppliesReadyFilter()
+    {
+        var sessionStore = new ImportSessionStore();
+        sessionStore.SetActiveSession(new ImportPreviewResult
+        {
+            Rows =
+            [
+                new ImportPreviewRow
+                {
+                    Id = "r1",
+                    Status = ImportPreviewRowStatus.Ready,
+                    IsIncluded = true,
+                    Transaction = new Transaction { Id = "t1", Titel = "Ready", Datum = DateTime.Today, Betrag = 10m }
+                },
+                new ImportPreviewRow
+                {
+                    Id = "r2",
+                    Status = ImportPreviewRowStatus.Uncategorized,
+                    IsIncluded = true,
+                    Transaction = new Transaction { Id = "t2", Titel = "NoCat", Datum = DateTime.Today, Betrag = 20m }
+                },
+                new ImportPreviewRow
+                {
+                    Id = "r3",
+                    Status = ImportPreviewRowStatus.Duplicate,
+                    IsIncluded = false,
+                    Transaction = new Transaction { Id = "t3", Titel = "Dup", Datum = DateTime.Today, Betrag = 30m }
+                }
+            ]
+        });
+
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        categoryRepository.GetCategoriesAsync().Returns([
+            new Category { Id = "cat-1", Name = "Test", Icon = "T" }
+        ]);
+
+        var localization = Substitute.For<ILocalizationService>();
+        localization.GetString(Arg.Any<string>()).Returns(call => call.Arg<string>());
+        localization.GetString(Arg.Any<string>(), Arg.Any<object[]>()).Returns(call => call.Arg<string>());
+
+        var navigation = Substitute.For<INavigationService>();
+        navigation.GoBackAsync().Returns(Task.CompletedTask);
+
+        var dialog = Substitute.For<IDialogService>();
+        dialog.ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>()).Returns(Task.CompletedTask);
+
+        var vm = new ImportPreviewViewModel(
+            new ImportService([], Substitute.For<ITransactionRepository>(), Substitute.For<ILogger<ImportService>>(), categoryRepository),
+            sessionStore,
+            categoryRepository,
+            navigation,
+            dialog,
+            localization,
+            Substitute.For<IAppEvents>(),
+            Substitute.For<ILogger<ImportPreviewViewModel>>());
+
+        await vm.LoadPreviewCommand.ExecuteAsync(null);
+
+        Assert.Equal(3, vm.Rows.Count);
+        Assert.NotSame(vm.Rows[0].CategoryOptions[1], vm.Rows[1].CategoryOptions[1]);
+        Assert.NotNull(vm.SelectedFilter);
+        Assert.Equal(ImportPreviewFilter.All, vm.SelectedFilter.Filter);
+
+        vm.SelectedFilter = vm.FilterOptions.Single(option => option.Filter == ImportPreviewFilter.Ready);
+
+        Assert.Equal(2, vm.FilteredRows.Count);
+        Assert.All(vm.FilteredRows, row => Assert.True(row.Status is ImportPreviewRowStatus.Ready or ImportPreviewRowStatus.Uncategorized));
+    }
+
+    [Fact]
+    public void HandlePageDisappearing_ClearsSession()
+    {
+        var sessionStore = new ImportSessionStore();
+        sessionStore.SetActiveSession(new ImportPreviewResult
+        {
+            Rows =
+            [
+                new ImportPreviewRow
+                {
+                    Id = "r1",
+                    Status = ImportPreviewRowStatus.Ready,
+                    Transaction = new Transaction { Id = "t1", Titel = "Ready", Datum = DateTime.Today, Betrag = 1m }
+                }
+            ]
+        });
+
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var localization = Substitute.For<ILocalizationService>();
+        localization.GetString(Arg.Any<string>()).Returns(call => call.Arg<string>());
+        var vm = new ImportPreviewViewModel(
+            new ImportService([], Substitute.For<ITransactionRepository>(), Substitute.For<ILogger<ImportService>>(), categoryRepository),
+            sessionStore,
+            categoryRepository,
+            Substitute.For<INavigationService>(),
+            Substitute.For<IDialogService>(),
+            localization,
+            Substitute.For<IAppEvents>(),
+            Substitute.For<ILogger<ImportPreviewViewModel>>());
+
+        vm.HandlePageDisappearing();
+
+        Assert.Null(sessionStore.GetActiveSession());
+    }
+}

--- a/Finanzuebersicht.Tests/ViewModels/ImportPreviewViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/ImportPreviewViewModelTests.cs
@@ -8,7 +8,7 @@ namespace Finanzuebersicht.Tests.ViewModels;
 public class ImportPreviewViewModelTests
 {
     [Fact]
-    public async Task LoadPreview_LoadsRowsAndAppliesReadyFilter()
+    public async Task LoadPreview_LoadsRowsAndDefaultFilterIsAll()
     {
         var sessionStore = new ImportSessionStore();
         sessionStore.SetActiveSession(new ImportPreviewResult

--- a/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
@@ -3,6 +3,8 @@ using System.Collections.ObjectModel;
 using System.Threading.Tasks;
 using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.ViewModels;
 using Microsoft.Extensions.Logging;
 
@@ -163,6 +165,50 @@ public class TransactionsViewModelTests
         await deleteRepository.DidNotReceive().DeleteTransactionAsync(Arg.Any<string>());
     }
 
+    [Fact]
+    public async Task ImportCsv_NavigatesToPreviewRoute()
+    {
+        var parser = Substitute.For<IStatementParser>();
+        parser.Parse(Arg.Any<Stream>()).Returns([
+            new TransactionDto { Buchungsdatum = DateTime.Today, Betrag = 10m, Zahlungsempfaenger = "Import" }
+        ]);
+
+        var importRepository = Substitute.For<ITransactionRepository>();
+        importRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>()));
+
+        var importCategoryRepository = Substitute.For<ICategoryRepository>();
+        importCategoryRepository.GetCategoriesAsync()
+            .Returns(Task.FromResult(new List<Category>()));
+
+        var importLogger = Substitute.For<ILogger<ImportService>>();
+        var importService = new ImportService([parser], importRepository, importLogger, importCategoryRepository);
+
+        var pickedFile = new PickFileResult("test.csv", () => Task.FromResult<Stream>(new MemoryStream()));
+        var filePicker = Substitute.For<IFilePicker>();
+        filePicker.PickAsync().Returns(Task.FromResult<PickFileResult?>(pickedFile));
+
+        var importSessionStore = new ImportSessionStore();
+
+        var viewModel = CreateSut(
+            Substitute.For<ITransactionRepository>(),
+            Substitute.For<ICategoryRepository>(),
+            Substitute.For<ITransactionRepository>(),
+            Substitute.For<ICategoryRepository>(),
+            out _,
+            out _,
+            out _,
+            out var navigationService,
+            filePicker: filePicker,
+            importService: importService,
+            importSessionStore: importSessionStore);
+
+        await viewModel.ImportCsvCommand.ExecuteAsync(null);
+
+        Assert.NotNull(importSessionStore.GetActiveSession());
+        await navigationService.Received(1).GoToAsync(Routes.ImportPreview, Arg.Any<IDictionary<string, object>>());
+    }
+
     private static TransactionsViewModel CreateSut(
         ITransactionRepository loadTransactionRepository,
         ICategoryRepository loadCategoryRepository,
@@ -172,7 +218,10 @@ public class TransactionsViewModelTests
         out ILocalizationService localizationService,
         out IMainThreadDispatcher dispatcher,
         out INavigationService navigationService,
-        ITransactionRepository? deleteTransactionRepository = null)
+        ITransactionRepository? deleteTransactionRepository = null,
+        IFilePicker? filePicker = null,
+        ImportService? importService = null,
+        IImportSessionStore? importSessionStore = null)
     {
         dialogService = Substitute.For<IDialogService>();
         dialogService.ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
@@ -189,14 +238,17 @@ public class TransactionsViewModelTests
             .Returns(call => call.Arg<Func<Task>>()());
 
         navigationService = Substitute.For<INavigationService>();
+        navigationService.GoToAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object>>()).Returns(Task.CompletedTask);
+        navigationService.GoToAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
 
-        var filePicker = Substitute.For<IFilePicker>();
+        filePicker ??= Substitute.For<IFilePicker>();
         var appEvents = Substitute.For<IAppEvents>();
         var logger = Substitute.For<ILogger<TransactionsViewModel>>();
-        var importLogger = Substitute.For<ILogger<ImportService>>();
-        var importTransactionRepository = Substitute.For<ITransactionRepository>();
-        var importCategoryRepository = Substitute.For<ICategoryRepository>();
-        var importService = new ImportService([], importTransactionRepository, importLogger, importCategoryRepository);
+        importService ??= new ImportService(
+            [],
+            Substitute.For<ITransactionRepository>(),
+            Substitute.For<ILogger<ImportService>>(),
+            Substitute.For<ICategoryRepository>());
 
         deleteTransactionRepository ??= Substitute.For<ITransactionRepository>();
         deleteTransactionRepository.DeleteTransactionAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
@@ -213,6 +265,7 @@ public class TransactionsViewModelTests
             dispatcher,
             filePicker,
             appEvents,
-            logger);
+            logger,
+            importSessionStore);
     }
 }

--- a/Finanzuebersicht/AppShell.xaml.cs
+++ b/Finanzuebersicht/AppShell.xaml.cs
@@ -15,6 +15,7 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute(Routes.RecurringInstanceShift, typeof(RecurringInstanceShiftPage));
 		Routing.RegisterRoute(Routes.Settings, typeof(SettingsPage));
 		Routing.RegisterRoute(Routes.BackupList, typeof(BackupListPage));
+		Routing.RegisterRoute(Routes.ImportPreview, typeof(ImportPreviewPage));
 	}
 
 	private async void OnSettingsClicked(object? sender, EventArgs e)

--- a/Finanzuebersicht/Converters/BetragDisplayConverter.cs
+++ b/Finanzuebersicht/Converters/BetragDisplayConverter.cs
@@ -7,13 +7,41 @@ public class BetragDisplayConverter : IValueConverter
 {
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is not Transaction t) return string.Empty;
-
         var ci = culture ?? CultureInfo.CurrentCulture;
-        var abs = Math.Abs(t.Betrag);
-        var formatted = abs.ToString("C", ci);
-        var sign = t.Typ == TransactionType.Einnahme ? "+" : "-";
-        return $"{sign}{formatted}";
+
+        if (value is Transaction t)
+        {
+            var abs = Math.Abs(t.Betrag);
+            var formatted = abs.ToString("C", ci);
+            var sign = t.Typ == TransactionType.Einnahme ? "+" : "-";
+            return $"{sign}{formatted}";
+        }
+
+        if (value is TransactionTemplate tpl)
+        {
+            var abs = Math.Abs(tpl.Betrag);
+            var formatted = abs.ToString("C", ci);
+            var sign = tpl.Typ == TransactionType.Einnahme ? "+" : "-";
+            return $"{sign}{formatted}";
+        }
+
+        if (value is decimal dec)
+        {
+            var abs = Math.Abs(dec);
+            var formatted = abs.ToString("C", ci);
+            var sign = dec >= 0 ? "+" : "-";
+            return $"{sign}{formatted}";
+        }
+
+        if (value is double d)
+        {
+            var abs = Math.Abs(d);
+            var formatted = abs.ToString("C", ci);
+            var sign = d >= 0 ? "+" : "-";
+            return $"{sign}{formatted}";
+        }
+
+        return string.Empty;
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/Finanzuebersicht/Converters/ImportPreviewStatusColorConverter.cs
+++ b/Finanzuebersicht/Converters/ImportPreviewStatusColorConverter.cs
@@ -1,0 +1,32 @@
+using Finanzuebersicht.Models;
+using System.Globalization;
+
+namespace Finanzuebersicht.Converters;
+
+public class ImportPreviewStatusColorConverter : IValueConverter
+{
+    public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not ImportPreviewRowStatus status)
+            return ColorResourceHelper.GetThemeColor("Gray600", "Gray600", Color.FromArgb("#8E8E93"), Color.FromArgb("#8E8E93"));
+
+        return status switch
+        {
+            ImportPreviewRowStatus.Ready => ColorResourceHelper.GetThemeColor(
+                "Einnahme", "EinnahmeDark", Color.FromArgb("#34C759"), Color.FromArgb("#30D158")),
+            ImportPreviewRowStatus.Duplicate => ColorResourceHelper.GetThemeColor(
+                "Warning", "WarningDark", Color.FromArgb("#FF9500"), Color.FromArgb("#FF9F0A")),
+            ImportPreviewRowStatus.Invalid => ColorResourceHelper.GetThemeColor(
+                "Ausgabe", "AusgabeDark", Color.FromArgb("#FF3B30"), Color.FromArgb("#FF453A")),
+            ImportPreviewRowStatus.Uncategorized => ColorResourceHelper.GetThemeColor(
+                "ImportUncategorized", "ImportUncategorizedDark", Color.FromArgb("#FFCC00"), Color.FromArgb("#FFD60A")),
+            ImportPreviewRowStatus.SaveError => ColorResourceHelper.GetThemeColor(
+                "Ausgabe", "AusgabeDark", Color.FromArgb("#FF3B30"), Color.FromArgb("#FF453A")),
+            _ => ColorResourceHelper.GetThemeColor(
+                "Gray600", "Gray600", Color.FromArgb("#8E8E93"), Color.FromArgb("#8E8E93")),
+        };
+    }
+
+    public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Maui;
 using Finanzuebersicht.Application.DependencyInjection;
 using Finanzuebersicht.Infrastructure;
 using Finanzuebersicht.Presentation.DependencyInjection;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Services;
 using Finanzuebersicht.Views;
 
@@ -62,6 +63,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IMainThreadDispatcher, MauiMainThreadDispatcher>();
 		builder.Services.AddSingleton<Finanzuebersicht.Presentation.Services.IFilePicker, MauiFilePicker>();
 		builder.Services.AddSingleton<IAppEvents, MauiAppEvents>();
+		builder.Services.AddSingleton<IImportSessionStore, ImportSessionStore>();
 		builder.Services.AddSingleton<IFolderPicker, MauiFolderPicker>();
 		builder.Services.AddSingleton<IFileSaver, MauiFileSaver>();
 		builder.Services.AddSingleton<IThemeService>(sp => sp.GetRequiredService<ThemeService>());
@@ -80,6 +82,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<SettingsPage>();
 		builder.Services.AddTransient<SparZielePage>();
 		builder.Services.AddTransient<BackupListPage>();
+		builder.Services.AddTransient<ImportPreviewPage>();
 
 #if DEBUG
 		builder.Logging.AddDebug();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -142,6 +142,12 @@ Bitte starte die App neu.</value></data>
   <data name="Msg_ImportAbgeschlossen_Title" xml:space="preserve"><value>Import abgeschlossen</value></data>
   <data name="Msg_ImportiertCount" xml:space="preserve"><value>Importiert: {0} Transaktionen</value></data>
   <data name="Msg_ImportFehler_Title" xml:space="preserve"><value>Fehler beim Import</value></data>
+  <data name="Msg_ImportDuplikateCount" xml:space="preserve"><value>Duplikate: {0}</value></data>
+  <data name="Msg_ImportFehlerCount" xml:space="preserve"><value>Fehler: {0}</value></data>
+  <data name="Msg_ImportVorschauNichtVerfuegbar_Title" xml:space="preserve"><value>Import-Vorschau nicht verfügbar</value></data>
+  <data name="Msg_ImportVorschauNichtVerfuegbar_Body" xml:space="preserve"><value>Keine aktive Import-Vorschau gefunden.</value></data>
+  <data name="Msg_ImportVorschauNichtsAusgewaehlt_Title" xml:space="preserve"><value>Nichts ausgewählt</value></data>
+  <data name="Msg_ImportVorschauNichtsAusgewaehlt_Body" xml:space="preserve"><value>Wähle mindestens eine importierbare Zeile aus.</value></data>
 
   <!-- Backup / Restore / Export -->
   <data name="Stn_NoBackupYet" xml:space="preserve"><value>Noch keine Sicherung erstellt</value></data>
@@ -221,10 +227,40 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_FilterUmschalten" xml:space="preserve"><value>Filter umschalten</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} Daueraufträge bald fällig</value></data>
   <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} Dauerauftrag bald fällig</value></data>
+  <data name="Lbl_OhneKategorie" xml:space="preserve"><value>Ohne Kategorie</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>von {0}</value></data>
   <data name="Lbl_Von" xml:space="preserve"><value>von</value></data>
   <data name="Lbl_UeberBudget" xml:space="preserve"><value>über Budget</value></data>
+  <data name="Lbl_BudgetHinweise" xml:space="preserve"><value>Budget-Hinweise</value></data>
+  <data name="Lbl_BudgetVerbraucht" xml:space="preserve"><value>Budget verbraucht</value></data>
+  <data name="Lbl_TagesbudgetBisMonatsende" xml:space="preserve"><value>Tagesbudget bis Monatsende</value></data>
+  <data name="Lbl_BudgetWarnung80" xml:space="preserve"><value>80 % des Budgets verbraucht</value></data>
+  <data name="Lbl_BudgetAufgebraucht" xml:space="preserve"><value>Budget aufgebraucht oder überschritten</value></data>
+  <data name="Lbl_HaeufigVerwendet" xml:space="preserve"><value>Häufig verwendet</value></data>
+  <data name="Lbl_ImportFilterAlle" xml:space="preserve"><value>Alle</value></data>
+  <data name="Lbl_ImportFilterBereit" xml:space="preserve"><value>Bereit</value></data>
+  <data name="Lbl_ImportFilterDuplikate" xml:space="preserve"><value>Duplikate</value></data>
+  <data name="Lbl_ImportFilterProbleme" xml:space="preserve"><value>Probleme</value></data>
+  <data name="Lbl_ImportFilterAusgeschlossen" xml:space="preserve"><value>Ausgeschlossen</value></data>
+  <data name="Lbl_ImportStatusBereit" xml:space="preserve"><value>Bereit</value></data>
+  <data name="Lbl_ImportStatusDuplikat" xml:space="preserve"><value>Duplikat</value></data>
+  <data name="Lbl_ImportStatusUngueltig" xml:space="preserve"><value>Ungültig</value></data>
+  <data name="Lbl_ImportStatusUnkategorisiert" xml:space="preserve"><value>Ohne Kategorie</value></data>
+  <data name="Lbl_ImportStatusSpeicherfehler" xml:space="preserve"><value>Speicherfehler</value></data>
+  <data name="Lbl_ImportBereitCount" xml:space="preserve"><value>Bereit: {0}</value></data>
+  <data name="Lbl_ImportDuplikateCount" xml:space="preserve"><value>Duplikate: {0}</value></data>
+  <data name="Lbl_ImportProblemeCount" xml:space="preserve"><value>Probleme: {0}</value></data>
+  <data name="Lbl_ImportAusgewaehltCount" xml:space="preserve"><value>Ausgewählt: {0}</value></data>
+  <data name="Btn_Duplizieren" xml:space="preserve"><value>Duplizieren</value></data>
+  <data name="Btn_Verwenden" xml:space="preserve"><value>Verwenden</value></data>
+  <data name="Btn_AlsVorlageSpeichern" xml:space="preserve"><value>Als Vorlage speichern</value></data>
+  <data name="Dlg_VorlageLoeschen" xml:space="preserve"><value>Vorlage löschen</value></data>
+  <data name="Dlg_VorlageLoeschenFrage" xml:space="preserve"><value>Vorlage "{0}" löschen?</value></data>
+  <data name="Msg_VorlageGespeichert_Title" xml:space="preserve"><value>Vorlage gespeichert</value></data>
+  <data name="Msg_VorlageGespeichert_Body" xml:space="preserve"><value>Die Transaktionsvorlage ist jetzt unter häufig verwendet verfügbar.</value></data>
   <data name="Hint_BudgetOptional" xml:space="preserve"><value>0,00 (kein Budget)</value></data>
+  <data name="Empty_ImportVorschauLeer" xml:space="preserve"><value>Keine Zeilen für den aktuellen Filter.</value></data>
+  <data name="Ttl_ImportVorschau" xml:space="preserve"><value>Import-Vorschau</value></data>
   <data name="Hint_BudgetNull" xml:space="preserve"><value>Auf 0 setzen um Budget zu entfernen</value></data>
   <data name="Hint_ZielTitel" xml:space="preserve"><value>z.B. Urlaub, Neuer Laptop</value></data>
   <data name="Empty_KeineSparZiele" xml:space="preserve"><value>Noch keine Sparziele angelegt</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -251,6 +251,9 @@ Bitte starte die App neu.</value></data>
   <data name="Lbl_ImportDuplikateCount" xml:space="preserve"><value>Duplikate: {0}</value></data>
   <data name="Lbl_ImportProblemeCount" xml:space="preserve"><value>Probleme: {0}</value></data>
   <data name="Lbl_ImportAusgewaehltCount" xml:space="preserve"><value>Ausgewählt: {0}</value></data>
+  <data name="Msg_ImportStatusMissingDate" xml:space="preserve"><value>Buchungsdatum fehlt</value></data>
+  <data name="Msg_ImportStatusPossibleDuplicate" xml:space="preserve"><value>Mögliches Duplikat</value></data>
+  <data name="Msg_ImportStatusCategoryUnresolved" xml:space="preserve"><value>Kategorie nicht zugeordnet</value></data>
   <data name="Btn_Duplizieren" xml:space="preserve"><value>Duplizieren</value></data>
   <data name="Btn_Verwenden" xml:space="preserve"><value>Verwenden</value></data>
   <data name="Btn_AlsVorlageSpeichern" xml:space="preserve"><value>Als Vorlage speichern</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -142,6 +142,12 @@ Please restart the app.</value></data>
   <data name="Msg_ImportAbgeschlossen_Title" xml:space="preserve"><value>Import completed</value></data>
   <data name="Msg_ImportiertCount" xml:space="preserve"><value>Imported: {0} transactions</value></data>
   <data name="Msg_ImportFehler_Title" xml:space="preserve"><value>Error during import</value></data>
+  <data name="Msg_ImportDuplikateCount" xml:space="preserve"><value>Duplicates: {0}</value></data>
+  <data name="Msg_ImportFehlerCount" xml:space="preserve"><value>Errors: {0}</value></data>
+  <data name="Msg_ImportVorschauNichtVerfuegbar_Title" xml:space="preserve"><value>Import preview not available</value></data>
+  <data name="Msg_ImportVorschauNichtVerfuegbar_Body" xml:space="preserve"><value>No active import preview was found.</value></data>
+  <data name="Msg_ImportVorschauNichtsAusgewaehlt_Title" xml:space="preserve"><value>Nothing selected</value></data>
+  <data name="Msg_ImportVorschauNichtsAusgewaehlt_Body" xml:space="preserve"><value>Select at least one importable row.</value></data>
 
   <!-- Backup / Restore / Export -->
   <data name="Stn_NoBackupYet" xml:space="preserve"><value>No backup created yet</value></data>
@@ -221,10 +227,40 @@ Please restart the app.</value></data>
   <data name="A11y_FilterUmschalten" xml:space="preserve"><value>Toggle filters</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} recurring transactions due soon</value></data>
   <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} recurring transaction due soon</value></data>
+  <data name="Lbl_OhneKategorie" xml:space="preserve"><value>No category</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>of {0}</value></data>
   <data name="Lbl_Von" xml:space="preserve"><value>of</value></data>
   <data name="Lbl_UeberBudget" xml:space="preserve"><value>over budget</value></data>
+  <data name="Lbl_BudgetHinweise" xml:space="preserve"><value>Budget hints</value></data>
+  <data name="Lbl_BudgetVerbraucht" xml:space="preserve"><value>Used budget</value></data>
+  <data name="Lbl_TagesbudgetBisMonatsende" xml:space="preserve"><value>Daily budget until month end</value></data>
+  <data name="Lbl_BudgetWarnung80" xml:space="preserve"><value>80% of budget used</value></data>
+  <data name="Lbl_BudgetAufgebraucht" xml:space="preserve"><value>Budget used up or exceeded</value></data>
+  <data name="Lbl_HaeufigVerwendet" xml:space="preserve"><value>Frequently used</value></data>
+  <data name="Lbl_ImportFilterAlle" xml:space="preserve"><value>All</value></data>
+  <data name="Lbl_ImportFilterBereit" xml:space="preserve"><value>Ready</value></data>
+  <data name="Lbl_ImportFilterDuplikate" xml:space="preserve"><value>Duplicates</value></data>
+  <data name="Lbl_ImportFilterProbleme" xml:space="preserve"><value>Problems</value></data>
+  <data name="Lbl_ImportFilterAusgeschlossen" xml:space="preserve"><value>Excluded</value></data>
+  <data name="Lbl_ImportStatusBereit" xml:space="preserve"><value>Ready</value></data>
+  <data name="Lbl_ImportStatusDuplikat" xml:space="preserve"><value>Duplicate</value></data>
+  <data name="Lbl_ImportStatusUngueltig" xml:space="preserve"><value>Invalid</value></data>
+  <data name="Lbl_ImportStatusUnkategorisiert" xml:space="preserve"><value>No category</value></data>
+  <data name="Lbl_ImportStatusSpeicherfehler" xml:space="preserve"><value>Save error</value></data>
+  <data name="Lbl_ImportBereitCount" xml:space="preserve"><value>Ready: {0}</value></data>
+  <data name="Lbl_ImportDuplikateCount" xml:space="preserve"><value>Duplicates: {0}</value></data>
+  <data name="Lbl_ImportProblemeCount" xml:space="preserve"><value>Problems: {0}</value></data>
+  <data name="Lbl_ImportAusgewaehltCount" xml:space="preserve"><value>Selected: {0}</value></data>
+  <data name="Btn_Duplizieren" xml:space="preserve"><value>Duplicate</value></data>
+  <data name="Btn_Verwenden" xml:space="preserve"><value>Use</value></data>
+  <data name="Btn_AlsVorlageSpeichern" xml:space="preserve"><value>Save as template</value></data>
+  <data name="Dlg_VorlageLoeschen" xml:space="preserve"><value>Delete template</value></data>
+  <data name="Dlg_VorlageLoeschenFrage" xml:space="preserve"><value>Delete template "{0}"?</value></data>
+  <data name="Msg_VorlageGespeichert_Title" xml:space="preserve"><value>Template saved</value></data>
+  <data name="Msg_VorlageGespeichert_Body" xml:space="preserve"><value>The transaction template is now available under frequently used.</value></data>
   <data name="Hint_BudgetOptional" xml:space="preserve"><value>0.00 (no budget)</value></data>
+  <data name="Empty_ImportVorschauLeer" xml:space="preserve"><value>No rows for current filter.</value></data>
+  <data name="Ttl_ImportVorschau" xml:space="preserve"><value>Import Preview</value></data>
   <data name="Hint_BudgetNull" xml:space="preserve"><value>Set to 0 to remove budget</value></data>
   <data name="Hint_ZielTitel" xml:space="preserve"><value>e.g. Vacation, New Laptop</value></data>
   <data name="Empty_KeineSparZiele" xml:space="preserve"><value>No savings goals yet</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -251,6 +251,9 @@ Please restart the app.</value></data>
   <data name="Lbl_ImportDuplikateCount" xml:space="preserve"><value>Duplicates: {0}</value></data>
   <data name="Lbl_ImportProblemeCount" xml:space="preserve"><value>Problems: {0}</value></data>
   <data name="Lbl_ImportAusgewaehltCount" xml:space="preserve"><value>Selected: {0}</value></data>
+  <data name="Msg_ImportStatusMissingDate" xml:space="preserve"><value>Missing booking date</value></data>
+  <data name="Msg_ImportStatusPossibleDuplicate" xml:space="preserve"><value>Possible duplicate</value></data>
+  <data name="Msg_ImportStatusCategoryUnresolved" xml:space="preserve"><value>Category not assigned</value></data>
   <data name="Btn_Duplizieren" xml:space="preserve"><value>Duplicate</value></data>
   <data name="Btn_Verwenden" xml:space="preserve"><value>Use</value></data>
   <data name="Btn_AlsVorlageSpeichern" xml:space="preserve"><value>Save as template</value></data>

--- a/Finanzuebersicht/Resources/Styles/Colors.xaml
+++ b/Finanzuebersicht/Resources/Styles/Colors.xaml
@@ -12,6 +12,8 @@
     <Color x:Key="AusgabeDark">#FF453A</Color>
     <Color x:Key="Warning">#FF9500</Color>
     <Color x:Key="WarningDark">#FF9F0A</Color>
+    <Color x:Key="ImportUncategorized">#FFCC00</Color>
+    <Color x:Key="ImportUncategorizedDark">#FFD60A</Color>
 
     <!-- Reminder Banner (fällige Daueraufträge) -->
     <Color x:Key="ReminderBannerBorder">#FFD60A</Color>

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -162,6 +162,112 @@
                     </Border>
                 </Grid>
 
+                <!-- Budget-Hinweise -->
+                <Border StrokeShape="RoundRectangle 12"
+                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                        Padding="12"
+                        IsVisible="{Binding HasBudgetHinweise}">
+                    <VerticalStackLayout Spacing="10">
+                        <Grid ColumnDefinitions="*, Auto">
+                            <Label Grid.Column="0"
+                                   Text="{loc:Translate Lbl_BudgetHinweise}"
+                                   FontSize="18"
+                                   FontAttributes="Bold"
+                                   SemanticProperties.HeadingLevel="Level2" />
+                            <Label Grid.Column="1"
+                                   Text="{Binding BudgetRest, Converter={StaticResource Currency}}"
+                                   FontSize="15"
+                                   FontAttributes="Bold"
+                                   TextColor="{Binding BudgetRest, Converter={StaticResource BilanzColor}}" />
+                        </Grid>
+
+                        <Grid ColumnDefinitions="*, Auto">
+                            <Label Grid.Column="0"
+                                   Text="{loc:Translate Lbl_BudgetVerbraucht}"
+                                   FontSize="13"
+                                   TextColor="Gray" />
+                            <HorizontalStackLayout Grid.Column="1" Spacing="4">
+                                <Label Text="{Binding BudgetVerbraucht, Converter={StaticResource Currency}}"
+                                       FontSize="13"
+                                       FontAttributes="Bold" />
+                                <Label Text="{loc:Translate Lbl_Von}"
+                                       FontSize="13"
+                                       TextColor="Gray" />
+                                <Label Text="{Binding BudgetGesamt, Converter={StaticResource Currency}}"
+                                       FontSize="13"
+                                       TextColor="Gray" />
+                            </HorizontalStackLayout>
+                        </Grid>
+
+                        <Grid ColumnDefinitions="*, Auto"
+                              IsVisible="{Binding ShowBudgetTagesbudget}">
+                            <Label Grid.Column="0"
+                                   Text="{loc:Translate Lbl_TagesbudgetBisMonatsende}"
+                                   FontSize="13"
+                                   TextColor="Gray" />
+                            <Label Grid.Column="1"
+                                   Text="{Binding BudgetTagesbudget, Converter={StaticResource Currency}}"
+                                   FontSize="13"
+                                   FontAttributes="Bold"
+                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                        </Grid>
+
+                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding BudgetHinweise}"
+                                             Spacing="8">
+                            <BindableLayout.ItemTemplate>
+                                <DataTemplate x:DataType="models:BudgetHintSummary">
+                                    <VerticalStackLayout Spacing="4">
+                                        <Grid ColumnDefinitions="Auto, *, Auto" ColumnSpacing="8">
+                                            <Label Grid.Column="0"
+                                                   Text="{Binding Icon}"
+                                                   FontSize="16"
+                                                   VerticalTextAlignment="Center" />
+                                            <Label Grid.Column="1"
+                                                   Text="{Binding CategoryName}"
+                                                   FontSize="14"
+                                                   VerticalTextAlignment="Center" />
+                                            <Label Grid.Column="2"
+                                                   Text="{Binding Restbudget, Converter={StaticResource Currency}}"
+                                                   FontSize="14"
+                                                   FontAttributes="Bold"
+                                                   TextColor="{Binding Restbudget, Converter={StaticResource BilanzColor}}" />
+                                        </Grid>
+                                        <ProgressBar
+                                            Progress="{Binding VerbrauchProzent, Converter={StaticResource ProzentToWidth}}"
+                                            ProgressColor="{Binding IstAusgeschoepft, Converter={StaticResource BudgetProgressColor}}"
+                                            BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                            SemanticProperties.Description="{loc:Translate A11y_BudgetBalken}" />
+                                        <Grid ColumnDefinitions="*, Auto">
+                                            <Label Grid.Column="0"
+                                                   Text="{loc:Translate Lbl_BudgetWarnung80}"
+                                                   IsVisible="{Binding IstWarnung}"
+                                                   FontSize="11"
+                                                   TextColor="{AppThemeBinding Light={StaticResource Warning}, Dark={StaticResource WarningDark}}" />
+                                            <Label Grid.Column="0"
+                                                   Text="{loc:Translate Lbl_BudgetAufgebraucht}"
+                                                   IsVisible="{Binding IstAusgeschoepft}"
+                                                   FontSize="11"
+                                                   TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}" />
+                                            <HorizontalStackLayout Grid.Column="1" Spacing="2">
+                                                <Label Text="{Binding Verbrauch, Converter={StaticResource Currency}}"
+                                                       FontSize="11"
+                                                       TextColor="Gray" />
+                                                <Label Text="{loc:Translate Lbl_Von}"
+                                                       FontSize="11"
+                                                       TextColor="Gray" />
+                                                <Label Text="{Binding BudgetBetrag, Converter={StaticResource Currency}}"
+                                                       FontSize="11"
+                                                       TextColor="Gray" />
+                                            </HorizontalStackLayout>
+                                        </Grid>
+                                    </VerticalStackLayout>
+                                </DataTemplate>
+                            </BindableLayout.ItemTemplate>
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
                 <!-- Ausgaben nach Kategorie -->
                   <Label Text="{loc:Translate Lbl_AusgabenNachKategorie}" FontSize="18" FontAttributes="Bold"
                       Margin="0,8,0,0"

--- a/Finanzuebersicht/Views/ImportPreviewPage.xaml
+++ b/Finanzuebersicht/Views/ImportPreviewPage.xaml
@@ -60,7 +60,8 @@
                                            LineBreakMode="TailTruncation" />
                                 </VerticalStackLayout>
                                 <Switch Grid.Column="1"
-                                        IsToggled="{Binding IsIncluded}" />
+                                        IsToggled="{Binding IsIncluded}"
+                                        IsEnabled="{Binding CanCommit}" />
                             </Grid>
 
                             <Grid ColumnDefinitions="Auto, *, Auto" ColumnSpacing="8">

--- a/Finanzuebersicht/Views/ImportPreviewPage.xaml
+++ b/Finanzuebersicht/Views/ImportPreviewPage.xaml
@@ -11,18 +11,19 @@
 
     <views:BaseContentPage.Resources>
         <conv:InvertBoolConverter x:Key="InvertBool" />
+        <conv:ImportPreviewStatusColorConverter x:Key="ImportStatusColor" />
     </views:BaseContentPage.Resources>
 
     <Grid RowDefinitions="Auto, Auto, *, Auto" Padding="16" RowSpacing="12">
         <Border Grid.Row="0"
                 StrokeShape="RoundRectangle 12"
-                Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
                 Padding="12">
             <VerticalStackLayout Spacing="8">
                 <Label Text="{Binding SummaryText}"
                        FontSize="13"
-                       TextColor="{AppThemeBinding Light=#3C3C43, Dark=#EBEBF5}" />
+                       TextColor="{AppThemeBinding Light={StaticResource TextSecondary}, Dark={StaticResource TextSecondaryDark}}" />
                 <Picker ItemsSource="{Binding FilterOptions}"
                         SelectedItem="{Binding SelectedFilter}"
                         ItemDisplayBinding="{Binding DisplayName}" />
@@ -33,7 +34,7 @@
                Text="{loc:Translate Empty_ImportVorschauLeer}"
                IsVisible="{Binding HasRows, Converter={StaticResource InvertBool}}"
                HorizontalTextAlignment="Center"
-               TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
+               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                Margin="0,24,0,0" />
 
         <CollectionView Grid.Row="2"
@@ -43,8 +44,8 @@
             <CollectionView.ItemTemplate>
                 <DataTemplate x:DataType="vm:ImportPreviewRowItemViewModel">
                     <Border StrokeShape="RoundRectangle 12"
-                            Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                            Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
                             Padding="12"
                             Margin="0,0,0,10">
                         <VerticalStackLayout Spacing="8">
@@ -56,7 +57,7 @@
                                            LineBreakMode="TailTruncation" />
                                     <Label Text="{Binding Purpose}"
                                            FontSize="12"
-                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
+                                           TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                                            LineBreakMode="TailTruncation" />
                                 </VerticalStackLayout>
                                 <Switch Grid.Column="1"
@@ -67,20 +68,20 @@
                             <Grid ColumnDefinitions="Auto, *, Auto" ColumnSpacing="8">
                                 <Label Text="{Binding DateText}"
                                        FontSize="12"
-                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                 <Label Grid.Column="1"
                                        Text="{Binding AmountText}"
                                        FontSize="12"
                                        HorizontalTextAlignment="End"
-                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                 <Border Grid.Column="2"
                                         Stroke="Transparent"
-                                        BackgroundColor="{Binding StatusColorHex}"
+                                        BackgroundColor="{Binding Status, Converter={StaticResource ImportStatusColor}}"
                                         StrokeShape="RoundRectangle 8"
                                         Padding="8,4">
                                     <Label Text="{Binding StatusText}"
                                            FontSize="11"
-                                           TextColor="Black" />
+                                           TextColor="{StaticResource TextPrimary}" />
                                 </Border>
                             </Grid>
 
@@ -88,7 +89,7 @@
                                 <Label Text="{loc:Translate Lbl_Kategorie}"
                                        FontSize="12"
                                        VerticalTextAlignment="Center"
-                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                 <Picker Grid.Column="1"
                                         ItemsSource="{Binding CategoryOptions}"
                                         ItemDisplayBinding="{Binding DisplayName}"
@@ -106,8 +107,8 @@
             <Button Grid.Column="0"
                     Text="{loc:Translate Btn_Abbrechen}"
                     Command="{Binding CancelImportCommand}"
-                    BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                    TextColor="{AppThemeBinding Light=#1C1C1E, Dark=#F2F2F7}" />
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                    TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource Gray100}}" />
             <Button Grid.Column="1"
                     Text="{loc:Translate Btn_Import}"
                     Command="{Binding CommitImportCommand}"

--- a/Finanzuebersicht/Views/ImportPreviewPage.xaml
+++ b/Finanzuebersicht/Views/ImportPreviewPage.xaml
@@ -1,0 +1,118 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+              xmlns:views="clr-namespace:Finanzuebersicht.Views"
+              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
+              x:Class="Finanzuebersicht.Views.ImportPreviewPage"
+              x:DataType="vm:ImportPreviewViewModel"
+              Title="{loc:Translate Ttl_ImportVorschau}">
+
+    <views:BaseContentPage.Resources>
+        <conv:InvertBoolConverter x:Key="InvertBool" />
+    </views:BaseContentPage.Resources>
+
+    <Grid RowDefinitions="Auto, Auto, *, Auto" Padding="16" RowSpacing="12">
+        <Border Grid.Row="0"
+                StrokeShape="RoundRectangle 12"
+                Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                Padding="12">
+            <VerticalStackLayout Spacing="8">
+                <Label Text="{Binding SummaryText}"
+                       FontSize="13"
+                       TextColor="{AppThemeBinding Light=#3C3C43, Dark=#EBEBF5}" />
+                <Picker ItemsSource="{Binding FilterOptions}"
+                        SelectedItem="{Binding SelectedFilter}"
+                        ItemDisplayBinding="{Binding DisplayName}" />
+            </VerticalStackLayout>
+        </Border>
+
+        <Label Grid.Row="1"
+               Text="{loc:Translate Empty_ImportVorschauLeer}"
+               IsVisible="{Binding HasRows, Converter={StaticResource InvertBool}}"
+               HorizontalTextAlignment="Center"
+               TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
+               Margin="0,24,0,0" />
+
+        <ScrollView Grid.Row="2"
+                    IsVisible="{Binding HasRows}">
+            <VerticalStackLayout BindableLayout.ItemsSource="{Binding FilteredRows}"
+                                 Spacing="0">
+                <BindableLayout.ItemTemplate>
+                    <DataTemplate x:DataType="vm:ImportPreviewRowItemViewModel">
+                        <Border StrokeShape="RoundRectangle 12"
+                                Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                                Padding="12"
+                                Margin="0,0,0,10">
+                            <VerticalStackLayout Spacing="8">
+                                <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                                    <VerticalStackLayout Spacing="2">
+                                        <Label Text="{Binding Title}"
+                                               FontSize="15"
+                                               FontAttributes="Bold"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Text="{Binding Purpose}"
+                                               FontSize="12"
+                                               TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
+                                               LineBreakMode="TailTruncation" />
+                                    </VerticalStackLayout>
+                                    <Switch Grid.Column="1"
+                                            IsToggled="{Binding IsIncluded}" />
+                                </Grid>
+
+                                <Grid ColumnDefinitions="Auto, *, Auto" ColumnSpacing="8">
+                                    <Label Text="{Binding DateText}"
+                                           FontSize="12"
+                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                    <Label Grid.Column="1"
+                                           Text="{Binding AmountText}"
+                                           FontSize="12"
+                                           HorizontalTextAlignment="End"
+                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                    <Border Grid.Column="2"
+                                            Stroke="Transparent"
+                                            BackgroundColor="{Binding StatusColorHex}"
+                                            StrokeShape="RoundRectangle 8"
+                                            Padding="8,4">
+                                        <Label Text="{Binding StatusText}"
+                                               FontSize="11"
+                                               TextColor="Black" />
+                                    </Border>
+                                </Grid>
+
+                                <Grid ColumnDefinitions="90,*" ColumnSpacing="8">
+                                    <Label Text="{loc:Translate Lbl_Kategorie}"
+                                           FontSize="12"
+                                           VerticalTextAlignment="Center"
+                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                    <Picker Grid.Column="1"
+                                            ItemsSource="{Binding CategoryOptions}"
+                                            ItemDisplayBinding="{Binding DisplayName}"
+                                            SelectedItem="{Binding SelectedCategoryOption}"
+                                            IsEnabled="{Binding CanEditCategory}"
+                                            FontSize="13" />
+                                </Grid>
+                            </VerticalStackLayout>
+                        </Border>
+                    </DataTemplate>
+                </BindableLayout.ItemTemplate>
+            </VerticalStackLayout>
+        </ScrollView>
+
+        <Grid Grid.Row="3" ColumnDefinitions="*, *" ColumnSpacing="12">
+            <Button Grid.Column="0"
+                    Text="{loc:Translate Btn_Abbrechen}"
+                    Command="{Binding CancelImportCommand}"
+                    BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                    TextColor="{AppThemeBinding Light=#1C1C1E, Dark=#F2F2F7}" />
+            <Button Grid.Column="1"
+                    Text="{loc:Translate Btn_Import}"
+                    Command="{Binding CommitImportCommand}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                    TextColor="White" />
+        </Grid>
+    </Grid>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/ImportPreviewPage.xaml
+++ b/Finanzuebersicht/Views/ImportPreviewPage.xaml
@@ -36,71 +36,70 @@
                TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
                Margin="0,24,0,0" />
 
-        <ScrollView Grid.Row="2"
-                    IsVisible="{Binding HasRows}">
-            <VerticalStackLayout BindableLayout.ItemsSource="{Binding FilteredRows}"
-                                 Spacing="0">
-                <BindableLayout.ItemTemplate>
-                    <DataTemplate x:DataType="vm:ImportPreviewRowItemViewModel">
-                        <Border StrokeShape="RoundRectangle 12"
-                                Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                                BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
-                                Padding="12"
-                                Margin="0,0,0,10">
-                            <VerticalStackLayout Spacing="8">
-                                <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
-                                    <VerticalStackLayout Spacing="2">
-                                        <Label Text="{Binding Title}"
-                                               FontSize="15"
-                                               FontAttributes="Bold"
-                                               LineBreakMode="TailTruncation" />
-                                        <Label Text="{Binding Purpose}"
-                                               FontSize="12"
-                                               TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
-                                               LineBreakMode="TailTruncation" />
-                                    </VerticalStackLayout>
-                                    <Switch Grid.Column="1"
-                                            IsToggled="{Binding IsIncluded}" />
-                                </Grid>
+        <CollectionView Grid.Row="2"
+                        IsVisible="{Binding HasRows}"
+                        ItemsSource="{Binding FilteredRows}"
+                        SelectionMode="None">
+            <CollectionView.ItemTemplate>
+                <DataTemplate x:DataType="vm:ImportPreviewRowItemViewModel">
+                    <Border StrokeShape="RoundRectangle 12"
+                            Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                            Padding="12"
+                            Margin="0,0,0,10">
+                        <VerticalStackLayout Spacing="8">
+                            <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                                <VerticalStackLayout Spacing="2">
+                                    <Label Text="{Binding Title}"
+                                           FontSize="15"
+                                           FontAttributes="Bold"
+                                           LineBreakMode="TailTruncation" />
+                                    <Label Text="{Binding Purpose}"
+                                           FontSize="12"
+                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
+                                           LineBreakMode="TailTruncation" />
+                                </VerticalStackLayout>
+                                <Switch Grid.Column="1"
+                                        IsToggled="{Binding IsIncluded}" />
+                            </Grid>
 
-                                <Grid ColumnDefinitions="Auto, *, Auto" ColumnSpacing="8">
-                                    <Label Text="{Binding DateText}"
-                                           FontSize="12"
-                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
-                                    <Label Grid.Column="1"
-                                           Text="{Binding AmountText}"
-                                           FontSize="12"
-                                           HorizontalTextAlignment="End"
-                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
-                                    <Border Grid.Column="2"
-                                            Stroke="Transparent"
-                                            BackgroundColor="{Binding StatusColorHex}"
-                                            StrokeShape="RoundRectangle 8"
-                                            Padding="8,4">
-                                        <Label Text="{Binding StatusText}"
-                                               FontSize="11"
-                                               TextColor="Black" />
-                                    </Border>
-                                </Grid>
+                            <Grid ColumnDefinitions="Auto, *, Auto" ColumnSpacing="8">
+                                <Label Text="{Binding DateText}"
+                                       FontSize="12"
+                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                <Label Grid.Column="1"
+                                       Text="{Binding AmountText}"
+                                       FontSize="12"
+                                       HorizontalTextAlignment="End"
+                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                <Border Grid.Column="2"
+                                        Stroke="Transparent"
+                                        BackgroundColor="{Binding StatusColorHex}"
+                                        StrokeShape="RoundRectangle 8"
+                                        Padding="8,4">
+                                    <Label Text="{Binding StatusText}"
+                                           FontSize="11"
+                                           TextColor="Black" />
+                                </Border>
+                            </Grid>
 
-                                <Grid ColumnDefinitions="90,*" ColumnSpacing="8">
-                                    <Label Text="{loc:Translate Lbl_Kategorie}"
-                                           FontSize="12"
-                                           VerticalTextAlignment="Center"
-                                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
-                                    <Picker Grid.Column="1"
-                                            ItemsSource="{Binding CategoryOptions}"
-                                            ItemDisplayBinding="{Binding DisplayName}"
-                                            SelectedItem="{Binding SelectedCategoryOption}"
-                                            IsEnabled="{Binding CanEditCategory}"
-                                            FontSize="13" />
-                                </Grid>
-                            </VerticalStackLayout>
-                        </Border>
-                    </DataTemplate>
-                </BindableLayout.ItemTemplate>
-            </VerticalStackLayout>
-        </ScrollView>
+                            <Grid ColumnDefinitions="90,*" ColumnSpacing="8">
+                                <Label Text="{loc:Translate Lbl_Kategorie}"
+                                       FontSize="12"
+                                       VerticalTextAlignment="Center"
+                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                <Picker Grid.Column="1"
+                                        ItemsSource="{Binding CategoryOptions}"
+                                        ItemDisplayBinding="{Binding DisplayName}"
+                                        SelectedItem="{Binding SelectedCategoryOption}"
+                                        IsEnabled="{Binding CanEditCategory}"
+                                        FontSize="13" />
+                            </Grid>
+                        </VerticalStackLayout>
+                    </Border>
+                </DataTemplate>
+            </CollectionView.ItemTemplate>
+        </CollectionView>
 
         <Grid Grid.Row="3" ColumnDefinitions="*, *" ColumnSpacing="12">
             <Button Grid.Column="0"

--- a/Finanzuebersicht/Views/ImportPreviewPage.xaml.cs
+++ b/Finanzuebersicht/Views/ImportPreviewPage.xaml.cs
@@ -1,0 +1,20 @@
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Views;
+
+public partial class ImportPreviewPage : BaseContentPage
+{
+    public ImportPreviewPage(ImportPreviewViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    protected override void OnDisappearing()
+    {
+        if (BindingContext is ImportPreviewViewModel viewModel)
+            viewModel.HandlePageDisappearing();
+
+        base.OnDisappearing();
+    }
+}

--- a/Finanzuebersicht/Views/TransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/TransactionDetailPage.xaml
@@ -71,6 +71,14 @@
                     FontSize="16" FontAttributes="Bold"
                     Margin="0,20,0,0" />
 
+            <Button Text="{loc:Translate Btn_AlsVorlageSpeichern}"
+                    Command="{Binding SaveAsTemplateCommand}"
+                    BackgroundColor="Transparent"
+                    TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                    CornerRadius="12"
+                    HeightRequest="44"
+                    FontSize="15" />
+
         </VerticalStackLayout>
     </ScrollView>
 

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -196,7 +196,7 @@
                                                FontSize="13"
                                                FontAttributes="Bold"
                                                LineBreakMode="TailTruncation" />
-                                        <Label Text="{Binding Betrag, Converter={StaticResource BetragDisplay}}"
+                                        <Label Text="{Binding ., Converter={StaticResource BetragDisplay}}"
                                                FontSize="12"
                                                TextColor="Gray" />
                                     </VerticalStackLayout>

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -56,7 +56,7 @@
         </DataTemplate>
     </views:BaseContentPage.Resources>
 
-    <Grid RowDefinitions="Auto, Auto, Auto, *">
+    <Grid RowDefinitions="Auto, Auto, Auto, Auto, *">
 
         <!-- Row 0: Suchleiste + Filter-Button -->
         <Grid Grid.Row="0" ColumnDefinitions="*, Auto" Padding="12,8,12,4" ColumnSpacing="8">
@@ -166,8 +166,69 @@
             </VerticalStackLayout>
         </Border>
 
-        <!-- Row 3: Content -->
-        <Grid Grid.Row="3">
+        <!-- Row 3: Schnellbuchungen -->
+        <Border Grid.Row="3"
+                StrokeShape="RoundRectangle 12"
+                Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                Padding="12"
+                Margin="12,4"
+                IsVisible="{Binding ShowTransactionTemplates}">
+            <VerticalStackLayout Spacing="8">
+                <Label Text="{loc:Translate Lbl_HaeufigVerwendet}"
+                       FontSize="14"
+                       FontAttributes="Bold" />
+                <CollectionView ItemsSource="{Binding TransactionTemplates}"
+                                ItemsLayout="HorizontalList"
+                                SelectionMode="None"
+                                HeightRequest="86">
+                    <CollectionView.ItemTemplate>
+                        <DataTemplate x:DataType="models:TransactionTemplate">
+                            <Border StrokeShape="RoundRectangle 10"
+                                    Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
+                                    Padding="10"
+                                    Margin="0,0,8,0"
+                                    WidthRequest="150">
+                                <Grid RowDefinitions="*, Auto" ColumnDefinitions="*, Auto">
+                                    <VerticalStackLayout Grid.Row="0" Grid.Column="0" Spacing="2">
+                                        <Label Text="{Binding Name}"
+                                               FontSize="13"
+                                               FontAttributes="Bold"
+                                               LineBreakMode="TailTruncation" />
+                                        <Label Text="{Binding Betrag, Converter={StaticResource BetragDisplay}}"
+                                               FontSize="12"
+                                               TextColor="Gray" />
+                                    </VerticalStackLayout>
+                                    <Button Grid.Row="0" Grid.Column="1"
+                                            Text="×"
+                                            FontSize="14"
+                                            BackgroundColor="Transparent"
+                                            TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
+                                            Padding="0"
+                                            WidthRequest="28"
+                                            HeightRequest="28"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=DeleteTemplateCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    <Button Grid.Row="1" Grid.ColumnSpan="2"
+                                            Text="{loc:Translate Btn_Verwenden}"
+                                            FontSize="12"
+                                            Padding="8,4"
+                                            CornerRadius="8"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                            TextColor="White"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=CreateFromTemplateCommand}"
+                                            CommandParameter="{Binding .}" />
+                                </Grid>
+                            </Border>
+                        </DataTemplate>
+                    </CollectionView.ItemTemplate>
+                </CollectionView>
+            </VerticalStackLayout>
+        </Border>
+
+        <!-- Row 4: Content -->
+        <Grid Grid.Row="4">
 
             <!-- Monatsansicht (normal) -->
             <RefreshView Command="{Binding LoadTransaktionenCommand}"
@@ -194,6 +255,10 @@
                             <SwipeView>
                                 <SwipeView.RightItems>
                                     <SwipeItems>
+                                        <SwipeItem Text="{loc:Translate Btn_Duplizieren}"
+                                                   BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                                   Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=DuplicateTransaktionCommand}"
+                                                   CommandParameter="{Binding .}" />
                                         <SwipeItem Text="{loc:Translate Btn_Loeschen}"
                                                    BackgroundColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
                                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=DeleteTransaktionCommand}"
@@ -271,8 +336,8 @@
 
         </Grid>
 
-        <!-- FABs (immer sichtbar, über Row 3) -->
-        <Grid Grid.Row="3" HorizontalOptions="Fill" VerticalOptions="End" Padding="20,0,20,20">
+        <!-- FABs (immer sichtbar, über Row 4) -->
+        <Grid Grid.Row="4" HorizontalOptions="Fill" VerticalOptions="End" Padding="20,0,20,20">
             <Button Text="{loc:Translate Btn_Import}" FontSize="14" TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                     BackgroundColor="Transparent"
                     HorizontalOptions="Start" VerticalOptions="End"

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -169,8 +169,8 @@
         <!-- Row 3: Schnellbuchungen -->
         <Border Grid.Row="3"
                 StrokeShape="RoundRectangle 12"
-                Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
                 Padding="12"
                 Margin="12,4"
                 IsVisible="{Binding ShowTransactionTemplates}">
@@ -185,7 +185,7 @@
                     <CollectionView.ItemTemplate>
                         <DataTemplate x:DataType="models:TransactionTemplate">
                             <Border StrokeShape="RoundRectangle 10"
-                                    Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                    Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                                     BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
                                     Padding="10"
                                     Margin="0,0,8,0"
@@ -198,7 +198,7 @@
                                                LineBreakMode="TailTruncation" />
                                         <Label Text="{Binding ., Converter={StaticResource BetragDisplay}}"
                                                FontSize="12"
-                                               TextColor="Gray" />
+                                               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                     </VerticalStackLayout>
                                     <Button Grid.Row="0" Grid.Column="1"
                                             Text="×"

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -209,7 +209,8 @@
                                             WidthRequest="28"
                                             HeightRequest="28"
                                             Command="{Binding Source={RelativeSource AncestorType={x:Type vm:TransactionsViewModel}}, Path=DeleteTemplateCommand}"
-                                            CommandParameter="{Binding .}" />
+                                            CommandParameter="{Binding .}"
+                                            SemanticProperties.Description="{loc:Translate Btn_Loeschen}" />
                                     <Button Grid.Row="1" Grid.ColumnSpan="2"
                                             Text="{loc:Translate Btn_Verwenden}"
                                             FontSize="12"


### PR DESCRIPTION
Fügt Import-Vorschau und Transaktionsvorlagen hinzu sowie zugehörige Use Cases, Modelle, Services, DI-Registrierungen, Views und Tests.

Änderungen im Überblick:
- Import-Vorschau: neue Modelle (ImportPreviewResult, ImportPreviewRow, ImportPreviewRowStatus), ImportPreviewPage, ImportPreviewViewModel, ImportSessionStore, Anpassungen an ImportService und Kategorisierungs-Logik.
- Transaktionsvorlagen: neues Modell TransactionTemplate, Repository-Interface, TransactionTemplateStore und Use-Cases (Load/Save/Delete/Use).
- Infrastruktur: Anpassungen an LocalDataService, BackupService, DependencyInjection-Extensions, Routes, Resource-Strings.
- Präsentation: neue/aktualisierte Pages/ViewModels (ImportPreview, Transactions, TransactionDetail), Tests ergänzt/aktualisiert.
- Sonstiges: /.github/skills/ zu .gitignore hinzugefügt.

Tests: Unit- und Integrationstests für Import-Vorschau, Backup, Transactions aktualisiert.

Zweck: Ermöglicht Nutzer Import-Dateien vor dem Einspielen zu prüfen und Transaktionen aus Vorlagen schneller anzulegen.