### PR TITLE
✨ Multi-Account Ausbau: Verwaltung, Umbuchungen, Reporting+

### DIFF
--- a/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -1,4 +1,5 @@
 using Finanzuebersicht.Application.UseCases.Categories;
+using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
 using Finanzuebersicht.Application.UseCases.SparZiele;
@@ -15,6 +16,9 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<LoadCategoriesUseCase>();
         services.AddTransient<SaveCategoryDetailUseCase>();
         services.AddTransient<SaveCategoryBudgetUseCase>();
+        services.AddTransient<LoadAccountsUseCase>();
+        services.AddTransient<SaveAccountDetailUseCase>();
+        services.AddTransient<DeleteAccountUseCase>();
 
         services.AddTransient<LoadDashboardMonthUseCase>();
         services.AddTransient<LoadDashboardYearUseCase>();

--- a/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -18,6 +18,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<SaveCategoryBudgetUseCase>();
         services.AddTransient<LoadAccountsUseCase>();
         services.AddTransient<SaveAccountDetailUseCase>();
+        services.AddTransient<ToggleAccountArchiveUseCase>();
         services.AddTransient<DeleteAccountUseCase>();
 
         services.AddTransient<LoadDashboardMonthUseCase>();
@@ -38,6 +39,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<LoadTransactionsMonthUseCase>();
         services.AddTransient<LoadTransactionTemplatesUseCase>();
         services.AddTransient<SearchTransactionsUseCase>();
+        services.AddTransient<SaveTransferUseCase>();
         services.AddTransient<SaveRecurringTransactionDetailUseCase>();
         services.AddTransient<SaveTransactionDetailUseCase>();
         services.AddTransient<SaveTransactionTemplateUseCase>();

--- a/Finanzuebersicht.Application/UseCases/Accounts/DeleteAccountUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/DeleteAccountUseCase.cs
@@ -1,0 +1,56 @@
+using Finanzuebersicht.Constants;
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Accounts;
+
+public class DeleteAccountUseCase(
+    IAccountRepository accountRepository,
+    ITransactionRepository transactionRepository,
+    ITransactionTemplateRepository transactionTemplateRepository)
+{
+    private readonly IAccountRepository _accountRepository = accountRepository;
+    private readonly ITransactionRepository _transactionRepository = transactionRepository;
+    private readonly ITransactionTemplateRepository _transactionTemplateRepository = transactionTemplateRepository;
+
+    public async Task ExecuteAsync(string accountId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var accounts = await _accountRepository.GetAccountsAsync();
+        var target = accounts.FirstOrDefault(a => a.Id == accountId);
+        if (target == null) return;
+
+        if (target.SystemKey == SystemAccountKeys.Default)
+            throw new InvalidOperationException("Default account cannot be deleted.");
+
+        var fallback = accounts.FirstOrDefault(a => a.SystemKey == SystemAccountKeys.Default && a.Id != accountId)
+            ?? accounts.FirstOrDefault(a => a.Id != accountId);
+
+        if (fallback == null)
+        {
+            fallback = new Account
+            {
+                Name = "Girokonto",
+                Type = AccountType.Girokonto,
+                SystemKey = SystemAccountKeys.Default
+            };
+            await _accountRepository.SaveAccountAsync(fallback);
+        }
+
+        var transactions = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+        foreach (var transaction in transactions.Where(t => t.AccountId == accountId))
+        {
+            transaction.AccountId = fallback.Id;
+            await _transactionRepository.SaveTransactionAsync(transaction);
+        }
+
+        var templates = await _transactionTemplateRepository.GetTransactionTemplatesAsync();
+        foreach (var template in templates.Where(t => t.AccountId == accountId))
+        {
+            template.AccountId = fallback.Id;
+            await _transactionTemplateRepository.SaveTransactionTemplateAsync(template);
+        }
+
+        await _accountRepository.DeleteAccountAsync(accountId);
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Accounts/LoadAccountsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/LoadAccountsUseCase.cs
@@ -1,0 +1,14 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Accounts;
+
+public class LoadAccountsUseCase(IAccountRepository accountRepository)
+{
+    private readonly IAccountRepository _accountRepository = accountRepository;
+
+    public async Task<List<Account>> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        return await _accountRepository.GetAccountsAsync();
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Accounts/SaveAccountDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/SaveAccountDetailUseCase.cs
@@ -10,6 +10,7 @@ public class SaveAccountDetailUseCase(IAccountRepository accountRepository)
         Account? existingAccount,
         string name,
         AccountType type,
+        bool isArchived = false,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -17,6 +18,7 @@ public class SaveAccountDetailUseCase(IAccountRepository accountRepository)
         var account = existingAccount ?? new Account();
         account.Name = name;
         account.Type = type;
+        account.IsArchived = account.IsSystemAccount ? false : isArchived;
 
         await _accountRepository.SaveAccountAsync(account);
         return account;

--- a/Finanzuebersicht.Application/UseCases/Accounts/SaveAccountDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/SaveAccountDetailUseCase.cs
@@ -1,0 +1,24 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Accounts;
+
+public class SaveAccountDetailUseCase(IAccountRepository accountRepository)
+{
+    private readonly IAccountRepository _accountRepository = accountRepository;
+
+    public async Task<Account> ExecuteAsync(
+        Account? existingAccount,
+        string name,
+        AccountType type,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var account = existingAccount ?? new Account();
+        account.Name = name;
+        account.Type = type;
+
+        await _accountRepository.SaveAccountAsync(account);
+        return account;
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Accounts/ToggleAccountArchiveUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/ToggleAccountArchiveUseCase.cs
@@ -1,0 +1,20 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Accounts;
+
+public class ToggleAccountArchiveUseCase(IAccountRepository accountRepository)
+{
+    private readonly IAccountRepository _accountRepository = accountRepository;
+
+    public async Task<Account> ExecuteAsync(Account account, bool isArchived, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (account.IsSystemAccount)
+            throw new InvalidOperationException("System account cannot be archived.");
+
+        account.IsArchived = isArchived;
+        await _accountRepository.SaveAccountAsync(account);
+        return account;
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
@@ -14,13 +14,16 @@ public class LoadDashboardMonthUseCase(
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
     private readonly IBudgetRepository _budgetRepository = budgetRepository;
 
-    public async Task<DashboardMonthData> ExecuteAsync(DateTime aktuellerMonat, DateTime today, CancellationToken cancellationToken = default)
+    public async Task<DashboardMonthData> ExecuteAsync(DateTime aktuellerMonat, DateTime today, string? accountId = null, CancellationToken cancellationToken = default)
     {
         var kategorien = await _categoryRepository.GetCategoriesAsync();
 
         var von = aktuellerMonat;
         var bis = aktuellerMonat.AddMonths(1).AddDays(-1);
         var transaktionen = await _transactionRepository.GetTransactionsAsync(von, bis);
+        transaktionen = transaktionen.Where(t => !t.IsTransfer).ToList();
+        if (!string.IsNullOrWhiteSpace(accountId))
+            transaktionen = transaktionen.Where(t => t.AccountId == accountId).ToList();
 
         var istPrognose = aktuellerMonat > new DateTime(today.Year, today.Month, 1);
         if (istPrognose)

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
@@ -31,6 +31,9 @@ public class LoadDashboardMonthUseCase(
             var dauerauftraege = await _recurringTransactionRepository.GetRecurringTransactionsAsync();
             foreach (var da in dauerauftraege.Where(d => d.Aktiv))
             {
+                if (!string.IsNullOrWhiteSpace(accountId) && da.AccountId != accountId)
+                    continue;
+
                 if (da.Startdatum <= bis && (!da.Enddatum.HasValue || da.Enddatum.Value >= von))
                 {
                     // Only add a forecast transaction for this month if the recurrence actually occurs in the month

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
@@ -38,6 +38,7 @@ public class LoadDashboardMonthUseCase(
                             Betrag = da.Betrag,
                             Titel = da.Titel,
                             KategorieId = da.KategorieId,
+                            AccountId = da.AccountId,
                             Typ = da.Typ,
                             Datum = von,
                             DauerauftragId = da.Id

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardYearUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardYearUseCase.cs
@@ -2,40 +2,92 @@ using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Application.UseCases.Dashboard;
 
-public class LoadDashboardYearUseCase(IReportingService reportingService)
+public class LoadDashboardYearUseCase(
+    ITransactionRepository transactionRepository,
+    ICategoryRepository categoryRepository)
 {
-    private readonly IReportingService _reportingService = reportingService;
+    private readonly ITransactionRepository _transactionRepository = transactionRepository;
+    private readonly ICategoryRepository _categoryRepository = categoryRepository;
 
-    public async Task<DashboardYearData> ExecuteAsync(int year, CancellationToken cancellationToken = default)
+    public async Task<DashboardYearData> ExecuteAsync(int year, string? accountId = null, CancellationToken cancellationToken = default)
     {
-        var summary = await _reportingService.GetYearSummaryAsync(year);
-        if (summary == null)
-        {
-            return new DashboardYearData
-            {
-                GesamtAusgaben = 0,
-                Monate = [],
-                Kategorien = []
-            };
-        }
+        var from = new DateTime(year, 1, 1);
+        var to = new DateTime(year, 12, 31, 23, 59, 59);
+        var categories = await _categoryRepository.GetCategoriesAsync();
+        var categoryDict = categories.ToDictionary(c => c.Id);
 
-        if (summary.ByCategory != null && summary.Total > 0)
-        {
-            foreach (var cat in summary.ByCategory)
+        var transactions = await _transactionRepository.GetTransactionsAsync(from, to);
+        transactions = transactions
+            .Where(t => t.Typ == TransactionType.Ausgabe && !t.IsTransfer)
+            .ToList();
+
+        if (!string.IsNullOrWhiteSpace(accountId))
+            transactions = transactions.Where(t => t.AccountId == accountId).ToList();
+
+        var total = transactions.Sum(t => Math.Abs(t.Betrag));
+        var byCategory = transactions
+            .GroupBy(t => t.KategorieId)
+            .Select(g =>
             {
-                cat.PercentageAmount = cat.Total / summary.Total * 100;
+                categoryDict.TryGetValue(g.Key, out var category);
+                return new CategorySummary
+                {
+                    CategoryId = g.Key,
+                    CategoryName = category?.Name ?? string.Empty,
+                    Total = g.Sum(t => Math.Abs(t.Betrag)),
+                    Color = category?.Color ?? "#007AFF",
+                    Icon = category?.Icon ?? "📁"
+                };
+            })
+            .Where(c => !string.IsNullOrWhiteSpace(c.CategoryName))
+            .OrderByDescending(c => c.Total)
+            .ToList();
+
+        var months = Enumerable.Range(1, 12)
+            .Select(month =>
+            {
+                var monthItems = transactions.Where(t => t.Datum.Month == month).ToList();
+                var monthTotal = monthItems.Sum(t => Math.Abs(t.Betrag));
+                var monthByCategory = monthItems
+                    .GroupBy(t => t.KategorieId)
+                    .Select(g =>
+                    {
+                        categoryDict.TryGetValue(g.Key, out var category);
+                        return new CategorySummary
+                        {
+                            CategoryId = g.Key,
+                            CategoryName = category?.Name ?? string.Empty,
+                            Total = g.Sum(t => Math.Abs(t.Betrag)),
+                            Color = category?.Color ?? "#007AFF",
+                            Icon = category?.Icon ?? "📁"
+                        };
+                    })
+                    .Where(c => !string.IsNullOrWhiteSpace(c.CategoryName))
+                    .ToList();
+
+                return new MonthSummary
+                {
+                    Year = year,
+                    Month = month,
+                    Total = monthTotal,
+                    ByCategory = monthByCategory
+                };
+            })
+            .ToList();
+
+        if (total > 0)
+        {
+            foreach (var cat in byCategory)
+            {
+                cat.PercentageAmount = cat.Total / total * 100;
             }
         }
 
-        var jahrKatGefiltert = (summary.ByCategory ?? [])
-            .Where(c => !string.IsNullOrWhiteSpace(c.CategoryName))
-            .ToList();
-
         return new DashboardYearData
         {
-            GesamtAusgaben = summary.Total,
-            Monate = summary.Months,
-            Kategorien = jahrKatGefiltert
+            GesamtAusgaben = total,
+            Monate = months,
+            Kategorien = byCategory
         };
     }
 }

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/LoadRecurringTransactionDetailDataUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/LoadRecurringTransactionDetailDataUseCase.cs
@@ -2,21 +2,36 @@ using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Application.UseCases.RecurringTransactions;
 
-public class LoadRecurringTransactionDetailDataUseCase(ICategoryRepository categoryRepository)
+public class LoadRecurringTransactionDetailDataUseCase(
+    ICategoryRepository categoryRepository,
+    IAccountRepository accountRepository)
 {
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
+    private readonly IAccountRepository _accountRepository = accountRepository;
 
-    public async Task<RecurringTransactionDetailData> ExecuteAsync(string? selectedCategoryId, CancellationToken cancellationToken = default)
+    public async Task<RecurringTransactionDetailData> ExecuteAsync(
+        string? selectedCategoryId,
+        string? selectedAccountId = null,
+        CancellationToken cancellationToken = default)
     {
         var categories = await _categoryRepository.GetCategoriesAsync();
+        var accounts = await _accountRepository.GetAccountsAsync();
         var selectedCategory = selectedCategoryId == null
             ? null
             : categories.FirstOrDefault(c => c.Id == selectedCategoryId);
+        var selectedAccount = selectedAccountId == null
+            ? null
+            : accounts.FirstOrDefault(a => a.Id == selectedAccountId);
+
+        selectedAccount ??= accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+            ?? accounts.FirstOrDefault();
 
         return new RecurringTransactionDetailData
         {
             Kategorien = categories,
-            SelectedKategorie = selectedCategory
+            Accounts = accounts,
+            SelectedKategorie = selectedCategory,
+            SelectedAccount = selectedAccount
         };
     }
 }
@@ -24,5 +39,7 @@ public class LoadRecurringTransactionDetailDataUseCase(ICategoryRepository categ
 public class RecurringTransactionDetailData
 {
     public List<Category> Kategorien { get; set; } = [];
+    public List<Account> Accounts { get; set; } = [];
     public Category? SelectedKategorie { get; set; }
+    public Account? SelectedAccount { get; set; }
 }

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/LoadRecurringTransactionDetailDataUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/LoadRecurringTransactionDetailDataUseCase.cs
@@ -24,12 +24,20 @@ public class LoadRecurringTransactionDetailDataUseCase(
             : accounts.FirstOrDefault(a => a.Id == selectedAccountId);
 
         selectedAccount ??= accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+            ?? accounts.FirstOrDefault(a => !a.IsArchived)
             ?? accounts.FirstOrDefault();
+
+        var visibleAccounts = accounts
+            .Where(a => !a.IsArchived)
+            .ToList();
+
+        if (selectedAccount?.IsArchived == true && visibleAccounts.All(a => a.Id != selectedAccount.Id))
+            visibleAccounts.Add(selectedAccount);
 
         return new RecurringTransactionDetailData
         {
             Kategorien = categories,
-            Accounts = accounts,
+            Accounts = visibleAccounts.OrderBy(a => a.Name).ToList(),
             SelectedKategorie = selectedCategory,
             SelectedAccount = selectedAccount
         };

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/SaveRecurringTransactionDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/SaveRecurringTransactionDetailUseCase.cs
@@ -14,6 +14,7 @@ public class SaveRecurringTransactionDetailUseCase(
         decimal betrag,
         string titel,
         string kategorieId,
+        string? accountId,
         TransactionType typ,
         DateTime startdatum,
         DateTime? enddatum,
@@ -29,6 +30,7 @@ public class SaveRecurringTransactionDetailUseCase(
         recurring.Betrag = betrag;
         recurring.Titel = titel;
         recurring.KategorieId = kategorieId;
+        recurring.AccountId = accountId;
         recurring.Typ = typ;
         recurring.Startdatum = startdatum;
         recurring.Enddatum = enddatum;

--- a/Finanzuebersicht.Application/UseCases/RecurringTransactions/SaveRecurringTransactionDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/RecurringTransactions/SaveRecurringTransactionDetailUseCase.cs
@@ -4,10 +4,12 @@ namespace Finanzuebersicht.Application.UseCases.RecurringTransactions;
 
 public class SaveRecurringTransactionDetailUseCase(
     IRecurringTransactionRepository recurringTransactionRepository,
-    IRecurringGenerationService recurringGenerationService)
+    IRecurringGenerationService recurringGenerationService,
+    IAccountRepository accountRepository)
 {
     private readonly IRecurringTransactionRepository _recurringTransactionRepository = recurringTransactionRepository;
     private readonly IRecurringGenerationService _recurringGenerationService = recurringGenerationService;
+    private readonly IAccountRepository _accountRepository = accountRepository;
 
     public async Task ExecuteAsync(
         RecurringTransaction? existing,
@@ -25,6 +27,15 @@ public class SaveRecurringTransactionDetailUseCase(
         List<RecurringException>? exceptions = null, CancellationToken cancellationToken = default)
     {
         // logging removed: prefer centralized ILogger or conditional debug logging
+
+        if (!string.IsNullOrWhiteSpace(accountId))
+        {
+            var accounts = await _accountRepository.GetAccountsAsync();
+            var account = accounts.FirstOrDefault(a => a.Id == accountId)
+                ?? throw new InvalidOperationException("Selected account not found.");
+            if (account.IsArchived && (existing == null || existing.AccountId != accountId))
+                throw new InvalidOperationException("Archived account cannot be assigned to new recurring transactions.");
+        }
 
         var recurring = existing ?? new RecurringTransaction();
         recurring.Betrag = betrag;

--- a/Finanzuebersicht.Application/UseCases/Transactions/DeleteTransactionUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/DeleteTransactionUseCase.cs
@@ -9,4 +9,10 @@ public class DeleteTransactionUseCase(ITransactionRepository transactionReposito
     {
         await _transactionRepository.DeleteTransactionAsync(transactionId);
     }
+
+    public async Task ExecuteTransferGroupAsync(string transferGroupId, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await _transactionRepository.DeleteTransferGroupAsync(transferGroupId);
+    }
 }

--- a/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionDetailDataUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionDetailDataUseCase.cs
@@ -28,12 +28,20 @@ public class LoadTransactionDetailDataUseCase(
             : accounts.FirstOrDefault(a => a.Id == selectedAccountId);
 
         selectedAccount ??= accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+            ?? accounts.FirstOrDefault(a => !a.IsArchived)
             ?? accounts.FirstOrDefault();
+
+        var visibleAccounts = accounts
+            .Where(a => !a.IsArchived)
+            .ToList();
+
+        if (selectedAccount?.IsArchived == true && visibleAccounts.All(a => a.Id != selectedAccount.Id))
+            visibleAccounts.Add(selectedAccount);
 
         return new TransactionDetailData
         {
             Kategorien = categories,
-            Accounts = accounts,
+            Accounts = visibleAccounts.OrderBy(a => a.Name).ToList(),
             SelectedKategorie = selectedCategory,
             SelectedAccount = selectedAccount
         };

--- a/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionDetailDataUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionDetailDataUseCase.cs
@@ -2,13 +2,20 @@ using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Application.UseCases.Transactions;
 
-public class LoadTransactionDetailDataUseCase(ICategoryRepository categoryRepository)
+public class LoadTransactionDetailDataUseCase(
+    ICategoryRepository categoryRepository,
+    IAccountRepository accountRepository)
 {
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
+    private readonly IAccountRepository _accountRepository = accountRepository;
 
-    public async Task<TransactionDetailData> ExecuteAsync(string? selectedCategoryId, CancellationToken cancellationToken = default)
+    public async Task<TransactionDetailData> ExecuteAsync(
+        string? selectedCategoryId,
+        string? selectedAccountId = null,
+        CancellationToken cancellationToken = default)
     {
         var categories = await _categoryRepository.GetCategoriesAsync();
+        var accounts = await _accountRepository.GetAccountsAsync();
         var selectedCategory = selectedCategoryId == null
             ? null
             : categories.FirstOrDefault(c => c.Id == selectedCategoryId);
@@ -16,10 +23,19 @@ public class LoadTransactionDetailDataUseCase(ICategoryRepository categoryReposi
         selectedCategory ??= categories.FirstOrDefault(c => c.SystemKey == Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges)
             ?? categories.FirstOrDefault();
 
+        var selectedAccount = selectedAccountId == null
+            ? null
+            : accounts.FirstOrDefault(a => a.Id == selectedAccountId);
+
+        selectedAccount ??= accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+            ?? accounts.FirstOrDefault();
+
         return new TransactionDetailData
         {
             Kategorien = categories,
-            SelectedKategorie = selectedCategory
+            Accounts = accounts,
+            SelectedKategorie = selectedCategory,
+            SelectedAccount = selectedAccount
         };
     }
 }
@@ -27,5 +43,7 @@ public class LoadTransactionDetailDataUseCase(ICategoryRepository categoryReposi
 public class TransactionDetailData
 {
     public List<Category> Kategorien { get; set; } = [];
+    public List<Account> Accounts { get; set; } = [];
     public Category? SelectedKategorie { get; set; }
+    public Account? SelectedAccount { get; set; }
 }

--- a/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionsMonthUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/LoadTransactionsMonthUseCase.cs
@@ -4,17 +4,25 @@ namespace Finanzuebersicht.Application.UseCases.Transactions;
 
 public class LoadTransactionsMonthUseCase(
     ITransactionRepository transactionRepository,
-    ICategoryRepository categoryRepository)
+    ICategoryRepository categoryRepository,
+    IAccountRepository accountRepository)
 {
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
+    private readonly IAccountRepository _accountRepository = accountRepository;
 
-    public async Task<TransactionsMonthData> ExecuteAsync(DateTime aktuellerMonat, CancellationToken cancellationToken = default)
+    public async Task<TransactionsMonthData> ExecuteAsync(
+        DateTime aktuellerMonat,
+        string? accountId = null,
+        CancellationToken cancellationToken = default)
     {
         var von = aktuellerMonat;
         var bis = aktuellerMonat.AddMonths(1).AddDays(-1);
 
         var liste = await _transactionRepository.GetTransactionsAsync(von, bis);
+        if (accountId != null)
+            liste = liste.Where(t => t.AccountId == accountId).ToList();
+
         var gruppen = liste
             .GroupBy(t => t.Datum.Date)
             .OrderByDescending(g => g.Key)
@@ -23,11 +31,14 @@ public class LoadTransactionsMonthUseCase(
 
         var categories = await _categoryRepository.GetCategoriesAsync();
         var iconMap = categories.ToDictionary(c => c.Id, c => c.Icon ?? "📁");
+        var accounts = await _accountRepository.GetAccountsAsync();
+        var accountMap = accounts.ToDictionary(a => a.Id, a => a.Name);
 
         return new TransactionsMonthData
         {
             Gruppen = gruppen,
-            IconMap = iconMap
+            IconMap = iconMap,
+            AccountMap = accountMap
         };
     }
 }
@@ -36,4 +47,5 @@ public class TransactionsMonthData
 {
     public List<TransactionGroup> Gruppen { get; set; } = [];
     public Dictionary<string, string> IconMap { get; set; } = [];
+    public Dictionary<string, string> AccountMap { get; set; } = [];
 }

--- a/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionDetailUseCase.cs
@@ -2,9 +2,12 @@ using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Application.UseCases.Transactions;
 
-public class SaveTransactionDetailUseCase(ITransactionRepository transactionRepository)
+public class SaveTransactionDetailUseCase(
+    ITransactionRepository transactionRepository,
+    IAccountRepository accountRepository)
 {
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
+    private readonly IAccountRepository _accountRepository = accountRepository;
 
     public async Task ExecuteAsync(
         Transaction? existingTransaction,
@@ -16,6 +19,18 @@ public class SaveTransactionDetailUseCase(ITransactionRepository transactionRepo
         TransactionType typ,
         string verwendungszweck, CancellationToken cancellationToken = default)
     {
+        if (existingTransaction?.IsTransfer == true)
+            throw new InvalidOperationException("Transfers must be edited through the transfer flow.");
+
+        if (!string.IsNullOrWhiteSpace(accountId))
+        {
+            var accounts = await _accountRepository.GetAccountsAsync();
+            var account = accounts.FirstOrDefault(a => a.Id == accountId)
+                ?? throw new InvalidOperationException("Selected account not found.");
+            if (account.IsArchived && (existingTransaction == null || existingTransaction.AccountId != accountId))
+                throw new InvalidOperationException("Archived account cannot be assigned to new transactions.");
+        }
+
         var transaction = existingTransaction ?? new Transaction();
         transaction.Betrag = betrag;
         transaction.Titel = titel;

--- a/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionDetailUseCase.cs
@@ -12,6 +12,7 @@ public class SaveTransactionDetailUseCase(ITransactionRepository transactionRepo
         string titel,
         DateTime datum,
         string kategorieId,
+        string? accountId,
         TransactionType typ,
         string verwendungszweck, CancellationToken cancellationToken = default)
     {
@@ -20,6 +21,7 @@ public class SaveTransactionDetailUseCase(ITransactionRepository transactionRepo
         transaction.Titel = titel;
         transaction.Datum = datum;
         transaction.KategorieId = kategorieId;
+        transaction.AccountId = accountId ?? transaction.AccountId ?? string.Empty;
         transaction.Typ = typ;
         transaction.Verwendungszweck = verwendungszweck ?? string.Empty;
 

--- a/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SaveTransactionDetailUseCase.cs
@@ -1,3 +1,4 @@
+using Finanzuebersicht.Constants;
 using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Application.UseCases.Transactions;
@@ -36,10 +37,30 @@ public class SaveTransactionDetailUseCase(
         transaction.Titel = titel;
         transaction.Datum = datum;
         transaction.KategorieId = kategorieId;
-        transaction.AccountId = accountId ?? transaction.AccountId ?? string.Empty;
+        transaction.AccountId = await ResolveAccountIdAsync(accountId, transaction.AccountId, cancellationToken)
+            .ConfigureAwait(false);
         transaction.Typ = typ;
         transaction.Verwendungszweck = verwendungszweck ?? string.Empty;
 
         await _transactionRepository.SaveTransactionAsync(transaction);
+    }
+
+    private async Task<string> ResolveAccountIdAsync(
+        string? requestedAccountId,
+        string? existingAccountId,
+        CancellationToken cancellationToken)
+    {
+        if (!string.IsNullOrWhiteSpace(requestedAccountId))
+            return requestedAccountId;
+
+        if (!string.IsNullOrWhiteSpace(existingAccountId))
+            return existingAccountId;
+
+        cancellationToken.ThrowIfCancellationRequested();
+        var accounts = await _accountRepository.GetAccountsAsync().ConfigureAwait(false);
+        var defaultAccount = accounts.FirstOrDefault(a => a.SystemKey == SystemAccountKeys.Default && !a.IsArchived)
+            ?? accounts.FirstOrDefault(a => !a.IsArchived);
+
+        return defaultAccount?.Id ?? string.Empty;
     }
 }

--- a/Finanzuebersicht.Application/UseCases/Transactions/SaveTransferUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SaveTransferUseCase.cs
@@ -1,0 +1,70 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public class SaveTransferUseCase(
+    ITransactionRepository transactionRepository,
+    IAccountRepository accountRepository)
+{
+    private readonly ITransactionRepository _transactionRepository = transactionRepository;
+    private readonly IAccountRepository _accountRepository = accountRepository;
+
+    public async Task ExecuteAsync(
+        string fromAccountId,
+        string toAccountId,
+        decimal amount,
+        DateTime date,
+        string? title = null,
+        string? note = null,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        if (string.IsNullOrWhiteSpace(fromAccountId) || string.IsNullOrWhiteSpace(toAccountId))
+            throw new InvalidOperationException("Source and target account are required.");
+        if (fromAccountId == toAccountId)
+            throw new InvalidOperationException("Source and target account must be different.");
+        if (amount <= 0)
+            throw new InvalidOperationException("Transfer amount must be greater than zero.");
+
+        var accounts = await _accountRepository.GetAccountsAsync();
+        var source = accounts.FirstOrDefault(a => a.Id == fromAccountId);
+        var target = accounts.FirstOrDefault(a => a.Id == toAccountId);
+        if (source == null || target == null)
+            throw new InvalidOperationException("Source or target account not found.");
+        if (source.IsArchived || target.IsArchived)
+            throw new InvalidOperationException("Archived accounts cannot be used for new transfers.");
+
+        var transferGroupId = Guid.NewGuid().ToString();
+        var transferTitle = string.IsNullOrWhiteSpace(title) ? "Umbuchung" : title.Trim();
+        var transferNote = note ?? string.Empty;
+
+        var outgoing = new Transaction
+        {
+            Betrag = amount,
+            Titel = transferTitle,
+            Verwendungszweck = transferNote,
+            Datum = date,
+            Typ = TransactionType.Ausgabe,
+            KategorieId = string.Empty,
+            AccountId = fromAccountId,
+            IsTransfer = true,
+            TransferGroupId = transferGroupId
+        };
+
+        var incoming = new Transaction
+        {
+            Betrag = amount,
+            Titel = transferTitle,
+            Verwendungszweck = transferNote,
+            Datum = date,
+            Typ = TransactionType.Einnahme,
+            KategorieId = string.Empty,
+            AccountId = toAccountId,
+            IsTransfer = true,
+            TransferGroupId = transferGroupId
+        };
+
+        await _transactionRepository.SaveTransactionsAsync([outgoing, incoming]);
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Transactions/SaveTransferUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SaveTransferUseCase.cs
@@ -36,7 +36,7 @@ public class SaveTransferUseCase(
             throw new InvalidOperationException("Archived accounts cannot be used for new transfers.");
 
         var transferGroupId = Guid.NewGuid().ToString();
-        var transferTitle = string.IsNullOrWhiteSpace(title) ? "Umbuchung" : title.Trim();
+        var transferTitle = string.IsNullOrWhiteSpace(title) ? string.Empty : title.Trim();
         var transferNote = note ?? string.Empty;
 
         var outgoing = new Transaction

--- a/Finanzuebersicht.Application/UseCases/Transactions/SearchTransactionsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/SearchTransactionsUseCase.cs
@@ -7,6 +7,7 @@ public enum TransactionTypeFilter { Alle, Einnahme, Ausgabe }
 public record SearchTransactionsQuery(
     string SearchText = "",
     string? KategorieId = null,
+    string? AccountId = null,
     TransactionTypeFilter Typ = TransactionTypeFilter.Alle,
     DateTime? VonDatum = null,
     DateTime? BisDatum = null
@@ -16,15 +17,18 @@ public class SearchTransactionsResult
 {
     public List<TransactionGroup> Gruppen { get; set; } = [];
     public Dictionary<string, string> IconMap { get; set; } = [];
+    public Dictionary<string, string> AccountMap { get; set; } = [];
     public int TotalCount { get; set; }
 }
 
 public class SearchTransactionsUseCase(
     ITransactionRepository transactionRepository,
-    ICategoryRepository categoryRepository)
+    ICategoryRepository categoryRepository,
+    IAccountRepository accountRepository)
 {
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
+    private readonly IAccountRepository _accountRepository = accountRepository;
 
     public async Task<SearchTransactionsResult> ExecuteAsync(SearchTransactionsQuery query, CancellationToken cancellationToken = default)
     {
@@ -49,6 +53,9 @@ public class SearchTransactionsUseCase(
         if (query.KategorieId != null)
             gefiltert = gefiltert.Where(t => t.KategorieId == query.KategorieId);
 
+        if (query.AccountId != null)
+            gefiltert = gefiltert.Where(t => t.AccountId == query.AccountId);
+
         if (query.Typ == TransactionTypeFilter.Einnahme)
             gefiltert = gefiltert.Where(t => t.Typ == TransactionType.Einnahme);
         else if (query.Typ == TransactionTypeFilter.Ausgabe)
@@ -64,11 +71,14 @@ public class SearchTransactionsUseCase(
 
         var categories = await _categoryRepository.GetCategoriesAsync();
         var iconMap = categories.ToDictionary(c => c.Id, c => c.Icon ?? "📁");
+        var accounts = await _accountRepository.GetAccountsAsync();
+        var accountMap = accounts.ToDictionary(a => a.Id, a => a.Name);
 
         return new SearchTransactionsResult
         {
             Gruppen = gruppen,
             IconMap = iconMap,
+            AccountMap = accountMap,
             TotalCount = liste.Count
         };
     }

--- a/Finanzuebersicht.Core/Constants/SystemAccountKeys.cs
+++ b/Finanzuebersicht.Core/Constants/SystemAccountKeys.cs
@@ -1,0 +1,6 @@
+namespace Finanzuebersicht.Constants;
+
+public static class SystemAccountKeys
+{
+    public const string Default = "SysAcc_Default";
+}

--- a/Finanzuebersicht.Core/Models/Account.cs
+++ b/Finanzuebersicht.Core/Models/Account.cs
@@ -1,0 +1,9 @@
+namespace Finanzuebersicht.Models;
+
+public class Account
+{
+    public string Id { get; set; } = Guid.NewGuid().ToString();
+    public string Name { get; set; } = string.Empty;
+    public AccountType Type { get; set; } = AccountType.Girokonto;
+    public string? SystemKey { get; set; }
+}

--- a/Finanzuebersicht.Core/Models/Account.cs
+++ b/Finanzuebersicht.Core/Models/Account.cs
@@ -11,5 +11,4 @@ public class Account
     public bool IsSystemAccount => !string.IsNullOrWhiteSpace(SystemKey);
     public bool CanDelete => !IsSystemAccount;
     public bool CanArchive => !IsSystemAccount;
-    public string ArchiveActionText => IsArchived ? "Aktivieren" : "Archivieren";
 }

--- a/Finanzuebersicht.Core/Models/Account.cs
+++ b/Finanzuebersicht.Core/Models/Account.cs
@@ -6,7 +6,10 @@ public class Account
     public string Name { get; set; } = string.Empty;
     public AccountType Type { get; set; } = AccountType.Girokonto;
     public string? SystemKey { get; set; }
+    public bool IsArchived { get; set; }
 
     public bool IsSystemAccount => !string.IsNullOrWhiteSpace(SystemKey);
     public bool CanDelete => !IsSystemAccount;
+    public bool CanArchive => !IsSystemAccount;
+    public string ArchiveActionText => IsArchived ? "Aktivieren" : "Archivieren";
 }

--- a/Finanzuebersicht.Core/Models/Account.cs
+++ b/Finanzuebersicht.Core/Models/Account.cs
@@ -6,4 +6,7 @@ public class Account
     public string Name { get; set; } = string.Empty;
     public AccountType Type { get; set; } = AccountType.Girokonto;
     public string? SystemKey { get; set; }
+
+    public bool IsSystemAccount => !string.IsNullOrWhiteSpace(SystemKey);
+    public bool CanDelete => !IsSystemAccount;
 }

--- a/Finanzuebersicht.Core/Models/AccountType.cs
+++ b/Finanzuebersicht.Core/Models/AccountType.cs
@@ -1,0 +1,11 @@
+namespace Finanzuebersicht.Models;
+
+public enum AccountType
+{
+    Girokonto = 0,
+    Tagesgeld = 1,
+    Kreditkarte = 2,
+    Bargeld = 3,
+    Depot = 4,
+    Sonstiges = 5
+}

--- a/Finanzuebersicht.Core/Models/RecurringTransaction.cs
+++ b/Finanzuebersicht.Core/Models/RecurringTransaction.cs
@@ -6,6 +6,7 @@ public class RecurringTransaction
     public decimal Betrag { get; set; }
     public string Titel { get; set; } = string.Empty;
     public string KategorieId { get; set; } = string.Empty;
+    public string? AccountId { get; set; }
     public TransactionType Typ { get; set; } = TransactionType.Ausgabe;
     public DateTime Startdatum { get; set; } = DateTime.Today;
     public DateTime? Enddatum { get; set; }

--- a/Finanzuebersicht.Core/Models/Transaction.cs
+++ b/Finanzuebersicht.Core/Models/Transaction.cs
@@ -12,6 +12,8 @@ public class Transaction
 
     // Optional: which account this transaction belongs to (supports multi-account scenarios)
     public string? AccountId { get; set; }
+    public bool IsTransfer { get; set; }
+    public string? TransferGroupId { get; set; }
 
     // Detaillierter Verwendungszweck / Beschreibung aus dem Kontoauszug
     public string Verwendungszweck { get; set; } = string.Empty;

--- a/Finanzuebersicht.Core/Models/TransactionTemplate.cs
+++ b/Finanzuebersicht.Core/Models/TransactionTemplate.cs
@@ -7,6 +7,7 @@ public class TransactionTemplate
     public string Titel { get; set; } = string.Empty;
     public decimal Betrag { get; set; }
     public string KategorieId { get; set; } = string.Empty;
+    public string? AccountId { get; set; }
     public TransactionType Typ { get; set; } = TransactionType.Ausgabe;
     public string Verwendungszweck { get; set; } = string.Empty;
     public DateTime? LastUsedAt { get; set; }

--- a/Finanzuebersicht.Core/Services/DataServiceFacade.cs
+++ b/Finanzuebersicht.Core/Services/DataServiceFacade.cs
@@ -38,8 +38,14 @@ public class DataServiceFacade(
     public Task SaveTransactionAsync(Transaction transaction)
         => _transactionRepository.SaveTransactionAsync(transaction);
 
+    public Task SaveTransactionsAsync(IEnumerable<Transaction> transactions)
+        => _transactionRepository.SaveTransactionsAsync(transactions);
+
     public Task DeleteTransactionAsync(string id)
         => _transactionRepository.DeleteTransactionAsync(id);
+
+    public Task DeleteTransferGroupAsync(string transferGroupId)
+        => _transactionRepository.DeleteTransferGroupAsync(transferGroupId);
 
     public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions)
         => _transactionRepository.ReplaceAllTransactionsAsync(transactions);

--- a/Finanzuebersicht.Core/Services/IAccountRepository.cs
+++ b/Finanzuebersicht.Core/Services/IAccountRepository.cs
@@ -1,0 +1,11 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Core.Services;
+
+public interface IAccountRepository
+{
+    Task<List<Account>> GetAccountsAsync();
+    Task SaveAccountAsync(Account account);
+    Task DeleteAccountAsync(string id);
+    Task ReplaceAllAccountsAsync(IEnumerable<Account> accounts);
+}

--- a/Finanzuebersicht.Core/Services/ITransactionRepository.cs
+++ b/Finanzuebersicht.Core/Services/ITransactionRepository.cs
@@ -6,7 +6,9 @@ public interface ITransactionRepository
 {
     Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum);
     Task SaveTransactionAsync(Transaction transaction);
+    Task SaveTransactionsAsync(IEnumerable<Transaction> transactions);
     Task DeleteTransactionAsync(string id);
+    Task DeleteTransferGroupAsync(string transferGroupId);
     Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions);
 
     /// <summary>

--- a/Finanzuebersicht.Core/Services/ImportService.cs
+++ b/Finanzuebersicht.Core/Services/ImportService.cs
@@ -11,7 +11,8 @@ namespace Finanzuebersicht.Core.Services
         ITransactionRepository transactionRepository,
         ILogger<ImportService> logger,
         ICategoryRepository? categoryRepository = null,
-        CategorizationService? categorizationService = null)
+        CategorizationService? categorizationService = null,
+        IAccountRepository? accountRepository = null)
     {
         private const double HistoricalConfidenceThreshold = 0.5;
 
@@ -20,6 +21,7 @@ namespace Finanzuebersicht.Core.Services
         private readonly ILogger<ImportService> _logger = logger ?? throw new ArgumentNullException(nameof(logger));
         private readonly ICategoryRepository? _categoryRepository = categoryRepository;
         private readonly CategorizationService? _categorizationService = categorizationService;
+        private readonly IAccountRepository? _accountRepository = accountRepository;
 
         public async Task<ImportResult> ImportFromCsvAsync(
             Stream csvStream,
@@ -66,6 +68,7 @@ namespace Finanzuebersicht.Core.Services
 
             var dtos = parseResult.Dtos!;
             var categories = await LoadCategoriesAsync().ConfigureAwait(false);
+            var defaultAccountId = await ResolveDefaultAccountIdAsync(cancellationToken).ConfigureAwait(false);
             var existingInRange = await LoadExistingTransactionsForDtosAsync(dtos).ConfigureAwait(false);
             var historicalCategories = await BuildHistoricalCategoryMapAsync(dtos, categories, cancellationToken).ConfigureAwait(false);
 
@@ -102,7 +105,7 @@ namespace Finanzuebersicht.Core.Services
                     continue;
                 }
 
-                var transaction = CreateTransaction(dto, accountId);
+                var transaction = CreateTransaction(dto, accountId ?? defaultAccountId);
                 if (ContainsDuplicate(existingInRange, transaction) || ContainsDuplicate(batchTransactions, transaction))
                 {
                     rows.Add(new ImportPreviewRow
@@ -171,6 +174,7 @@ namespace Finanzuebersicht.Core.Services
                 .ToList();
 
             var existingInRange = await LoadExistingTransactionsForRowsAsync(rowsToCommit).ConfigureAwait(false);
+            var defaultAccountId = await ResolveDefaultAccountIdAsync(cancellationToken).ConfigureAwait(false);
             var imported = new List<Transaction>();
             var duplicates = new List<Transaction>();
             var saveErrors = new List<string>();
@@ -182,6 +186,8 @@ namespace Finanzuebersicht.Core.Services
                 cancellationToken.ThrowIfCancellationRequested();
 
                 var transaction = CloneTransaction(row.Transaction);
+                if (string.IsNullOrWhiteSpace(transaction.AccountId))
+                    transaction.AccountId = defaultAccountId;
                 if (string.IsNullOrWhiteSpace(transaction.KategorieId))
                 {
                     uncategorizedCategoryId ??= await EnsureUncategorizedCategoryAsync(cancellationToken).ConfigureAwait(false);
@@ -450,6 +456,26 @@ namespace Finanzuebersicht.Core.Services
             {
                 _logger.LogWarning(ex, "ImportService: failed to reload transactions for commit duplicate check");
                 return [];
+            }
+        }
+
+        private async Task<string?> ResolveDefaultAccountIdAsync(CancellationToken cancellationToken)
+        {
+            if (_accountRepository is null)
+                return null;
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            try
+            {
+                var accounts = await _accountRepository.GetAccountsAsync().ConfigureAwait(false);
+                return accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)?.Id
+                    ?? accounts.FirstOrDefault()?.Id;
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "ImportService: failed to load accounts for default selection");
+                return null;
             }
         }
 

--- a/Finanzuebersicht.Core/Services/InitializationService.cs
+++ b/Finanzuebersicht.Core/Services/InitializationService.cs
@@ -2,12 +2,19 @@ using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Core.Services;
 
-public class InitializationService(ICategoryRepository categoryRepository)
+public class InitializationService(
+    ICategoryRepository categoryRepository,
+    IAccountRepository accountRepository,
+    ITransactionRepository transactionRepository)
 {
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
+    private readonly IAccountRepository _accountRepository = accountRepository;
+    private readonly ITransactionRepository _transactionRepository = transactionRepository;
 
     public async Task InitializeAsync()
     {
+        await EnsureDefaultAccountAsync();
+
         var kategorien = await _categoryRepository.GetCategoriesAsync();
         if (kategorien.Count > 0) return;
 
@@ -25,6 +32,41 @@ public class InitializationService(ICategoryRepository categoryRepository)
         foreach (var kategorie in standardKategorien)
         {
             await _categoryRepository.SaveCategoryAsync(kategorie);
+        }
+    }
+
+    private async Task EnsureDefaultAccountAsync()
+    {
+        var accounts = await _accountRepository.GetAccountsAsync();
+        var defaultAccount = accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+            ?? accounts.FirstOrDefault();
+
+        if (defaultAccount == null)
+        {
+            defaultAccount = new Account
+            {
+                Name = "Girokonto",
+                Type = AccountType.Girokonto,
+                SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default
+            };
+            await _accountRepository.SaveAccountAsync(defaultAccount);
+        }
+
+        var transactions = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+        var migrated = false;
+
+        foreach (var transaction in transactions)
+        {
+            if (string.IsNullOrWhiteSpace(transaction.AccountId))
+            {
+                transaction.AccountId = defaultAccount.Id;
+                migrated = true;
+            }
+        }
+
+        if (migrated)
+        {
+            await _transactionRepository.ReplaceAllTransactionsAsync(transactions);
         }
     }
 }

--- a/Finanzuebersicht.Core/Services/Migrations/V2ToV3Migrator.cs
+++ b/Finanzuebersicht.Core/Services/Migrations/V2ToV3Migrator.cs
@@ -1,0 +1,18 @@
+namespace Finanzuebersicht.Core.Services.Migrations;
+
+/// <summary>
+/// Migriert v2-Backups auf v3: ergänzt accounts.json mit leerem Array.
+/// </summary>
+public class V2ToV3Migrator : IDataMigrator
+{
+    public int FromVersion => 2;
+    public int ToVersion => 3;
+
+    public Task<BackupArchiveData> MigrateAsync(BackupArchiveData data)
+    {
+        if (!data.Files.ContainsKey("accounts.json"))
+            data.Files["accounts.json"] = "[]";
+
+        return Task.FromResult(data);
+    }
+}

--- a/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
+++ b/Finanzuebersicht.Core/Services/RecurringGenerationService.cs
@@ -7,10 +7,12 @@ public class RecurringGenerationService(
     IRecurringTransactionRepository recurringRepository,
     ITransactionRepository transactionRepository,
     Finanzuebersicht.Core.Services.IClock? clock = null,
-    ILogger<RecurringGenerationService>? logger = null) : IRecurringGenerationService
+    ILogger<RecurringGenerationService>? logger = null,
+    IAccountRepository? accountRepository = null) : IRecurringGenerationService
 {
     private readonly IRecurringTransactionRepository _recurringRepository = recurringRepository;
     private readonly ITransactionRepository _transactionRepository = transactionRepository;
+    private readonly IAccountRepository? _accountRepository = accountRepository;
     private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
     private readonly ILogger<RecurringGenerationService>? _logger = logger;
     private const int MaxInstancesPerRun = 500;
@@ -18,6 +20,7 @@ public class RecurringGenerationService(
     public async Task GeneratePendingRecurringTransactionsAsync(CancellationToken cancellationToken = default)
     {
         var recurringItems = await _recurringRepository.GetRecurringTransactionsAsync();
+        var defaultAccountId = await ResolveDefaultAccountIdAsync(cancellationToken);
         var today = _clock.Today;
 
         foreach (var recurring in recurringItems.Where(item => item.Aktiv))
@@ -67,10 +70,12 @@ public class RecurringGenerationService(
                     Titel = recurring.Titel,
                     Datum = transactionDate,
                     KategorieId = recurring.KategorieId,
+                    AccountId = recurring.AccountId ?? defaultAccountId,
                     Typ = recurring.Typ,
                     DauerauftragId = recurring.Id
                 };
 
+                recurring.AccountId ??= defaultAccountId;
                 await _transactionRepository.SaveTransactionAsync(transaction);
                 generatedCount++;
 
@@ -90,6 +95,16 @@ public class RecurringGenerationService(
 
             await _recurringRepository.SaveRecurringTransactionAsync(recurring);
         }
+    }
+
+    private async Task<string?> ResolveDefaultAccountIdAsync(CancellationToken cancellationToken)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        if (_accountRepository == null) return null;
+
+        var accounts = await _accountRepository.GetAccountsAsync();
+        return accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)?.Id
+            ?? accounts.FirstOrDefault()?.Id;
     }
 
     private static DateTime GetNextInstance(RecurringTransaction recurring, DateTime fromDate)

--- a/Finanzuebersicht.Core/Services/ReportingService.cs
+++ b/Finanzuebersicht.Core/Services/ReportingService.cs
@@ -14,7 +14,7 @@ public class ReportingService(
         var from = new DateTime(year, month, 1);
         var to = from.AddMonths(1).AddTicks(-1);
         var items = await _transactionRepository.GetTransactionsAsync(from, to);
-        var expenditure = items.Where(t => t.Typ == TransactionType.Ausgabe).ToList();
+        var expenditure = items.Where(t => t.Typ == TransactionType.Ausgabe && !t.IsTransfer).ToList();
 
         var categories = await _categoryRepository.GetCategoriesAsync();
         var catDict = categories.ToDictionary(c => c.Id);
@@ -46,7 +46,7 @@ public class ReportingService(
         var from = new DateTime(year, 1, 1);
         var to = new DateTime(year, 12, 31, 23, 59, 59);
         var items = await _transactionRepository.GetTransactionsAsync(from, to);
-        var expenditure = items.Where(t => t.Typ == TransactionType.Ausgabe).ToList();
+        var expenditure = items.Where(t => t.Typ == TransactionType.Ausgabe && !t.IsTransfer).ToList();
 
         var categories = await _categoryRepository.GetCategoriesAsync();
         var catDict = categories.ToDictionary(c => c.Id);

--- a/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -12,6 +12,7 @@ public static class InfrastructureServiceCollectionExtensions
 
         // Backup
         services.AddSingleton<IDataMigrator, Finanzuebersicht.Core.Services.Migrations.V1ToV2Migrator>();
+        services.AddSingleton<IDataMigrator, Finanzuebersicht.Core.Services.Migrations.V2ToV3Migrator>();
         services.AddSingleton<DataMigrationService>(sp =>
             new DataMigrationService(sp.GetServices<IDataMigrator>()));
         services.AddSingleton<IBackupService, BackupService>();
@@ -30,6 +31,11 @@ public static class InfrastructureServiceCollectionExtensions
             new CategoryStore(
                 GetDataDir(sp),
                 sp.GetService<ILogger<CategoryStore>>()));
+
+        services.AddSingleton<AccountStore>(sp =>
+            new AccountStore(
+                GetDataDir(sp),
+                sp.GetService<ILogger<AccountStore>>()));
 
         services.AddSingleton<TransactionStore>(sp =>
             new TransactionStore(
@@ -62,6 +68,7 @@ public static class InfrastructureServiceCollectionExtensions
         services.AddSingleton<LocalDataService>(sp =>
             new LocalDataService(
                 sp.GetRequiredService<CategoryStore>(),
+                sp.GetRequiredService<AccountStore>(),
                 sp.GetRequiredService<TransactionStore>(),
                 sp.GetRequiredService<RecurringStore>(),
                 sp.GetRequiredService<BudgetStore>(),
@@ -71,6 +78,7 @@ public static class InfrastructureServiceCollectionExtensions
 
         // Expose the LocalDataService instance via the repository interfaces it implements
         services.AddSingleton<ICategoryRepository>(sp => sp.GetRequiredService<LocalDataService>());
+        services.AddSingleton<IAccountRepository>(sp => sp.GetRequiredService<LocalDataService>());
         services.AddSingleton<ITransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
         services.AddSingleton<IRecurringTransactionRepository>(sp => sp.GetRequiredService<LocalDataService>());
         services.AddSingleton<IBudgetRepository>(sp => sp.GetRequiredService<LocalDataService>());

--- a/Finanzuebersicht.Infrastructure/Services/AccountStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/AccountStore.cs
@@ -1,0 +1,64 @@
+using Finanzuebersicht.Models;
+using Microsoft.Extensions.Logging;
+
+namespace Finanzuebersicht.Infrastructure.Services;
+
+public class AccountStore : JsonDataStoreBase, IAccountRepository
+{
+    private string AccountsFile => Path.Combine(DataDir, "accounts.json");
+
+    public AccountStore(string dataDir, ILogger<AccountStore>? logger = null)
+        : base(dataDir, logger)
+    {
+    }
+
+    public async Task<List<Account>> GetAccountsAsync()
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            return await LoadAsync<Account>(AccountsFile);
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
+    public async Task SaveAccountAsync(Account account)
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            var items = await LoadAsync<Account>(AccountsFile);
+            var idx = items.FindIndex(a => a.Id == account.Id);
+            if (idx >= 0)
+                items[idx] = account;
+            else
+                items.Add(account);
+            await SaveAsync(AccountsFile, items);
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
+    public async Task DeleteAccountAsync(string id)
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            var items = await LoadAsync<Account>(AccountsFile);
+            items.RemoveAll(a => a.Id == id);
+            await SaveAsync(AccountsFile, items);
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
+    public Task ReplaceAllAccountsAsync(IEnumerable<Account> accounts)
+        => ReplaceAllAsync(AccountsFile, accounts);
+}

--- a/Finanzuebersicht.Infrastructure/Services/BackupService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/BackupService.cs
@@ -16,6 +16,7 @@ namespace Finanzuebersicht.Infrastructure.Services
     public class BackupService : IBackupService
     {
         private readonly ICategoryRepository _categoryRepository;
+        private readonly IAccountRepository _accountRepository;
         private readonly ITransactionRepository _transactionRepository;
         private readonly IRecurringTransactionRepository _recurringRepository;
         private readonly IBudgetRepository _budgetRepository;
@@ -33,10 +34,11 @@ namespace Finanzuebersicht.Infrastructure.Services
         };
 
         private const string BackupMetadataFileName = "backup.metadata.json";
-        private const int CurrentSchemaVersion = 2;
+        private const int CurrentSchemaVersion = 3;
 
         public BackupService(
             ICategoryRepository categoryRepository,
+            IAccountRepository accountRepository,
             ITransactionRepository transactionRepository,
             IRecurringTransactionRepository recurringRepository,
             IBudgetRepository budgetRepository,
@@ -48,6 +50,7 @@ namespace Finanzuebersicht.Infrastructure.Services
             Finanzuebersicht.Core.Services.IClock? clock = null)
         {
             _categoryRepository = categoryRepository ?? throw new ArgumentNullException(nameof(categoryRepository));
+            _accountRepository = accountRepository ?? throw new ArgumentNullException(nameof(accountRepository));
             _transactionRepository = transactionRepository ?? throw new ArgumentNullException(nameof(transactionRepository));
             _recurringRepository = recurringRepository ?? throw new ArgumentNullException(nameof(recurringRepository));
             _budgetRepository = budgetRepository ?? throw new ArgumentNullException(nameof(budgetRepository));
@@ -76,6 +79,7 @@ namespace Finanzuebersicht.Infrastructure.Services
 
                 // Lade alle Daten
                 var categories = await _categoryRepository.GetCategoriesAsync();
+                var accounts = await _accountRepository.GetAccountsAsync();
                 var transactions = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
                 var recurring = await _recurringRepository.GetRecurringTransactionsAsync();
                 var budgets = await _budgetRepository.GetBudgetsAsync();
@@ -94,6 +98,7 @@ namespace Finanzuebersicht.Infrastructure.Services
                     EntityCounts = new Dictionary<string, int>
                     {
                         { "categories", categories.Count() },
+                        { "accounts", accounts.Count() },
                         { "transactions", transactions.Count() },
                         { "recurring", recurring.Count() },
                         { "budgets", budgets.Count },
@@ -107,6 +112,7 @@ namespace Finanzuebersicht.Infrastructure.Services
                 {
                     // Schreibe Daten-Dateien
                     WriteJsonToZip(zipArchive, "categories.json", categories);
+                    WriteJsonToZip(zipArchive, "accounts.json", accounts);
                     WriteJsonToZip(zipArchive, "transactions.json", transactions);
                     WriteJsonToZip(zipArchive, "recurring.json", recurring);
                     WriteJsonToZip(zipArchive, "budgets.json", budgets);
@@ -217,17 +223,18 @@ namespace Finanzuebersicht.Infrastructure.Services
 
                 // Deserialisiere die (ggf. migrierten) Daten in konkrete Typen
                 var categories = DeserializeFile<List<Category>>(archiveData, "categories.json");
+                var accounts = DeserializeFile<List<Account>>(archiveData, "accounts.json");
                 var transactions = DeserializeFile<List<Transaction>>(archiveData, "transactions.json");
                 var recurring = DeserializeFile<List<RecurringTransaction>>(archiveData, "recurring.json");
                 var budgets = DeserializeFile<List<CategoryBudget>>(archiveData, "budgets.json");
                 var sparziele = DeserializeFile<List<SparZiel>>(archiveData, "sparziele.json");
                 var transactionTemplates = DeserializeFile<List<TransactionTemplate>>(archiveData, "transaction-templates.json") ?? [];
 
-                if (categories == null || transactions == null || recurring == null || budgets == null || sparziele == null)
+                if (categories == null || accounts == null || transactions == null || recurring == null || budgets == null || sparziele == null)
                     return new RestoreResult { Success = false, ErrorMessage = "ZIP-Datei ist beschädigt oder unvollständig" };
 
                 // Atomare Restore mit Rollback-Capability
-                var restoreSuccess = await AtomicRestoreAsync(categories, transactions, recurring, budgets, sparziele, transactionTemplates);
+                var restoreSuccess = await AtomicRestoreAsync(categories, accounts, transactions, recurring, budgets, sparziele, transactionTemplates);
 
                 if (!restoreSuccess)
                     return new RestoreResult { Success = false, ErrorMessage = "Fehler beim Speichern der wiederhergestellten Daten" };
@@ -273,6 +280,7 @@ namespace Finanzuebersicht.Infrastructure.Services
         /// </summary>
         private async Task<bool> AtomicRestoreAsync(
             List<Category> categories,
+            List<Account> accounts,
             List<Transaction> transactions,
             List<RecurringTransaction> recurring,
             List<CategoryBudget> budgets,
@@ -283,6 +291,7 @@ namespace Finanzuebersicht.Infrastructure.Services
             // Wenn dieser Schritt fehlschlägt (z.B. DataCorruptionException), bricht der Restore
             // ab bevor irgendetwas überschrieben wurde — das ist das gewünschte Verhalten.
             var snapshotCategories = await _categoryRepository.GetCategoriesAsync();
+            var snapshotAccounts = await _accountRepository.GetAccountsAsync();
             var snapshotTransactions = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
             var snapshotRecurring = await _recurringRepository.GetRecurringTransactionsAsync();
             var snapshotBudgets = await _budgetRepository.GetBudgetsAsync();
@@ -297,6 +306,7 @@ namespace Finanzuebersicht.Infrastructure.Services
                     categories.Count, transactions.Count, recurring.Count, budgets.Count, sparziele.Count, transactionTemplates.Count);
 
                 await _categoryRepository.ReplaceAllCategoriesAsync(categories);
+                await _accountRepository.ReplaceAllAccountsAsync(accounts);
                 await _transactionRepository.ReplaceAllTransactionsAsync(transactions);
                 await _recurringRepository.ReplaceAllRecurringTransactionsAsync(recurring);
                 await _budgetRepository.ReplaceAllBudgetsAsync(budgets);
@@ -309,13 +319,14 @@ namespace Finanzuebersicht.Infrastructure.Services
             catch (Exception ex)
             {
                 _logger?.LogError(ex, "Fehler bei der Wiederherstellung – starte Rollback");
-                await RollbackAsync(snapshotCategories, snapshotTransactions, snapshotRecurring, snapshotBudgets, snapshotSparziele, snapshotTransactionTemplates);
+                await RollbackAsync(snapshotCategories, snapshotAccounts, snapshotTransactions, snapshotRecurring, snapshotBudgets, snapshotSparziele, snapshotTransactionTemplates);
                 return false;
             }
         }
 
         private async Task RollbackAsync(
             List<Category> categories,
+            List<Account> accounts,
             List<Transaction> transactions,
             List<RecurringTransaction> recurring,
             List<CategoryBudget> budgets,
@@ -325,6 +336,7 @@ namespace Finanzuebersicht.Infrastructure.Services
             try
             {
                 await _categoryRepository.ReplaceAllCategoriesAsync(categories);
+                await _accountRepository.ReplaceAllAccountsAsync(accounts);
                 await _transactionRepository.ReplaceAllTransactionsAsync(transactions);
                 await _recurringRepository.ReplaceAllRecurringTransactionsAsync(recurring);
                 await _budgetRepository.ReplaceAllBudgetsAsync(budgets);
@@ -445,18 +457,6 @@ namespace Finanzuebersicht.Infrastructure.Services
             {
                 using (var zipArchive = ZipFile.OpenRead(zipPath))
                 {
-                    var requiredFiles = new[] { "categories.json", "transactions.json", "recurring.json", BackupMetadataFileName };
-                    var missingFiles = requiredFiles.Where(f => zipArchive.GetEntry(f) == null).ToList();
-
-                    if (missingFiles.Count != 0)
-                    {
-                        return new RestoreResult
-                        {
-                            Success = false,
-                            ErrorMessage = $"Backup unvollständig. Fehlende Dateien: {string.Join(", ", missingFiles)}"
-                        };
-                    }
-
                     // Validiere Metadaten-Schema: ältere Versionen werden migriert, neuere abgelehnt
                     var metadata = ReadJsonFromZip<BackupMetadata>(zipArchive, BackupMetadataFileName);
                     if (metadata == null || metadata.SchemaVersion > CurrentSchemaVersion)
@@ -467,9 +467,23 @@ namespace Finanzuebersicht.Infrastructure.Services
                             ErrorMessage = $"Schema-Version nicht kompatibel. Backup: v{metadata?.SchemaVersion}, App: v{CurrentSchemaVersion}"
                         };
                     }
-                }
 
-                return new RestoreResult { Success = true };
+                    var requiredFiles = new List<string> { "categories.json", "transactions.json", "recurring.json", BackupMetadataFileName };
+                    if (metadata.SchemaVersion >= 3)
+                        requiredFiles.Add("accounts.json");
+
+                    var missingFiles = requiredFiles.Where(f => zipArchive.GetEntry(f) == null).ToList();
+                    if (missingFiles.Count != 0)
+                    {
+                        return new RestoreResult
+                        {
+                            Success = false,
+                            ErrorMessage = $"Backup unvollständig. Fehlende Dateien: {string.Join(", ", missingFiles)}"
+                        };
+                    }
+
+                    return new RestoreResult { Success = true };
+                }
             }
             catch (Exception ex)
             {

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -14,9 +14,10 @@ namespace Finanzuebersicht.Infrastructure.Services;
 /// - ReportingService: Transaction aggregations
 /// - RecurringGenerationService: Auto-generation of recurring transactions
 /// </summary>
-public class LocalDataService : IDataService, ITransactionTemplateRepository, IDisposable
+public class LocalDataService : IDataService, IAccountRepository, ITransactionTemplateRepository, IDisposable
 {
     private readonly CategoryStore _categoryStore;
+    private readonly AccountStore _accountStore;
     private readonly TransactionStore _transactionStore;
     private readonly RecurringStore _recurringStore;
     private readonly BudgetStore _budgetStore;
@@ -30,6 +31,7 @@ public class LocalDataService : IDataService, ITransactionTemplateRepository, ID
     /// </summary>
     public LocalDataService(
         CategoryStore categoryStore,
+        AccountStore accountStore,
         TransactionStore transactionStore,
         RecurringStore recurringStore,
         BudgetStore budgetStore,
@@ -38,6 +40,7 @@ public class LocalDataService : IDataService, ITransactionTemplateRepository, ID
         IClock clock)
     {
         _categoryStore = categoryStore;
+        _accountStore = accountStore;
         _transactionStore = transactionStore;
         _recurringStore = recurringStore;
         _budgetStore = budgetStore;
@@ -57,6 +60,7 @@ public class LocalDataService : IDataService, ITransactionTemplateRepository, ID
         var dataDir = string.IsNullOrWhiteSpace(customPath) ? defaultDataDir : customPath;
 
         _categoryStore = new CategoryStore(dataDir);
+        _accountStore = new AccountStore(dataDir);
         _transactionStore = new TransactionStore(dataDir, categoryStore: _categoryStore);
         _recurringStore = new RecurringStore(dataDir);
         _budgetStore = new BudgetStore(dataDir);
@@ -79,6 +83,22 @@ public class LocalDataService : IDataService, ITransactionTemplateRepository, ID
 
     public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories)
         => _categoryStore.ReplaceAllCategoriesAsync(categories);
+
+    #endregion
+
+    #region IAccountRepository delegation
+
+    public Task<List<Account>> GetAccountsAsync()
+        => _accountStore.GetAccountsAsync();
+
+    public Task SaveAccountAsync(Account account)
+        => _accountStore.SaveAccountAsync(account);
+
+    public Task DeleteAccountAsync(string id)
+        => _accountStore.DeleteAccountAsync(id);
+
+    public Task ReplaceAllAccountsAsync(IEnumerable<Account> accounts)
+        => _accountStore.ReplaceAllAccountsAsync(accounts);
 
     #endregion
 

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -110,8 +110,14 @@ public class LocalDataService : IDataService, IAccountRepository, ITransactionTe
     public async Task SaveTransactionAsync(Transaction transaction)
         => await _transactionStore.SaveTransactionAsync(transaction);
 
+    public async Task SaveTransactionsAsync(IEnumerable<Transaction> transactions)
+        => await _transactionStore.SaveTransactionsAsync(transactions);
+
     public async Task DeleteTransactionAsync(string id)
         => await _transactionStore.DeleteTransactionAsync(id);
+
+    public async Task DeleteTransferGroupAsync(string transferGroupId)
+        => await _transactionStore.DeleteTransferGroupAsync(transferGroupId);
 
     public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions)
         => _transactionStore.ReplaceAllTransactionsAsync(transactions);

--- a/Finanzuebersicht.Infrastructure/Services/TransactionStore.cs
+++ b/Finanzuebersicht.Infrastructure/Services/TransactionStore.cs
@@ -56,6 +56,28 @@ public class TransactionStore : JsonDataStoreBase, ITransactionRepository
         }
     }
 
+    public async Task SaveTransactionsAsync(IEnumerable<Transaction> transactions)
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            var items = await LoadAsync<Transaction>(TransactionsFile);
+            foreach (var transaction in transactions)
+            {
+                var idx = items.FindIndex(t => t.Id == transaction.Id);
+                if (idx >= 0)
+                    items[idx] = transaction;
+                else
+                    items.Add(transaction);
+            }
+            await SaveAsync(TransactionsFile, items);
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
     public async Task DeleteTransactionAsync(string id)
     {
         await StoreLock.WaitAsync();
@@ -63,6 +85,21 @@ public class TransactionStore : JsonDataStoreBase, ITransactionRepository
         {
             var items = await LoadAsync<Transaction>(TransactionsFile);
             items.RemoveAll(t => t.Id == id);
+            await SaveAsync(TransactionsFile, items);
+        }
+        finally
+        {
+            StoreLock.Release();
+        }
+    }
+
+    public async Task DeleteTransferGroupAsync(string transferGroupId)
+    {
+        await StoreLock.WaitAsync();
+        try
+        {
+            var items = await LoadAsync<Transaction>(TransactionsFile);
+            items.RemoveAll(t => t.TransferGroupId == transferGroupId);
             await SaveAsync(TransactionsFile, items);
         }
         finally

--- a/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
@@ -23,6 +23,7 @@ public static class PresentationServiceCollectionExtensions
         services.AddTransient<CategoriesViewModel>();
         services.AddTransient<CategoryDetailViewModel>();
         services.AddTransient<AccountDetailViewModel>();
+        services.AddTransient<TransferDetailViewModel>();
         services.AddTransient<TransactionsViewModel>();
         services.AddTransient<TransactionDetailViewModel>();
         services.AddTransient<RecurringTransactionsViewModel>();

--- a/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
@@ -22,6 +22,7 @@ public static class PresentationServiceCollectionExtensions
         services.AddTransient<DashboardViewModel>();
         services.AddTransient<CategoriesViewModel>();
         services.AddTransient<CategoryDetailViewModel>();
+        services.AddTransient<AccountDetailViewModel>();
         services.AddTransient<TransactionsViewModel>();
         services.AddTransient<TransactionDetailViewModel>();
         services.AddTransient<RecurringTransactionsViewModel>();

--- a/Finanzuebersicht.Presentation/Navigation/Routes.cs
+++ b/Finanzuebersicht.Presentation/Navigation/Routes.cs
@@ -9,6 +9,7 @@ public static class Routes
     public static readonly string TransactionDetail = "TransactionDetailPage";
     public static readonly string RecurringTransactionDetail = "RecurringTransactionDetailPage";
     public static readonly string CategoryDetail = "CategoryDetailPage";
+    public static readonly string AccountDetail = "AccountDetailPage";
     public static readonly string RecurringInstanceShift = "RecurringInstanceShiftPage";
     public static readonly string Settings = "SettingsPage";
     public static readonly string BackupList = "BackupListPage";

--- a/Finanzuebersicht.Presentation/Navigation/Routes.cs
+++ b/Finanzuebersicht.Presentation/Navigation/Routes.cs
@@ -10,6 +10,7 @@ public static class Routes
     public static readonly string RecurringTransactionDetail = "RecurringTransactionDetailPage";
     public static readonly string CategoryDetail = "CategoryDetailPage";
     public static readonly string AccountDetail = "AccountDetailPage";
+    public static readonly string TransferDetail = "TransferDetailPage";
     public static readonly string RecurringInstanceShift = "RecurringInstanceShiftPage";
     public static readonly string Settings = "SettingsPage";
     public static readonly string BackupList = "BackupListPage";

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -19,6 +19,9 @@ public static class ResourceKeys
     public const string Title_NeueKategorie = nameof(Title_NeueKategorie);
     public const string Title_KategorieBearbeiten = nameof(Title_KategorieBearbeiten);
     public const string Title_Jahresansicht = nameof(Title_Jahresansicht);
+    public const string Title_Umbuchung = nameof(Title_Umbuchung);
+    public const string Title_KontoHinzufuegen = nameof(Title_KontoHinzufuegen);
+    public const string Title_KontoBearbeiten = nameof(Title_KontoBearbeiten);
 
     // Labels
     public const string Lbl_Name = nameof(Lbl_Name);
@@ -86,6 +89,8 @@ public static class ResourceKeys
     public const string Empty_KeineDashboardDaten = nameof(Empty_KeineDashboardDaten);
     public const string Empty_KeineJahresDaten = nameof(Empty_KeineJahresDaten);
     public const string Empty_NochKeineTransaktionen = nameof(Empty_NochKeineTransaktionen);
+    public const string Empty_KeineKonten = nameof(Empty_KeineKonten);
+    public const string Empty_KontenHinweis = nameof(Empty_KontenHinweis);
     public const string Btn_ZuTransaktionen = nameof(Btn_ZuTransaktionen);
 
     // Error Messages
@@ -97,6 +102,7 @@ public static class ResourceKeys
     public const string Err_SpeichernFehlgeschlagen = nameof(Err_SpeichernFehlgeschlagen);
     public const string Err_LoeschenFehlgeschlagen = nameof(Err_LoeschenFehlgeschlagen);
     public const string Err_LadenFehlgeschlagen = nameof(Err_LadenFehlgeschlagen);
+    public const string Err_TransferKontenUnterschiedlich = nameof(Err_TransferKontenUnterschiedlich);
     public const string Err_OrdnerNichtWaehlbar = nameof(Err_OrdnerNichtWaehlbar);
     public const string Err_SucheFehlgeschlagen = nameof(Err_SucheFehlgeschlagen);
 
@@ -217,6 +223,12 @@ public static class ResourceKeys
     public const string Lbl_SuchergebnisseAnzahl = nameof(Lbl_SuchergebnisseAnzahl);
     public const string Lbl_AlleKategorien = nameof(Lbl_AlleKategorien);
     public const string Lbl_AlleKonten = nameof(Lbl_AlleKonten);
+    public const string Lbl_Archiviert = nameof(Lbl_Archiviert);
+    public const string Lbl_VonKonto = nameof(Lbl_VonKonto);
+    public const string Lbl_NachKonto = nameof(Lbl_NachKonto);
+    public const string Btn_Archivieren = nameof(Btn_Archivieren);
+    public const string Btn_Aktivieren = nameof(Btn_Aktivieren);
+    public const string Hint_Systemkonto = nameof(Hint_Systemkonto);
     public const string Lbl_AlleTypen = nameof(Lbl_AlleTypen);
     public const string Lbl_VonDatum = nameof(Lbl_VonDatum);
     public const string Lbl_BisDatum = nameof(Lbl_BisDatum);
@@ -275,6 +287,7 @@ public static class ResourceKeys
     public const string A11y_VorherigesJahr = nameof(A11y_VorherigesJahr);
     public const string A11y_NaechstesJahr = nameof(A11y_NaechstesJahr);
     public const string A11y_TransaktionHinzufuegen = nameof(A11y_TransaktionHinzufuegen);
+    public const string A11y_UmbuchungHinzufuegen = nameof(A11y_UmbuchungHinzufuegen);
     public const string A11y_KategorieHinzufuegen = nameof(A11y_KategorieHinzufuegen);
     public const string A11y_SparZielHinzufuegen = nameof(A11y_SparZielHinzufuegen);
     public const string A11y_DauerauftragHinzufuegen = nameof(A11y_DauerauftragHinzufuegen);

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -103,6 +103,7 @@ public static class ResourceKeys
     public const string Err_LoeschenFehlgeschlagen = nameof(Err_LoeschenFehlgeschlagen);
     public const string Err_LadenFehlgeschlagen = nameof(Err_LadenFehlgeschlagen);
     public const string Err_TransferKontenUnterschiedlich = nameof(Err_TransferKontenUnterschiedlich);
+    public const string Err_UmbuchungNichtBearbeitbar = nameof(Err_UmbuchungNichtBearbeitbar);
     public const string Err_OrdnerNichtWaehlbar = nameof(Err_OrdnerNichtWaehlbar);
     public const string Err_SucheFehlgeschlagen = nameof(Err_SucheFehlgeschlagen);
 
@@ -113,6 +114,8 @@ public static class ResourceKeys
     public const string Dlg_DauerauftragLoeschenFrage = nameof(Dlg_DauerauftragLoeschenFrage);
     public const string Dlg_TransaktionLoeschen = nameof(Dlg_TransaktionLoeschen);
     public const string Dlg_TransaktionLoeschenFrage = nameof(Dlg_TransaktionLoeschenFrage);
+    public const string Dlg_UmbuchungLoeschen = nameof(Dlg_UmbuchungLoeschen);
+    public const string Dlg_UmbuchungLoeschenFrage = nameof(Dlg_UmbuchungLoeschenFrage);
     public const string Dlg_VorlageLoeschen = nameof(Dlg_VorlageLoeschen);
     public const string Dlg_VorlageLoeschenFrage = nameof(Dlg_VorlageLoeschenFrage);
     public const string Dlg_SparZielLoeschen = nameof(Dlg_SparZielLoeschen);

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -10,6 +10,7 @@ public static class ResourceKeys
     public const string Nav_Transaktionen = nameof(Nav_Transaktionen);
     public const string Nav_Dauerauftraege = nameof(Nav_Dauerauftraege);
     public const string Nav_Kategorien = nameof(Nav_Kategorien);
+    public const string Nav_Verwaltung = nameof(Nav_Verwaltung);
     public const string Nav_Einstellungen = nameof(Nav_Einstellungen);
 
     // Page Titles

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -215,6 +215,7 @@ public static class ResourceKeys
     public const string Lbl_ForecastNaechsterMonat = nameof(Lbl_ForecastNaechsterMonat);
     public const string Lbl_SuchergebnisseAnzahl = nameof(Lbl_SuchergebnisseAnzahl);
     public const string Lbl_AlleKategorien = nameof(Lbl_AlleKategorien);
+    public const string Lbl_AlleKonten = nameof(Lbl_AlleKonten);
     public const string Lbl_AlleTypen = nameof(Lbl_AlleTypen);
     public const string Lbl_VonDatum = nameof(Lbl_VonDatum);
     public const string Lbl_BisDatum = nameof(Lbl_BisDatum);

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -11,10 +11,12 @@ namespace Finanzuebersicht.ViewModels;
 public partial class AccountDetailViewModel(
     SaveAccountDetailUseCase saveAccountDetailUseCase,
     INavigationService navigationService,
+    ILocalizationService localizationService,
     ILogger<AccountDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
 {
     private readonly SaveAccountDetailUseCase _saveAccountDetailUseCase = saveAccountDetailUseCase;
     private readonly INavigationService _navigationService = navigationService;
+    private readonly ILocalizationService _loc = localizationService;
     private readonly ILogger<AccountDetailViewModel>? _logger = logger;
     private Account? _existingAccount;
 
@@ -24,9 +26,28 @@ public partial class AccountDetailViewModel(
     [ObservableProperty]
     private AccountType type = AccountType.Girokonto;
 
+    [ObservableProperty]
+    private bool isArchived;
+
+    [ObservableProperty]
+    private AccountTypeOption? selectedTypeOption;
+
     public string PageTitle => _existingAccount == null ? "Konto hinzufügen" : "Konto bearbeiten";
 
-    public List<AccountType> VerfuegbareTypen { get; } = Enum.GetValues<AccountType>().ToList();
+    public bool IsSystemAccount => _existingAccount?.IsSystemAccount == true;
+    public bool CanArchive => !IsSystemAccount;
+    public string ArchiveStatusText => IsArchived ? "Archiviert" : "Aktiv";
+    public string SystemAccountHint => IsSystemAccount ? "Systemkonto kann nicht archiviert oder gelöscht werden." : string.Empty;
+
+    public List<AccountTypeOption> VerfuegbareTypen =>
+    [
+        new(AccountType.Girokonto, _loc.GetString("AccountType_Girokonto")),
+        new(AccountType.Tagesgeld, _loc.GetString("AccountType_Tagesgeld")),
+        new(AccountType.Kreditkarte, _loc.GetString("AccountType_Kreditkarte")),
+        new(AccountType.Bargeld, _loc.GetString("AccountType_Bargeld")),
+        new(AccountType.Depot, _loc.GetString("AccountType_Depot")),
+        new(AccountType.Sonstiges, _loc.GetString("AccountType_Sonstiges"))
+    ];
 
     public Account? Account
     {
@@ -37,7 +58,13 @@ public partial class AccountDetailViewModel(
                 _existingAccount = value;
                 Name = value.Name;
                 Type = value.Type;
+                IsArchived = value.IsArchived;
+                SelectedTypeOption = VerfuegbareTypen.FirstOrDefault(t => t.Value == value.Type);
                 OnPropertyChanged(nameof(PageTitle));
+                OnPropertyChanged(nameof(IsSystemAccount));
+                OnPropertyChanged(nameof(CanArchive));
+                OnPropertyChanged(nameof(SystemAccountHint));
+                OnPropertyChanged(nameof(ArchiveStatusText));
             }
         }
     }
@@ -53,7 +80,10 @@ public partial class AccountDetailViewModel(
     {
         if (string.IsNullOrWhiteSpace(Name)) return;
 
-        await _saveAccountDetailUseCase.ExecuteAsync(_existingAccount, Name, Type);
+        Type = SelectedTypeOption?.Value ?? Type;
+        await _saveAccountDetailUseCase.ExecuteAsync(_existingAccount, Name, Type, IsArchived);
         await _navigationService.GoBackAsync();
     }
 }
+
+public sealed record AccountTypeOption(AccountType Value, string DisplayName);

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -1,0 +1,59 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Resources.Strings;
+using Microsoft.Extensions.Logging;
+
+namespace Finanzuebersicht.ViewModels;
+
+public partial class AccountDetailViewModel(
+    SaveAccountDetailUseCase saveAccountDetailUseCase,
+    INavigationService navigationService,
+    ILogger<AccountDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
+{
+    private readonly SaveAccountDetailUseCase _saveAccountDetailUseCase = saveAccountDetailUseCase;
+    private readonly INavigationService _navigationService = navigationService;
+    private readonly ILogger<AccountDetailViewModel>? _logger = logger;
+    private Account? _existingAccount;
+
+    [ObservableProperty]
+    private string name = string.Empty;
+
+    [ObservableProperty]
+    private AccountType type = AccountType.Girokonto;
+
+    public string PageTitle => _existingAccount == null ? "Konto hinzufügen" : "Konto bearbeiten";
+
+    public List<AccountType> VerfuegbareTypen { get; } = Enum.GetValues<AccountType>().ToList();
+
+    public Account? Account
+    {
+        set
+        {
+            if (value != null)
+            {
+                _existingAccount = value;
+                Name = value.Name;
+                Type = value.Type;
+                OnPropertyChanged(nameof(PageTitle));
+            }
+        }
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("Account", out var val) && val is Account a)
+            Account = a;
+    }
+
+    [RelayCommand]
+    private async Task Save()
+    {
+        if (string.IsNullOrWhiteSpace(Name)) return;
+
+        await _saveAccountDetailUseCase.ExecuteAsync(_existingAccount, Name, Type);
+        await _navigationService.GoBackAsync();
+    }
+}

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -32,12 +32,20 @@ public partial class AccountDetailViewModel(
     [ObservableProperty]
     private AccountTypeOption? selectedTypeOption;
 
-    public string PageTitle => _existingAccount == null ? "Konto hinzufügen" : "Konto bearbeiten";
+    public string PageTitle => _existingAccount == null
+        ? _loc.GetString(ResourceKeys.Title_KontoHinzufuegen)
+        : _loc.GetString(ResourceKeys.Title_KontoBearbeiten);
 
     public bool IsSystemAccount => _existingAccount?.IsSystemAccount == true;
     public bool CanArchive => !IsSystemAccount;
-    public string ArchiveStatusText => IsArchived ? "Archiviert" : "Aktiv";
-    public string SystemAccountHint => IsSystemAccount ? "Systemkonto kann nicht archiviert oder gelöscht werden." : string.Empty;
+    public string ArchiveStatusText => IsArchived
+        ? _loc.GetString(ResourceKeys.Lbl_Archiviert)
+        : _loc.GetString(ResourceKeys.Lbl_Aktiv);
+    public string SystemAccountHint => IsSystemAccount
+        ? _loc.GetString(ResourceKeys.Hint_Systemkonto)
+        : string.Empty;
+
+    partial void OnIsArchivedChanged(bool value) => OnPropertyChanged(nameof(ArchiveStatusText));
 
     public List<AccountTypeOption> VerfuegbareTypen =>
     [

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Categories;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
@@ -12,6 +13,8 @@ namespace Finanzuebersicht.ViewModels;
 public partial class CategoriesViewModel(
     DeleteCategoryUseCase deleteCategoryUseCase,
     LoadCategoriesUseCase loadCategoriesUseCase,
+    LoadAccountsUseCase loadAccountsUseCase,
+    DeleteAccountUseCase deleteAccountUseCase,
     ILocalizationService localizationService,
     INavigationService navigationService,
     IDialogService dialogService,
@@ -19,6 +22,8 @@ public partial class CategoriesViewModel(
 {
     private readonly DeleteCategoryUseCase _deleteCategoryUseCase = deleteCategoryUseCase;
     private readonly LoadCategoriesUseCase _loadCategoriesUseCase = loadCategoriesUseCase;
+    private readonly LoadAccountsUseCase _loadAccountsUseCase = loadAccountsUseCase;
+    private readonly DeleteAccountUseCase _deleteAccountUseCase = deleteAccountUseCase;
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
@@ -30,7 +35,24 @@ public partial class CategoriesViewModel(
     private ObservableCollection<Category> kategorien = [];
 
     [ObservableProperty]
+    private ObservableCollection<Account> konten = [];
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsKategorienVisible))]
+    [NotifyPropertyChangedFor(nameof(IsKontenVisible))]
+    private int selectedSectionIndex;
+
+    public bool IsKategorienVisible => SelectedSectionIndex == 0;
+    public bool IsKontenVisible => SelectedSectionIndex == 1;
+
+    [ObservableProperty]
     private bool isLoading;
+
+    [RelayCommand]
+    private void ShowKategorien() => SelectedSectionIndex = 0;
+
+    [RelayCommand]
+    private void ShowKonten() => SelectedSectionIndex = 1;
 
     [RelayCommand]
     private async Task LoadKategorien()
@@ -42,6 +64,8 @@ public partial class CategoriesViewModel(
         {
             var liste = await _loadCategoriesUseCase.ExecuteAsync();
             Kategorien = new ObservableCollection<Category>(liste);
+            var accounts = await _loadAccountsUseCase.ExecuteAsync();
+            Konten = new ObservableCollection<Account>(accounts.OrderBy(a => a.Name));
         }
         catch (Exception ex)
         {
@@ -82,10 +106,52 @@ public partial class CategoriesViewModel(
     }
 
     [RelayCommand]
-    private async Task GoToDetail(Category? kategorie = null)
+    private async Task DeleteKonto(Account konto)
     {
+        if (!konto.CanDelete) return;
+
+        var confirm = await _dialogService.ShowConfirmationAsync(
+            "Konto löschen",
+            $"\"{konto.Name}\" wirklich löschen?",
+            _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
+        if (!confirm) return;
+
+        try
+        {
+            await _deleteAccountUseCase.ExecuteAsync(konto.Id);
+            Konten.Remove(konto);
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "CategoriesViewModel: {Context}", nameof(DeleteKonto));
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    [RelayCommand]
+    private async Task GoToDetail(object? item = null)
+    {
+        if (item is Account konto)
+        {
+            var kontoParameter = new Dictionary<string, object>
+            {
+                ["Account"] = konto
+            };
+            await _navigationService.GoToAsync(Routes.AccountDetail, kontoParameter);
+            return;
+        }
+
+        if (item == null && IsKontenVisible)
+        {
+            await _navigationService.GoToAsync(Routes.AccountDetail);
+            return;
+        }
+
         var parameter = new Dictionary<string, object>();
-        if (kategorie != null)
+        if (item is Category kategorie)
             parameter["Category"] = kategorie;
 
         await _navigationService.GoToAsync(Routes.CategoryDetail, parameter);

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -14,6 +14,7 @@ public partial class CategoriesViewModel(
     DeleteCategoryUseCase deleteCategoryUseCase,
     LoadCategoriesUseCase loadCategoriesUseCase,
     LoadAccountsUseCase loadAccountsUseCase,
+    ToggleAccountArchiveUseCase toggleAccountArchiveUseCase,
     DeleteAccountUseCase deleteAccountUseCase,
     ILocalizationService localizationService,
     INavigationService navigationService,
@@ -23,6 +24,7 @@ public partial class CategoriesViewModel(
     private readonly DeleteCategoryUseCase _deleteCategoryUseCase = deleteCategoryUseCase;
     private readonly LoadCategoriesUseCase _loadCategoriesUseCase = loadCategoriesUseCase;
     private readonly LoadAccountsUseCase _loadAccountsUseCase = loadAccountsUseCase;
+    private readonly ToggleAccountArchiveUseCase _toggleAccountArchiveUseCase = toggleAccountArchiveUseCase;
     private readonly DeleteAccountUseCase _deleteAccountUseCase = deleteAccountUseCase;
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
@@ -65,7 +67,7 @@ public partial class CategoriesViewModel(
             var liste = await _loadCategoriesUseCase.ExecuteAsync();
             Kategorien = new ObservableCollection<Category>(liste);
             var accounts = await _loadAccountsUseCase.ExecuteAsync();
-            Konten = new ObservableCollection<Account>(accounts.OrderBy(a => a.Name));
+            Konten = new ObservableCollection<Account>(accounts.OrderBy(a => a.IsArchived).ThenBy(a => a.Name));
         }
         catch (Exception ex)
         {
@@ -127,6 +129,38 @@ public partial class CategoriesViewModel(
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    [RelayCommand]
+    private async Task ToggleKontoArchivierung(Account konto)
+    {
+        if (!konto.CanArchive) return;
+
+        var setArchived = !konto.IsArchived;
+        var confirmTitle = setArchived ? "Konto archivieren" : "Konto reaktivieren";
+        var confirmBody = setArchived
+            ? $"\"{konto.Name}\" archivieren? Konto steht dann nicht mehr für neue Buchungen zur Auswahl."
+            : $"\"{konto.Name}\" wieder aktivieren?";
+        var confirm = await _dialogService.ShowConfirmationAsync(
+            confirmTitle,
+            confirmBody,
+            _loc.GetString(ResourceKeys.Btn_Ja),
+            _loc.GetString(ResourceKeys.Btn_Nein));
+        if (!confirm) return;
+
+        try
+        {
+            await _toggleAccountArchiveUseCase.ExecuteAsync(konto, setArchived);
+            await LoadKategorien();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "CategoriesViewModel: {Context}", nameof(ToggleKontoArchivierung));
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
         }
     }

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -16,7 +16,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private readonly LoadForecastUseCase _loadForecastUseCase;
     private readonly GetDueRecurringWithHintsUseCase _getDueRecurringUseCase;
     private readonly IBudgetRepository _budgetRepository;
-    private readonly IReportingService _reportingService;
+    private readonly IAccountRepository _accountRepository;
     private readonly ILocalizationService _loc;
     private readonly INavigationService _navigationService;
     private readonly IClock _clock;
@@ -115,6 +115,15 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private bool isLoading;
 
     [ObservableProperty]
+    private ObservableCollection<KategorieFilterItem> availableKonten = [];
+
+    [ObservableProperty]
+    private KategorieFilterItem? selectedKontoFilterItem;
+
+    [ObservableProperty]
+    private string? selectedAccountId;
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsYearView))]
     [NotifyPropertyChangedFor(nameof(ShowMonthView))]
     [NotifyPropertyChangedFor(nameof(ShowYearView))]
@@ -153,16 +162,26 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private bool _minJahrLoaded;
     private bool _foundTransactions;
 
+    partial void OnSelectedKontoFilterItemChanged(KategorieFilterItem? value)
+    {
+        SelectedAccountId = value?.Id;
+    }
+
+    partial void OnSelectedAccountIdChanged(string? value)
+    {
+        _ = LoadDashboard();
+    }
+
     public DashboardViewModel(
         LoadDashboardMonthUseCase loadDashboardMonthUseCase,
         LoadDashboardYearUseCase loadDashboardYearUseCase,
         LoadForecastUseCase loadForecastUseCase,
         GetDueRecurringWithHintsUseCase getDueRecurringUseCase,
         IBudgetRepository budgetRepository,
-        IReportingService reportingService,
         ILocalizationService localizationService,
         INavigationService navigationService,
         ITransactionRepository transactionRepository,
+        IAccountRepository accountRepository,
         IClock? clock = null,
         ILogger<DashboardViewModel>? logger = null) : base(clock)
     {
@@ -174,10 +193,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _loadForecastUseCase = loadForecastUseCase;
         _getDueRecurringUseCase = getDueRecurringUseCase;
         _budgetRepository = budgetRepository;
-        _reportingService = reportingService;
         _loc = localizationService;
         _navigationService = navigationService;
         _transactionRepository = transactionRepository;
+        _accountRepository = accountRepository;
         _logger = logger;
         UpdateJahrAnzeige();
     }
@@ -192,6 +211,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         try
         {
             await EnsureMinJahrLoadedAsync();
+            await EnsureAccountFilterLoadedAsync();
             if (IsMonthView)
             {
                 await LadeMonatAsync();
@@ -201,7 +221,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
                 await LadeJahrAsync();
             }
             await LadeFaelligeDauerauftraegeAsync();
-            HasAnyDataLoaded = _foundTransactions || HasMonthData || HasYearData;
+            HasAnyDataLoaded = HasMonthData || HasYearData;
         }
         finally
         {
@@ -233,9 +253,26 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         PreviousYearCommand.NotifyCanExecuteChanged();
     }
 
+    private async Task EnsureAccountFilterLoadedAsync()
+    {
+        if (AvailableKonten.Count > 0) return;
+
+        var accounts = await _accountRepository.GetAccountsAsync();
+        var items = new ObservableCollection<KategorieFilterItem>
+        {
+            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten))
+        };
+
+        foreach (var account in accounts.Where(a => !a.IsArchived).OrderBy(a => a.Name))
+            items.Add(new KategorieFilterItem(account.Id, account.Name));
+
+        AvailableKonten = items;
+        SelectedKontoFilterItem = items[0];
+    }
+
     private async Task LadeMonatAsync()
     {
-        var data = await _loadDashboardMonthUseCase.ExecuteAsync(AktuellerMonat, _clock.Today);
+        var data = await _loadDashboardMonthUseCase.ExecuteAsync(AktuellerMonat, _clock.Today, SelectedAccountId);
 
         IstPrognose = data.IstPrognose;
         GesamtEinnahmen = data.GesamtEinnahmen;
@@ -255,10 +292,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
         // Vormonatsvergleich: nur Gesamt-Ausgaben via ReportingService (keine Kategorien nötig)
         var prevMonth = AktuellerMonat.AddMonths(-1);
-        var prevSummary = await _reportingService.GetMonthSummaryAsync(prevMonth.Year, prevMonth.Month);
-        if (prevSummary.Total > 0)
+        var prevData = await _loadDashboardMonthUseCase.ExecuteAsync(prevMonth, _clock.Today, SelectedAccountId);
+        if (prevData.GesamtAusgaben > 0)
         {
-            var pct = (GesamtAusgaben - prevSummary.Total) / prevSummary.Total * 100;
+            var pct = (GesamtAusgaben - prevData.GesamtAusgaben) / prevData.GesamtAusgaben * 100;
             TrendProzent = pct;
             TrendPositiv = pct < 0; // weniger Ausgaben = positiv (grün)
             TrendText = pct >= 0
@@ -290,7 +327,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     private async Task LadeJahrAsync()
     {
-        var data = await _loadDashboardYearUseCase.ExecuteAsync(_aktuellesJahr);
+        var data = await _loadDashboardYearUseCase.ExecuteAsync(_aktuellesJahr, SelectedAccountId);
         JahrGesamtAusgaben = data.GesamtAusgaben;
         JahrMonate = data.Monate;
         JahrKategorien = new ObservableCollection<CategorySummary>(data.Kategorien);

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -47,6 +47,9 @@ public partial class RecurringTransactionDetailViewModel(
     private Category? selectedKategorie;
 
     [ObservableProperty]
+    private Account? selectedAccount;
+
+    [ObservableProperty]
     private TransactionType typ = TransactionType.Ausgabe;
 
     [ObservableProperty]
@@ -66,6 +69,9 @@ public partial class RecurringTransactionDetailViewModel(
 
     [ObservableProperty]
     private ObservableCollection<Category> kategorien = [];
+
+    [ObservableProperty]
+    private ObservableCollection<Account> accounts = [];
 
     [ObservableProperty]
     private RecurrenceInterval interval = RecurrenceInterval.Monthly;
@@ -109,6 +115,7 @@ public partial class RecurringTransactionDetailViewModel(
                 }
 
                 _ = SetKategorieAsync(value.KategorieId);
+                _ = SetAccountAsync(value.AccountId);
                 Interval = value.Interval;
                 IntervalFactor = value.IntervalFactor;
                 IntervalFactorText = value.IntervalFactor.ToString();
@@ -128,10 +135,13 @@ public partial class RecurringTransactionDetailViewModel(
     [RelayCommand]
     private async Task LoadKategorien()
     {
-        var currentId = SelectedKategorie?.Id ?? _existing?.KategorieId;
-        var data = await _loadRecurringTransactionDetailDataUseCase.ExecuteAsync(currentId);
+        var currentCategoryId = SelectedKategorie?.Id ?? _existing?.KategorieId;
+        var currentAccountId = SelectedAccount?.Id ?? _existing?.AccountId;
+        var data = await _loadRecurringTransactionDetailDataUseCase.ExecuteAsync(currentCategoryId, currentAccountId);
         Kategorien = new ObservableCollection<Category>(data.Kategorien);
+        Accounts = new ObservableCollection<Account>(data.Accounts);
         SelectedKategorie = data.SelectedKategorie;
+        SelectedAccount = data.SelectedAccount;
     }
 
     [RelayCommand]
@@ -189,6 +199,7 @@ public partial class RecurringTransactionDetailViewModel(
             betrag,
             Titel,
             SelectedKategorie!.Id,
+            SelectedAccount?.Id,
             Typ,
             Startdatum,
             HatEnddatum ? EnddatumWert : null,
@@ -289,6 +300,23 @@ public partial class RecurringTransactionDetailViewModel(
         catch (Exception ex)
         {
             _logger?.LogWarning(ex, "Fehler beim Laden der Kategorie");
+        }
+    }
+
+    private async Task SetAccountAsync(string? accountId)
+    {
+        try
+        {
+            if (Accounts.Count == 0)
+                await LoadKategorien();
+
+            SelectedAccount = Accounts.FirstOrDefault(a => a.Id == accountId)
+                ?? Accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+                ?? Accounts.FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Fehler beim Laden des Kontos");
         }
     }
 }

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
@@ -13,7 +13,6 @@ public partial class TransactionDetailViewModel(
     SaveTransactionDetailUseCase saveTransactionDetailUseCase,
     LoadTransactionDetailDataUseCase loadTransactionDetailDataUseCase,
     ITransactionValidationService validationService,
-    IAccountRepository accountRepository,
     ILocalizationService localizationService,
     INavigationService navigationService,
     IDialogService dialogService,
@@ -24,7 +23,6 @@ public partial class TransactionDetailViewModel(
     private readonly SaveTransactionDetailUseCase _saveTransactionDetailUseCase = saveTransactionDetailUseCase;
     private readonly LoadTransactionDetailDataUseCase _loadTransactionDetailDataUseCase = loadTransactionDetailDataUseCase;
     private readonly ITransactionValidationService _validationService = validationService;
-    private readonly IAccountRepository _accountRepository = accountRepository;
     private Transaction? _existingTransaction;
     private string? _selectedKategorieId;
     private string? _selectedAccountId;

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
@@ -13,6 +13,7 @@ public partial class TransactionDetailViewModel(
     SaveTransactionDetailUseCase saveTransactionDetailUseCase,
     LoadTransactionDetailDataUseCase loadTransactionDetailDataUseCase,
     ITransactionValidationService validationService,
+    IAccountRepository accountRepository,
     ILocalizationService localizationService,
     INavigationService navigationService,
     IDialogService dialogService,
@@ -23,8 +24,10 @@ public partial class TransactionDetailViewModel(
     private readonly SaveTransactionDetailUseCase _saveTransactionDetailUseCase = saveTransactionDetailUseCase;
     private readonly LoadTransactionDetailDataUseCase _loadTransactionDetailDataUseCase = loadTransactionDetailDataUseCase;
     private readonly ITransactionValidationService _validationService = validationService;
+    private readonly IAccountRepository _accountRepository = accountRepository;
     private Transaction? _existingTransaction;
     private string? _selectedKategorieId;
+    private string? _selectedAccountId;
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
@@ -50,10 +53,16 @@ public partial class TransactionDetailViewModel(
     private Category? selectedKategorie;
 
     [ObservableProperty]
+    private Account? selectedAccount;
+
+    [ObservableProperty]
     private TransactionType typ = TransactionType.Ausgabe;
 
     [ObservableProperty]
     private ObservableCollection<Category> kategorien = [];
+
+    [ObservableProperty]
+    private ObservableCollection<Account> accounts = [];
 
     public Transaction? Transaction
     {
@@ -63,6 +72,7 @@ public partial class TransactionDetailViewModel(
             {
                 _existingTransaction = value;
                 _selectedKategorieId = value.KategorieId;
+                _selectedAccountId = value.AccountId;
                 BetragText = value.Betrag.ToString("F2", System.Globalization.CultureInfo.CurrentCulture);
                 Titel = value.Titel;
                 Verwendungszweck = value.Verwendungszweck ?? string.Empty;
@@ -94,9 +104,13 @@ public partial class TransactionDetailViewModel(
     [RelayCommand]
     private async Task LoadKategorien()
     {
-        var data = await _loadTransactionDetailDataUseCase.ExecuteAsync(_selectedKategorieId ?? _existingTransaction?.KategorieId);
+        var data = await _loadTransactionDetailDataUseCase.ExecuteAsync(
+            _selectedKategorieId ?? _existingTransaction?.KategorieId,
+            _selectedAccountId ?? _existingTransaction?.AccountId);
         Kategorien = new ObservableCollection<Category>(data.Kategorien);
         SelectedKategorie = data.SelectedKategorie;
+        Accounts = new ObservableCollection<Account>(data.Accounts);
+        SelectedAccount = data.SelectedAccount;
     }
 
     [RelayCommand]
@@ -140,6 +154,7 @@ public partial class TransactionDetailViewModel(
                 Titel,
                 Datum,
                 SelectedKategorie!.Id,
+                _selectedAccountId ?? SelectedAccount?.Id,
                 Typ,
                 Verwendungszweck);
             await _navigationService.GoBackAsync();
@@ -189,6 +204,7 @@ public partial class TransactionDetailViewModel(
             Titel = Titel,
             Betrag = betrag,
             KategorieId = SelectedKategorie!.Id,
+            AccountId = _selectedAccountId ?? SelectedAccount?.Id,
             Typ = Typ,
             Verwendungszweck = Verwendungszweck ?? string.Empty
         };
@@ -219,6 +235,31 @@ public partial class TransactionDetailViewModel(
         }
     }
 
+    private async Task SetAccountAsync(string? accountId)
+    {
+        _selectedAccountId = accountId;
+
+        try
+        {
+            if (Accounts.Count == 0)
+            {
+                await LoadKategorien();
+                return;
+            }
+
+            SelectedAccount = accountId == null
+                ? Accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+                    ?? Accounts.FirstOrDefault()
+                : Accounts.FirstOrDefault(a => a.Id == accountId)
+                    ?? Accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+                    ?? Accounts.FirstOrDefault();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Fehler beim Laden des Kontos");
+        }
+    }
+
     private void ApplyTransactionDraft(Transaction source, DateTime datum)
     {
         _existingTransaction = null;
@@ -228,7 +269,9 @@ public partial class TransactionDetailViewModel(
         Datum = datum;
         Typ = source.Typ;
         _selectedKategorieId = source.KategorieId;
+        _selectedAccountId = source.AccountId;
         _ = SetKategorieAsync(source.KategorieId);
+        _ = SetAccountAsync(source.AccountId);
     }
 
     private void ApplyTemplateDraft(TransactionTemplate template)
@@ -240,6 +283,8 @@ public partial class TransactionDetailViewModel(
         Datum = _clock.Today;
         Typ = template.Typ;
         _selectedKategorieId = template.KategorieId;
+        _selectedAccountId = template.AccountId;
         _ = SetKategorieAsync(template.KategorieId);
+        _ = SetAccountAsync(template.AccountId);
     }
 }

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -397,10 +397,10 @@ public partial class TransactionsViewModel(
     private async Task DeleteTransaktion(Transaction transaktion)
     {
         var dialogTitle = transaktion.IsTransfer
-            ? "Umbuchung löschen"
+            ? _loc.GetString(ResourceKeys.Dlg_UmbuchungLoeschen)
             : _loc.GetString(ResourceKeys.Dlg_TransaktionLoeschen);
         var dialogText = transaktion.IsTransfer
-            ? $"Umbuchung \"{transaktion.Titel}\" wirklich löschen? Beide Buchungen werden entfernt."
+            ? _loc.GetString(ResourceKeys.Dlg_UmbuchungLoeschenFrage, transaktion.Titel)
             : _loc.GetString(ResourceKeys.Dlg_TransaktionLoeschenFrage, transaktion.Titel);
         var confirm = await _dialogService.ShowConfirmationAsync(
             dialogTitle,
@@ -444,7 +444,7 @@ public partial class TransactionsViewModel(
             {
                 await _dialogService.ShowAlertAsync(
                     _loc.GetString(ResourceKeys.Err_Titel),
-                    "Umbuchungen können nicht als Einzelbuchung bearbeitet werden.",
+                    _loc.GetString(ResourceKeys.Err_UmbuchungNichtBearbeitbar),
                     _loc.GetString(ResourceKeys.Btn_OK));
                 return;
             }

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -20,6 +20,7 @@ public partial class TransactionsViewModel(
     IDialogService dialogService,
     ILocalizationService localizationService,
     ICategoryRepository categoryRepository,
+    IAccountRepository accountRepository,
     IMainThreadDispatcher dispatcher,
     IFilePicker filePicker,
     IAppEvents appEvents,
@@ -39,6 +40,7 @@ public partial class TransactionsViewModel(
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILocalizationService _loc = localizationService;
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
+    private readonly IAccountRepository _accountRepository = accountRepository;
     private readonly IMainThreadDispatcher _dispatcher = dispatcher;
     private readonly IFilePicker _filePicker = filePicker;
     private readonly IAppEvents _appEvents = appEvents;
@@ -66,6 +68,9 @@ public partial class TransactionsViewModel(
 
     [ObservableProperty]
     private Dictionary<string, string> iconMap = [];
+
+    [ObservableProperty]
+    private Dictionary<string, string> accountMap = [];
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(HasTransactionTemplates))]
@@ -129,8 +134,12 @@ public partial class TransactionsViewModel(
     [ObservableProperty]
     private ObservableCollection<KategorieFilterItem> availableKategorien = [];
 
+    [ObservableProperty]
+    private ObservableCollection<KategorieFilterItem> availableKonten = [];
+
     public bool IsFilterActive =>
         SelectedKategorieId != null ||
+        SelectedAccountId != null ||
         SelectedTypFilter != TransactionTypeFilter.Alle ||
         IsDateFilterEnabled;
 
@@ -153,6 +162,12 @@ public partial class TransactionsViewModel(
 
     [ObservableProperty]
     private KategorieFilterItem? selectedKategorieFilterItem;
+
+    [ObservableProperty]
+    private KategorieFilterItem? selectedKontoFilterItem;
+
+    [ObservableProperty]
+    private string? selectedAccountId = null;
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsFilterActive))]
@@ -191,6 +206,11 @@ public partial class TransactionsViewModel(
         SelectedKategorieId = value?.Id;
     }
 
+    partial void OnSelectedKontoFilterItemChanged(KategorieFilterItem? value)
+    {
+        SelectedAccountId = value?.Id;
+    }
+
     partial void OnIsDateFilterEnabledChanged(bool value)
     {
         VonDatum = value ? VonDatumPicker : null;
@@ -212,6 +232,7 @@ public partial class TransactionsViewModel(
 
     partial void OnSearchTextChanged(string value) => TriggerSearchDebounced();
     partial void OnSelectedKategorieIdChanged(string? value) => TriggerSearchDebounced();
+    partial void OnSelectedAccountIdChanged(string? value) => TriggerSearchDebounced();
     partial void OnSelectedTypFilterChanged(TransactionTypeFilter value) => TriggerSearchDebounced();
     partial void OnVonDatumChanged(DateTime? value) => TriggerSearchDebounced();
     partial void OnBisDatumChanged(DateTime? value) => TriggerSearchDebounced();
@@ -250,6 +271,7 @@ public partial class TransactionsViewModel(
             var query = new SearchTransactionsQuery(
                 SearchText: SearchText.Trim(),
                 KategorieId: SelectedKategorieId,
+                AccountId: SelectedAccountId,
                 Typ: SelectedTypFilter,
                 VonDatum: VonDatum,
                 BisDatum: BisDatum);
@@ -258,6 +280,7 @@ public partial class TransactionsViewModel(
             SearchErgebnisGruppen = new ObservableCollection<TransactionGroup>(result.Gruppen);
             TotalSearchCount = result.TotalCount;
             IconMap = result.IconMap;
+            AccountMap = result.AccountMap;
         }
         catch (Exception ex)
         {
@@ -287,6 +310,8 @@ public partial class TransactionsViewModel(
         SearchText = string.Empty;
         SelectedKategorieId = null;
         SelectedKategorieFilterItem = AvailableKategorien.FirstOrDefault();
+        SelectedAccountId = null;
+        SelectedKontoFilterItem = AvailableKonten.FirstOrDefault();
         SelectedTypFilter = TransactionTypeFilter.Alle;
         SelectedTypIndex = 0;
         IsDateFilterEnabled = false;
@@ -313,6 +338,19 @@ public partial class TransactionsViewModel(
         SelectedKategorieFilterItem = items[0];
     }
 
+    private async Task LoadKontenAsync()
+    {
+        var konten = await _accountRepository.GetAccountsAsync();
+        var items = new ObservableCollection<KategorieFilterItem>
+        {
+            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten))
+        };
+        foreach (var konto in konten.OrderBy(k => k.Name))
+            items.Add(new KategorieFilterItem(konto.Id, konto.Name));
+        AvailableKonten = items;
+        SelectedKontoFilterItem = items.FirstOrDefault(i => i.Id == SelectedAccountId) ?? items[0];
+    }
+
     [RelayCommand]
     private async Task LoadTransaktionen()
     {
@@ -321,12 +359,15 @@ public partial class TransactionsViewModel(
 
         try
         {
-            var data = await _loadTransactionsMonthUseCase.ExecuteAsync(AktuellerMonat);
+            var data = await _loadTransactionsMonthUseCase.ExecuteAsync(AktuellerMonat, SelectedAccountId);
             TransaktionsGruppen = new ObservableCollection<TransactionGroup>(data.Gruppen);
             IconMap = data.IconMap;
+            AccountMap = data.AccountMap;
 
             if (AvailableKategorien.Count == 0)
                 await LoadKategorienAsync();
+            if (AvailableKonten.Count == 0)
+                await LoadKontenAsync();
 
             await LoadTemplatesAsync();
         }
@@ -481,7 +522,7 @@ public partial class TransactionsViewModel(
             if (result == null) return;
 
             using var stream = await result.OpenReadAsync();
-            var preview = await _importService.AnalyzeCsvAsync(stream);
+            var preview = await _importService.AnalyzeCsvAsync(stream, SelectedAccountId);
 
             if (!preview.Success)
             {

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -396,22 +396,34 @@ public partial class TransactionsViewModel(
     [RelayCommand]
     private async Task DeleteTransaktion(Transaction transaktion)
     {
+        var dialogTitle = transaktion.IsTransfer
+            ? "Umbuchung löschen"
+            : _loc.GetString(ResourceKeys.Dlg_TransaktionLoeschen);
+        var dialogText = transaktion.IsTransfer
+            ? $"Umbuchung \"{transaktion.Titel}\" wirklich löschen? Beide Buchungen werden entfernt."
+            : _loc.GetString(ResourceKeys.Dlg_TransaktionLoeschenFrage, transaktion.Titel);
         var confirm = await _dialogService.ShowConfirmationAsync(
-            _loc.GetString(ResourceKeys.Dlg_TransaktionLoeschen),
-            _loc.GetString(ResourceKeys.Dlg_TransaktionLoeschenFrage, transaktion.Titel),
+            dialogTitle,
+            dialogText,
             _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
         if (!confirm) return;
 
         try
         {
+            if (transaktion.IsTransfer && !string.IsNullOrWhiteSpace(transaktion.TransferGroupId))
+            {
+                await _deleteTransactionUseCase.ExecuteTransferGroupAsync(transaktion.TransferGroupId);
+                await LoadTransaktionen();
+                return;
+            }
+
             await _deleteTransactionUseCase.ExecuteAsync(transaktion.Id);
             var gruppe = TransaktionsGruppen.FirstOrDefault(g => g.Contains(transaktion));
-            if (gruppe != null)
-            {
-                gruppe.Remove(transaktion);
-                if (gruppe.Count == 0)
-                    TransaktionsGruppen.Remove(gruppe);
-            }
+            if (gruppe == null) return;
+
+            gruppe.Remove(transaktion);
+            if (gruppe.Count == 0)
+                TransaktionsGruppen.Remove(gruppe);
         }
         catch (Exception ex)
         {
@@ -428,6 +440,15 @@ public partial class TransactionsViewModel(
     {
         try
         {
+            if (transaktion?.IsTransfer == true)
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Err_Titel),
+                    "Umbuchungen können nicht als Einzelbuchung bearbeitet werden.",
+                    _loc.GetString(ResourceKeys.Btn_OK));
+                return;
+            }
+
             _logger?.LogDebug("GoToDetail called for transaction {Id}", transaktion?.Id ?? "(new)");
 
             var parameter = new Dictionary<string, object>();
@@ -476,6 +497,12 @@ public partial class TransactionsViewModel(
         {
             ["TransactionTemplate"] = template
         });
+    }
+
+    [RelayCommand]
+    private async Task GoToTransfer()
+    {
+        await _navigationService.GoToAsync(Routes.TransferDetail);
     }
 
     [RelayCommand]

--- a/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
@@ -88,12 +88,16 @@ public partial class TransferDetailViewModel(
 
         try
         {
+            var title = string.IsNullOrWhiteSpace(Title)
+                ? _loc.GetString(ResourceKeys.Title_Umbuchung)
+                : Title.Trim();
+
             await _saveTransferUseCase.ExecuteAsync(
                 SourceAccount.Id,
                 TargetAccount.Id,
                 amount,
                 Date,
-                Title,
+                title,
                 Note);
 
             await _navigationService.GoBackAsync();

--- a/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
@@ -41,17 +41,21 @@ public partial class TransferDetailViewModel(
     private string amountText = string.Empty;
 
     [ObservableProperty]
-    private string title = "Umbuchung";
+    private string title = string.Empty;
 
     [ObservableProperty]
     private string note = string.Empty;
 
     [ObservableProperty]
-    private DateTime date = Finanzuebersicht.Core.Services.SystemClock.Instance.Today;
+    private DateTime date;
 
     [RelayCommand]
     private async Task LoadAccounts()
     {
+        Date = _clock.Today;
+        if (string.IsNullOrWhiteSpace(Title))
+            Title = _loc.GetString(ResourceKeys.Title_Umbuchung);
+
         var accounts = await _accountRepository.GetAccountsAsync();
         var active = accounts.Where(a => !a.IsArchived).OrderBy(a => a.Name).ToList();
         Accounts = new ObservableCollection<Account>(active);
@@ -77,7 +81,7 @@ public partial class TransferDetailViewModel(
         {
             await _dialogService.ShowAlertAsync(
                 _loc.GetString(ResourceKeys.Err_Titel),
-                "Bitte unterschiedliche Quell- und Zielkonten auswählen.",
+                _loc.GetString(ResourceKeys.Err_TransferKontenUnterschiedlich),
                 _loc.GetString(ResourceKeys.Btn_OK));
             return;
         }

--- a/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
@@ -1,0 +1,106 @@
+using System.Collections.ObjectModel;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Resources.Strings;
+using Microsoft.Extensions.Logging;
+
+namespace Finanzuebersicht.ViewModels;
+
+public partial class TransferDetailViewModel(
+    SaveTransferUseCase saveTransferUseCase,
+    IAccountRepository accountRepository,
+    INavigationService navigationService,
+    IDialogService dialogService,
+    ILocalizationService localizationService,
+    ILogger<TransferDetailViewModel>? logger = null,
+    Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel
+{
+    private readonly SaveTransferUseCase _saveTransferUseCase = saveTransferUseCase;
+    private readonly IAccountRepository _accountRepository = accountRepository;
+    private readonly INavigationService _navigationService = navigationService;
+    private readonly IDialogService _dialogService = dialogService;
+    private readonly ILocalizationService _loc = localizationService;
+    private readonly ILogger<TransferDetailViewModel>? _logger = logger;
+    private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadAccountsCommand;
+
+    [ObservableProperty]
+    private ObservableCollection<Account> accounts = [];
+
+    [ObservableProperty]
+    private Account? sourceAccount;
+
+    [ObservableProperty]
+    private Account? targetAccount;
+
+    [ObservableProperty]
+    private string amountText = string.Empty;
+
+    [ObservableProperty]
+    private string title = "Umbuchung";
+
+    [ObservableProperty]
+    private string note = string.Empty;
+
+    [ObservableProperty]
+    private DateTime date = Finanzuebersicht.Core.Services.SystemClock.Instance.Today;
+
+    [RelayCommand]
+    private async Task LoadAccounts()
+    {
+        var accounts = await _accountRepository.GetAccountsAsync();
+        var active = accounts.Where(a => !a.IsArchived).OrderBy(a => a.Name).ToList();
+        Accounts = new ObservableCollection<Account>(active);
+
+        SourceAccount = active.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+            ?? active.FirstOrDefault();
+        TargetAccount = active.FirstOrDefault(a => a.Id != SourceAccount?.Id);
+    }
+
+    [RelayCommand]
+    private async Task Save()
+    {
+        if (!decimal.TryParse(AmountText, System.Globalization.NumberStyles.Any, System.Globalization.CultureInfo.CurrentCulture, out var amount) || amount <= 0)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_BetragGroesserNull),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        if (SourceAccount == null || TargetAccount == null || SourceAccount.Id == TargetAccount.Id)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                "Bitte unterschiedliche Quell- und Zielkonten auswählen.",
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        try
+        {
+            await _saveTransferUseCase.ExecuteAsync(
+                SourceAccount.Id,
+                TargetAccount.Id,
+                amount,
+                Date,
+                Title,
+                Note);
+
+            await _navigationService.GoBackAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "Error saving transfer");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+}

--- a/Finanzuebersicht.Tests/Application/UseCases/Accounts/AccountUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/Accounts/AccountUseCaseTests.cs
@@ -1,0 +1,72 @@
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Tests.Application.UseCases.Accounts;
+
+public class AccountUseCaseTests
+{
+    [Fact]
+    public async Task SaveAccountDetailUseCase_PersistsNameAndType()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.SaveAccountAsync(Arg.Any<Account>()).Returns(Task.CompletedTask);
+
+        var sut = new SaveAccountDetailUseCase(repository);
+
+        var saved = await sut.ExecuteAsync(null, "Tagesgeld", AccountType.Tagesgeld);
+
+        await repository.Received(1).SaveAccountAsync(Arg.Is<Account>(a =>
+            a.Name == "Tagesgeld" &&
+            a.Type == AccountType.Tagesgeld));
+        Assert.Equal("Tagesgeld", saved.Name);
+        Assert.Equal(AccountType.Tagesgeld, saved.Type);
+    }
+
+    [Fact]
+    public async Task DeleteAccountUseCase_ReassignsTransactionsAndTemplates()
+    {
+        var defaultAccount = new Account { Id = "acc-default", Name = "Girokonto", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default };
+        var accountToDelete = new Account { Id = "acc-old", Name = "Alt" };
+
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account> { defaultAccount, accountToDelete });
+        accountRepository.DeleteAccountAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Id = "t1", AccountId = "acc-old" }
+            });
+        transactionRepository.SaveTransactionAsync(Arg.Any<Transaction>()).Returns(Task.CompletedTask);
+
+        var templateRepository = Substitute.For<ITransactionTemplateRepository>();
+        templateRepository.GetTransactionTemplatesAsync().Returns(new List<TransactionTemplate>
+        {
+            new() { Id = "tpl1", AccountId = "acc-old" }
+        });
+        templateRepository.SaveTransactionTemplateAsync(Arg.Any<TransactionTemplate>()).Returns(Task.CompletedTask);
+
+        var sut = new DeleteAccountUseCase(accountRepository, transactionRepository, templateRepository);
+
+        await sut.ExecuteAsync("acc-old");
+
+        await transactionRepository.Received(1).SaveTransactionAsync(Arg.Is<Transaction>(t => t.AccountId == "acc-default"));
+        await templateRepository.Received(1).SaveTransactionTemplateAsync(Arg.Is<TransactionTemplate>(t => t.AccountId == "acc-default"));
+        await accountRepository.Received(1).DeleteAccountAsync("acc-old");
+    }
+
+    [Fact]
+    public async Task DeleteAccountUseCase_RejectsDefaultAccount()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-default", Name = "Girokonto", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        });
+
+        var sut = new DeleteAccountUseCase(accountRepository, Substitute.For<ITransactionRepository>(), Substitute.For<ITransactionTemplateRepository>());
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() => sut.ExecuteAsync("acc-default"));
+    }
+}

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardMonthUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardMonthUseCaseTests.cs
@@ -213,6 +213,55 @@ public class LoadDashboardMonthUseCaseTests
     }
 
     [Fact]
+    public async Task ExecuteAsync_ForecastRecurring_AppliesAccountFilter()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-a", Name = "Abo", Typ = TransactionType.Ausgabe }
+        });
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+        recurringRepository.GetRecurringTransactionsAsync().Returns(new List<RecurringTransaction>
+        {
+            new()
+            {
+                Id = "rec-1",
+                Titel = "Streaming",
+                Betrag = 15m,
+                KategorieId = "cat-a",
+                AccountId = "acc-1",
+                Typ = TransactionType.Ausgabe,
+                Aktiv = true,
+                Startdatum = new DateTime(2025, 1, 1)
+            },
+            new()
+            {
+                Id = "rec-2",
+                Titel = "Gym",
+                Betrag = 50m,
+                KategorieId = "cat-a",
+                AccountId = "acc-2",
+                Typ = TransactionType.Ausgabe,
+                Aktiv = true,
+                Startdatum = new DateTime(2025, 1, 1)
+            }
+        });
+
+        var useCase = new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringRepository, Substitute.For<IBudgetRepository>());
+
+        var result = await useCase.ExecuteAsync(new DateTime(2026, 4, 1), new DateTime(2026, 3, 15), "acc-1");
+
+        Assert.True(result.IstPrognose);
+        Assert.Equal(15m, result.GesamtAusgaben);
+        Assert.Single(result.KategorieAusgaben);
+        Assert.Equal(15m, result.KategorieAusgaben[0].Total);
+    }
+
+    [Fact]
     public async Task ExecuteAsync_ExcludesTransfers_AndAppliesAccountFilter()
     {
         var categoryRepository = Substitute.For<ICategoryRepository>();

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardMonthUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardMonthUseCaseTests.cs
@@ -21,8 +21,8 @@ public class LoadDashboardMonthUseCaseTests
         transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>
             {
-                new() { Typ = TransactionType.Einnahme, Betrag = 2000m, KategorieId = "cat-a" },
-                new() { Typ = TransactionType.Ausgabe, Betrag = 800m, KategorieId = "cat-b" }
+                new() { Typ = TransactionType.Einnahme, Betrag = 2000m, KategorieId = "cat-a", AccountId = "acc-1" },
+                new() { Typ = TransactionType.Ausgabe, Betrag = 800m, KategorieId = "cat-b", AccountId = "acc-2" }
             });
 
         var useCase = new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringRepository, Substitute.For<IBudgetRepository>());

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardMonthUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardMonthUseCaseTests.cs
@@ -211,4 +211,33 @@ public class LoadDashboardMonthUseCaseTests
         Assert.False(hint.IstWarnung);
         Assert.False(hint.IstAusgeschoepft);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_ExcludesTransfers_AndAppliesAccountFilter()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var budgetRepository = Substitute.For<IBudgetRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-food", Name = "Food", Typ = TransactionType.Ausgabe }
+        });
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Typ = TransactionType.Ausgabe, Betrag = 100m, KategorieId = "cat-food", AccountId = "acc-1", IsTransfer = false },
+                new() { Typ = TransactionType.Ausgabe, Betrag = 40m, KategorieId = "cat-food", AccountId = "acc-1", IsTransfer = true },
+                new() { Typ = TransactionType.Ausgabe, Betrag = 30m, KategorieId = "cat-food", AccountId = "acc-2", IsTransfer = false }
+            });
+
+        var useCase = new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringRepository, budgetRepository);
+
+        var result = await useCase.ExecuteAsync(new DateTime(2026, 3, 1), new DateTime(2026, 3, 15), "acc-1");
+
+        Assert.Equal(100m, result.GesamtAusgaben);
+        Assert.Single(result.KategorieAusgaben);
+        Assert.Equal(100m, result.KategorieAusgaben[0].Total);
+    }
 }

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardYearUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadDashboardYearUseCaseTests.cs
@@ -9,41 +9,52 @@ public class LoadDashboardYearUseCaseTests
     [Fact]
     public async Task ExecuteAsync_ReturnsFilteredCategoriesAndPercentages()
     {
-        var reportingService = Substitute.For<IReportingService>();
-        reportingService.GetYearSummaryAsync(2026).Returns(new YearSummary
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
-            Total = 100m,
-            Months = new List<MonthSummary> { new() { Month = 1, Total = 40m }, new() { Month = 2, Total = 60m } },
-            ByCategory = new List<CategorySummary>
-            {
-                new() { CategoryId = "cat-1", CategoryName = "Miete", Total = 60m },
-                new() { CategoryId = "cat-2", CategoryName = "", Total = 40m }
-            }
+            new() { Id = "cat-1", Name = "Miete" },
+            new() { Id = "cat-2", Name = "Mobilität" }
+        });
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>()).Returns(new List<Transaction>
+        {
+            new() { KategorieId = "cat-1", Typ = TransactionType.Ausgabe, Betrag = 60m, Datum = new DateTime(2026, 1, 5), AccountId = "acc-1" },
+            new() { KategorieId = "cat-2", Typ = TransactionType.Ausgabe, Betrag = 40m, Datum = new DateTime(2026, 2, 3), AccountId = "acc-1" },
+            new() { KategorieId = "cat-2", Typ = TransactionType.Ausgabe, Betrag = 20m, Datum = new DateTime(2026, 2, 8), AccountId = "acc-2", IsTransfer = true }
         });
 
-        var sut = new LoadDashboardYearUseCase(reportingService);
+        var sut = new LoadDashboardYearUseCase(transactionRepository, categoryRepository);
 
-        var result = await sut.ExecuteAsync(2026);
+        var result = await sut.ExecuteAsync(2026, "acc-1");
 
         Assert.Equal(100m, result.GesamtAusgaben);
-        Assert.Equal(2, result.Monate.Count);
-        Assert.Single(result.Kategorien);
-        Assert.Equal("cat-1", result.Kategorien[0].CategoryId);
-        Assert.Equal(60m, result.Kategorien[0].PercentageAmount);
+        Assert.Equal(12, result.Monate.Count);
+        Assert.Equal(2, result.Kategorien.Count);
+        Assert.Contains(result.Kategorien, c => c.CategoryId == "cat-1" && c.Total == 60m);
+        Assert.Contains(result.Kategorien, c => c.CategoryId == "cat-2" && c.Total == 40m);
     }
 
     [Fact]
-    public async Task ExecuteAsync_ReturnsEmptyData_WhenSummaryIsNull()
+    public async Task ExecuteAsync_ExcludesTransfers()
     {
-        var reportingService = Substitute.For<IReportingService>();
-        reportingService.GetYearSummaryAsync(2026).Returns(Task.FromResult((YearSummary)null!));
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-1", Name = "Miete" }
+        });
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>()).Returns(new List<Transaction>
+        {
+            new() { KategorieId = "cat-1", Typ = TransactionType.Ausgabe, Betrag = 120m, Datum = new DateTime(2026, 1, 5), IsTransfer = true },
+            new() { KategorieId = "cat-1", Typ = TransactionType.Ausgabe, Betrag = 80m, Datum = new DateTime(2026, 1, 8), IsTransfer = false }
+        });
 
-        var sut = new LoadDashboardYearUseCase(reportingService);
+        var sut = new LoadDashboardYearUseCase(transactionRepository, categoryRepository);
 
         var result = await sut.ExecuteAsync(2026);
 
-        Assert.Equal(0m, result.GesamtAusgaben);
-        Assert.Empty(result.Monate);
-        Assert.Empty(result.Kategorien);
+        Assert.Equal(80m, result.GesamtAusgaben);
+        Assert.Single(result.Kategorien);
+        Assert.Equal(80m, result.Kategorien[0].Total);
     }
 }

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadRecurringTransactionDetailDataUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadRecurringTransactionDetailDataUseCaseTests.cs
@@ -10,37 +10,53 @@ public class LoadRecurringTransactionDetailDataUseCaseTests
     public async Task ExecuteAsync_SelectsCategory_WhenIdExists()
     {
         var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
         categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
             new() { Id = "cat-1", Name = "Lebensmittel" },
             new() { Id = "cat-2", Name = "Miete" }
         });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Girokonto", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        });
 
-        var sut = new LoadRecurringTransactionDetailDataUseCase(categoryRepository);
+        var sut = new LoadRecurringTransactionDetailDataUseCase(categoryRepository, accountRepository);
 
-        var result = await sut.ExecuteAsync("cat-2");
+        var result = await sut.ExecuteAsync("cat-2", "acc-1");
 
         Assert.Equal(2, result.Kategorien.Count);
         Assert.NotNull(result.SelectedKategorie);
         Assert.Equal("cat-2", result.SelectedKategorie!.Id);
+        Assert.NotNull(result.SelectedAccount);
+        Assert.Equal("acc-1", result.SelectedAccount!.Id);
         await categoryRepository.Received(1).GetCategoriesAsync();
+        await accountRepository.Received(1).GetAccountsAsync();
     }
 
     [Fact]
     public async Task ExecuteAsync_ReturnsNullSelection_WhenIdNotFound()
     {
         var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
         categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
             new() { Id = "cat-1", Name = "Lebensmittel" }
         });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Girokonto", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        });
 
-        var sut = new LoadRecurringTransactionDetailDataUseCase(categoryRepository);
+        var sut = new LoadRecurringTransactionDetailDataUseCase(categoryRepository, accountRepository);
 
-        var result = await sut.ExecuteAsync("cat-x");
+        var result = await sut.ExecuteAsync("cat-x", "acc-x");
 
         Assert.Single(result.Kategorien);
         Assert.Null(result.SelectedKategorie);
+        Assert.NotNull(result.SelectedAccount);
+        Assert.Equal("acc-1", result.SelectedAccount!.Id);
         await categoryRepository.Received(1).GetCategoriesAsync();
+        await accountRepository.Received(1).GetAccountsAsync();
     }
 }

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadRecurringTransactionDetailDataUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadRecurringTransactionDetailDataUseCaseTests.cs
@@ -59,4 +59,29 @@ public class LoadRecurringTransactionDetailDataUseCaseTests
         await categoryRepository.Received(1).GetCategoriesAsync();
         await accountRepository.Received(1).GetAccountsAsync();
     }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsActiveAccounts_AndSelectedArchivedFallback()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-1", Name = "Lebensmittel" }
+        });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Giro", IsArchived = false, SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default },
+            new() { Id = "acc-2", Name = "Archiv", IsArchived = true }
+        });
+
+        var sut = new LoadRecurringTransactionDetailDataUseCase(categoryRepository, accountRepository);
+
+        var result = await sut.ExecuteAsync("cat-1", "acc-2");
+
+        Assert.Equal("acc-2", result.SelectedAccount!.Id);
+        Assert.Equal(2, result.Accounts.Count);
+        Assert.Contains(result.Accounts, a => a.Id == "acc-1");
+        Assert.Contains(result.Accounts, a => a.Id == "acc-2");
+    }
 }

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadTransactionDetailDataUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadTransactionDetailDataUseCaseTests.cs
@@ -84,4 +84,28 @@ public class LoadTransactionDetailDataUseCaseTests
         Assert.NotNull(result.SelectedKategorie);
         Assert.Equal("cat-1", result.SelectedKategorie!.Id);
     }
+
+    [Fact]
+    public async Task ExecuteAsync_HidesArchivedAccounts_ButKeepsSelectedArchived()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "cat-1", Name = "Lebensmittel" }
+        });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Aktivkonto", IsArchived = false },
+            new() { Id = "acc-2", Name = "Altkonto", IsArchived = true }
+        });
+
+        var sut = new LoadTransactionDetailDataUseCase(categoryRepository, accountRepository);
+
+        var result = await sut.ExecuteAsync("cat-1", "acc-2");
+
+        Assert.Equal("acc-2", result.SelectedAccount!.Id);
+        Assert.Equal(2, result.Accounts.Count);
+        Assert.Contains(result.Accounts, a => a.Id == "acc-2");
+    }
 }

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadTransactionDetailDataUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadTransactionDetailDataUseCaseTests.cs
@@ -10,56 +10,77 @@ public class LoadTransactionDetailDataUseCaseTests
     public async Task ExecuteAsync_SelectsCategory_WhenIdExists()
     {
         var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
         categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
             new() { Id = "cat-1", Name = "Lebensmittel" },
             new() { Id = "cat-2", Name = "Miete" }
         });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Girokonto", Type = AccountType.Girokonto }
+        });
 
-        var sut = new LoadTransactionDetailDataUseCase(categoryRepository);
+        var sut = new LoadTransactionDetailDataUseCase(categoryRepository, accountRepository);
 
         var result = await sut.ExecuteAsync("cat-2");
 
         Assert.Equal(2, result.Kategorien.Count);
+        Assert.Single(result.Accounts);
         Assert.NotNull(result.SelectedKategorie);
         Assert.Equal("cat-2", result.SelectedKategorie!.Id);
+        Assert.NotNull(result.SelectedAccount);
+        Assert.Equal("acc-1", result.SelectedAccount!.Id);
         await categoryRepository.Received(1).GetCategoriesAsync();
+        await accountRepository.Received(1).GetAccountsAsync();
     }
 
     [Fact]
     public async Task ExecuteAsync_SelectsFallback_WhenIdNotFound()
     {
         var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
         categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
             new() { Id = "cat-1", Name = "Lebensmittel" },
             new() { Id = "cat-2", Name = "Sonstiges", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges }
         });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Girokonto", Type = AccountType.Girokonto, SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        });
 
-        var sut = new LoadTransactionDetailDataUseCase(categoryRepository);
+        var sut = new LoadTransactionDetailDataUseCase(categoryRepository, accountRepository);
 
         var result = await sut.ExecuteAsync("cat-x");
 
         Assert.Equal(2, result.Kategorien.Count);
+        Assert.Single(result.Accounts);
         Assert.NotNull(result.SelectedKategorie);
         Assert.Equal("cat-2", result.SelectedKategorie!.Id);
+        Assert.NotNull(result.SelectedAccount);
+        Assert.Equal("acc-1", result.SelectedAccount!.Id);
         await categoryRepository.Received(1).GetCategoriesAsync();
+        await accountRepository.Received(1).GetAccountsAsync();
     }
 
     [Fact]
     public async Task ExecuteAsync_SelectsFirstCategory_WhenFallbackMissing()
     {
         var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
         categoryRepository.GetCategoriesAsync().Returns(new List<Category>
         {
             new() { Id = "cat-1", Name = "Lebensmittel" }
         });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>());
 
-        var sut = new LoadTransactionDetailDataUseCase(categoryRepository);
+        var sut = new LoadTransactionDetailDataUseCase(categoryRepository, accountRepository);
 
         var result = await sut.ExecuteAsync("cat-x");
 
         Assert.Single(result.Kategorien);
+        Assert.Empty(result.Accounts);
         Assert.NotNull(result.SelectedKategorie);
         Assert.Equal("cat-1", result.SelectedKategorie!.Id);
     }

--- a/Finanzuebersicht.Tests/Application/UseCases/LoadTransactionsMonthUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/LoadTransactionsMonthUseCaseTests.cs
@@ -10,6 +10,7 @@ public class LoadTransactionsMonthUseCaseTests
     {
         var transactionRepository = Substitute.For<ITransactionRepository>();
         var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
 
         transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>
@@ -24,8 +25,13 @@ public class LoadTransactionsMonthUseCaseTests
             new() { Id = "c1", Icon = "🍔" },
             new() { Id = "c2", Icon = "🚗" }
         });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "a1", Name = "Giro" },
+            new() { Id = "a2", Name = "Tagesgeld" }
+        });
 
-        var useCase = new LoadTransactionsMonthUseCase(transactionRepository, categoryRepository);
+        var useCase = new LoadTransactionsMonthUseCase(transactionRepository, categoryRepository, accountRepository);
 
         var result = await useCase.ExecuteAsync(new DateTime(2026, 3, 1));
 
@@ -42,6 +48,7 @@ public class LoadTransactionsMonthUseCaseTests
     {
         var transactionRepository = Substitute.For<ITransactionRepository>();
         var categoryRepository = Substitute.For<ICategoryRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
 
         transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>());
@@ -51,12 +58,14 @@ public class LoadTransactionsMonthUseCaseTests
             new() { Id = "c1", Icon = "💼" },
             new() { Id = "c2", Icon = null! }
         });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>());
 
-        var useCase = new LoadTransactionsMonthUseCase(transactionRepository, categoryRepository);
+        var useCase = new LoadTransactionsMonthUseCase(transactionRepository, categoryRepository, accountRepository);
 
         var result = await useCase.ExecuteAsync(new DateTime(2026, 3, 1));
 
         Assert.Equal("💼", result.IconMap["c1"]);
         Assert.Equal("📁", result.IconMap["c2"]);
+        Assert.Empty(result.AccountMap);
     }
 }

--- a/Finanzuebersicht.Tests/Application/UseCases/SaveRecurringTransactionDetailUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/SaveRecurringTransactionDetailUseCaseTests.cs
@@ -11,7 +11,9 @@ public class SaveRecurringTransactionDetailUseCaseTests
     {
         var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
         var recurringGenerationService = Substitute.For<IRecurringGenerationService>();
-        var sut = new SaveRecurringTransactionDetailUseCase(recurringRepository, recurringGenerationService);
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account> { new() { Id = "acc-1", IsArchived = false } });
+        var sut = new SaveRecurringTransactionDetailUseCase(recurringRepository, recurringGenerationService, accountRepository);
 
         await sut.ExecuteAsync(
             existing: null,
@@ -42,6 +44,8 @@ public class SaveRecurringTransactionDetailUseCaseTests
     {
         var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
         var recurringGenerationService = Substitute.For<IRecurringGenerationService>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account> { new() { Id = "acc-2", IsArchived = false } });
         var existing = new RecurringTransaction
         {
             Id = "r-1",
@@ -53,7 +57,7 @@ public class SaveRecurringTransactionDetailUseCaseTests
             Enddatum = null,
             Aktiv = false
         };
-        var sut = new SaveRecurringTransactionDetailUseCase(recurringRepository, recurringGenerationService);
+        var sut = new SaveRecurringTransactionDetailUseCase(recurringRepository, recurringGenerationService, accountRepository);
 
         await sut.ExecuteAsync(
             existing,

--- a/Finanzuebersicht.Tests/Application/UseCases/SaveRecurringTransactionDetailUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/SaveRecurringTransactionDetailUseCaseTests.cs
@@ -18,6 +18,7 @@ public class SaveRecurringTransactionDetailUseCaseTests
             betrag: 49.99m,
             titel: "Streaming",
             kategorieId: "cat-1",
+            accountId: "acc-1",
             typ: TransactionType.Ausgabe,
             startdatum: new DateTime(2026, 3, 1),
             enddatum: new DateTime(2026, 12, 31),
@@ -28,6 +29,7 @@ public class SaveRecurringTransactionDetailUseCaseTests
                 r.Betrag == 49.99m &&
                 r.Titel == "Streaming" &&
                 r.KategorieId == "cat-1" &&
+                r.AccountId == "acc-1" &&
                 r.Typ == TransactionType.Ausgabe &&
                 r.Startdatum == new DateTime(2026, 3, 1) &&
                 r.Enddatum == new DateTime(2026, 12, 31) &&
@@ -58,6 +60,7 @@ public class SaveRecurringTransactionDetailUseCaseTests
             betrag: 120m,
             titel: "Neu",
             kategorieId: "cat-2",
+            accountId: "acc-2",
             typ: TransactionType.Einnahme,
             startdatum: new DateTime(2026, 4, 1),
             enddatum: null,
@@ -68,6 +71,7 @@ public class SaveRecurringTransactionDetailUseCaseTests
         Assert.Equal(120m, existing.Betrag);
         Assert.Equal("Neu", existing.Titel);
         Assert.Equal("cat-2", existing.KategorieId);
+        Assert.Equal("acc-2", existing.AccountId);
         Assert.Equal(TransactionType.Einnahme, existing.Typ);
         Assert.Equal(new DateTime(2026, 4, 1), existing.Startdatum);
         Assert.Null(existing.Enddatum);

--- a/Finanzuebersicht.Tests/Application/UseCases/SaveTransactionDetailUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/SaveTransactionDetailUseCaseTests.cs
@@ -18,6 +18,7 @@ public class SaveTransactionDetailUseCaseTests
             titel: "Einkauf",
             datum: new DateTime(2026, 3, 1),
             kategorieId: "cat-1",
+            accountId: "acc-1",
             typ: TransactionType.Ausgabe,
             verwendungszweck: "Zweck A");
 
@@ -27,6 +28,7 @@ public class SaveTransactionDetailUseCaseTests
                 t.Titel == "Einkauf" &&
                 t.Datum == new DateTime(2026, 3, 1) &&
                 t.KategorieId == "cat-1" &&
+                t.AccountId == "acc-1" &&
                 t.Typ == TransactionType.Ausgabe &&
                 t.Verwendungszweck == "Zweck A"));
     }
@@ -53,6 +55,7 @@ public class SaveTransactionDetailUseCaseTests
             titel: "Neu",
             datum: new DateTime(2026, 3, 2),
             kategorieId: "cat-2",
+            accountId: "acc-2",
             typ: TransactionType.Einnahme,
             verwendungszweck: "Gehaltszahlung");
 
@@ -62,6 +65,7 @@ public class SaveTransactionDetailUseCaseTests
         Assert.Equal("Neu", existing.Titel);
         Assert.Equal(new DateTime(2026, 3, 2), existing.Datum);
         Assert.Equal("cat-2", existing.KategorieId);
+        Assert.Equal("acc-2", existing.AccountId);
         Assert.Equal(TransactionType.Einnahme, existing.Typ);
         Assert.Equal("Gehaltszahlung", existing.Verwendungszweck);
     }

--- a/Finanzuebersicht.Tests/Application/UseCases/SaveTransactionDetailUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/SaveTransactionDetailUseCaseTests.cs
@@ -10,7 +10,9 @@ public class SaveTransactionDetailUseCaseTests
     public async Task ExecuteAsync_CreatesNewTransaction_WhenExistingIsNull()
     {
         var transactionRepository = Substitute.For<ITransactionRepository>();
-        var sut = new SaveTransactionDetailUseCase(transactionRepository);
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account> { new() { Id = "acc-1", IsArchived = false } });
+        var sut = new SaveTransactionDetailUseCase(transactionRepository, accountRepository);
 
         await sut.ExecuteAsync(
             existingTransaction: null,
@@ -37,6 +39,8 @@ public class SaveTransactionDetailUseCaseTests
     public async Task ExecuteAsync_UpdatesExistingTransaction_WhenProvided()
     {
         var transactionRepository = Substitute.For<ITransactionRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account> { new() { Id = "acc-2", IsArchived = false } });
         var existing = new Transaction
         {
             Id = "tx-1",
@@ -47,7 +51,7 @@ public class SaveTransactionDetailUseCaseTests
             Datum = new DateTime(2026, 1, 1)
         };
 
-        var sut = new SaveTransactionDetailUseCase(transactionRepository);
+        var sut = new SaveTransactionDetailUseCase(transactionRepository, accountRepository);
 
         await sut.ExecuteAsync(
             existingTransaction: existing,
@@ -68,5 +72,32 @@ public class SaveTransactionDetailUseCaseTests
         Assert.Equal("acc-2", existing.AccountId);
         Assert.Equal(TransactionType.Einnahme, existing.Typ);
         Assert.Equal("Gehaltszahlung", existing.Verwendungszweck);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ThrowsForTransferTransactions()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        var existing = new Transaction
+        {
+            Id = "tx-transfer",
+            IsTransfer = true,
+            TransferGroupId = "grp-1"
+        };
+
+        var sut = new SaveTransactionDetailUseCase(transactionRepository, accountRepository);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ExecuteAsync(
+                existing,
+                120m,
+                "Edit",
+                new DateTime(2026, 3, 2),
+                "cat-2",
+                "acc-2",
+                TransactionType.Einnahme,
+                "Zweck"));
+        await transactionRepository.DidNotReceive().SaveTransactionAsync(Arg.Any<Transaction>());
     }
 }

--- a/Finanzuebersicht.Tests/Application/UseCases/SaveTransactionDetailUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/SaveTransactionDetailUseCaseTests.cs
@@ -1,4 +1,5 @@
 using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Constants;
 using Finanzuebersicht.Models;
 using NSubstitute;
 
@@ -72,6 +73,30 @@ public class SaveTransactionDetailUseCaseTests
         Assert.Equal("acc-2", existing.AccountId);
         Assert.Equal(TransactionType.Einnahme, existing.Typ);
         Assert.Equal("Gehaltszahlung", existing.Verwendungszweck);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_UsesDefaultAccount_WhenAccountIdIsNull()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        var defaultAccount = new Account { Id = "acc-default", SystemKey = SystemAccountKeys.Default };
+        accountRepository.GetAccountsAsync().Returns(new List<Account> { defaultAccount });
+
+        var sut = new SaveTransactionDetailUseCase(transactionRepository, accountRepository);
+
+        await sut.ExecuteAsync(
+            existingTransaction: null,
+            betrag: 50m,
+            titel: "Test",
+            datum: new DateTime(2026, 3, 1),
+            kategorieId: "cat-1",
+            accountId: null,
+            typ: TransactionType.Ausgabe,
+            verwendungszweck: string.Empty);
+
+        await transactionRepository.Received(1).SaveTransactionAsync(
+            Arg.Is<Transaction>(t => t.AccountId == "acc-default"));
     }
 
     [Fact]

--- a/Finanzuebersicht.Tests/Application/UseCases/SaveTransferUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/SaveTransferUseCaseTests.cs
@@ -1,0 +1,45 @@
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Models;
+using NSubstitute;
+
+namespace Finanzuebersicht.Tests.Application.UseCases;
+
+public class SaveTransferUseCaseTests
+{
+    [Fact]
+    public async Task ExecuteAsync_SavesTwoTransferLegsInSingleCall()
+    {
+        var repository = Substitute.For<ITransactionRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", IsArchived = false },
+            new() { Id = "acc-2", IsArchived = false }
+        });
+        var sut = new SaveTransferUseCase(repository, accountRepository);
+
+        await sut.ExecuteAsync("acc-1", "acc-2", 150m, new DateTime(2026, 4, 10), "Umbuchung", "Test");
+
+        await repository.Received(1).SaveTransactionsAsync(Arg.Is<IEnumerable<Transaction>>(items =>
+            items.Count() == 2
+            && items.All(t => t.IsTransfer)
+            && items.Select(t => t.TransferGroupId).Distinct().Count() == 1
+            && items.Any(t => t.AccountId == "acc-1" && t.Typ == TransactionType.Ausgabe && t.Betrag == 150m)
+            && items.Any(t => t.AccountId == "acc-2" && t.Typ == TransactionType.Einnahme && t.Betrag == 150m)));
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_Throws_WhenAccountsEqual()
+    {
+        var repository = Substitute.For<ITransactionRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", IsArchived = false }
+        });
+        var sut = new SaveTransferUseCase(repository, accountRepository);
+
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            sut.ExecuteAsync("acc-1", "acc-1", 150m, new DateTime(2026, 4, 10)));
+    }
+}

--- a/Finanzuebersicht.Tests/Application/UseCases/Transactions/SearchTransactionsUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/Transactions/SearchTransactionsUseCaseTests.cs
@@ -8,7 +8,8 @@ public class SearchTransactionsUseCaseTests
 {
     private static SearchTransactionsUseCase CreateSut(
         IEnumerable<Transaction>? transactions = null,
-        IEnumerable<Category>? categories = null)
+        IEnumerable<Category>? categories = null,
+        IEnumerable<Account>? accounts = null)
     {
         var allTransactions = (transactions ?? []).ToList();
         var transactionRepo = Substitute.For<ITransactionRepository>();
@@ -24,7 +25,11 @@ public class SearchTransactionsUseCaseTests
         categoryRepo.GetCategoriesAsync()
             .Returns((categories ?? []).ToList());
 
-        return new SearchTransactionsUseCase(transactionRepo, categoryRepo);
+        var accountRepo = Substitute.For<IAccountRepository>();
+        accountRepo.GetAccountsAsync()
+            .Returns((accounts ?? []).ToList());
+
+        return new SearchTransactionsUseCase(transactionRepo, categoryRepo, accountRepo);
     }
 
     private static Transaction MakeTransaction(
@@ -232,5 +237,29 @@ public class SearchTransactionsUseCaseTests
 
         Assert.True(result.IconMap.ContainsKey("kat-1"));
         Assert.Equal("🛒", result.IconMap["kat-1"]);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_FilterNachKonto_OnlyReturnsMatchingAccount()
+    {
+        var transactions = new[]
+        {
+            MakeTransaction("1", "Supermarkt", datum: new DateTime(2026, 1, 1)),
+            MakeTransaction("2", "Gehalt", datum: new DateTime(2026, 1, 2))
+        };
+        transactions[0].AccountId = "acc-1";
+        transactions[1].AccountId = "acc-2";
+
+        var sut = CreateSut(transactions, accounts: new[]
+        {
+            new Account { Id = "acc-1", Name = "Girokonto" },
+            new Account { Id = "acc-2", Name = "Tagesgeld" }
+        });
+
+        var result = await sut.ExecuteAsync(new SearchTransactionsQuery(AccountId: "acc-1"));
+
+        Assert.Equal(1, result.TotalCount);
+        Assert.All(result.Gruppen.SelectMany(g => g), t => Assert.Equal("acc-1", t.AccountId));
+        Assert.Equal("Girokonto", result.AccountMap["acc-1"]);
     }
 }

--- a/Finanzuebersicht.Tests/Core/Services/InitializationServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/InitializationServiceTests.cs
@@ -1,21 +1,31 @@
 using Finanzuebersicht.Models;
+using NSubstitute;
+using Finanzuebersicht.Constants;
 
 namespace Finanzuebersicht.Tests.Services;
 
 public class InitializationServiceTests
 {
     private readonly ICategoryRepository _categoryRepository = Substitute.For<ICategoryRepository>();
+    private readonly IAccountRepository _accountRepository = Substitute.For<IAccountRepository>();
+    private readonly ITransactionRepository _transactionRepository = Substitute.For<ITransactionRepository>();
 
     [Fact]
     public async Task InitializeAsync_ErstelltStandardKategorien_WennKeineVorhanden()
     {
         _categoryRepository.GetCategoriesAsync().Returns(new List<Category>());
+        _accountRepository.GetAccountsAsync().Returns(new List<Account>());
+        _transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>()).Returns(new List<Transaction>());
 
-        var service = new InitializationService(_categoryRepository);
+        var service = new InitializationService(_categoryRepository, _accountRepository, _transactionRepository);
         await service.InitializeAsync();
 
         // 7 Standardkategorien werden erstellt
         await _categoryRepository.Received(7).SaveCategoryAsync(Arg.Any<Category>());
+        await _accountRepository.Received(1).SaveAccountAsync(Arg.Is<Account>(a =>
+            a.SystemKey == SystemAccountKeys.Default &&
+            a.Type == AccountType.Girokonto &&
+            a.Name == "Girokonto"));
     }
 
     [Fact]
@@ -25,10 +35,41 @@ public class InitializationServiceTests
         {
             new() { Id = "1", Name = "Existiert", Icon = "📦", Color = "#007AFF", Typ = TransactionType.Ausgabe }
         });
+        _accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Girokonto", Type = AccountType.Girokonto, SystemKey = SystemAccountKeys.Default }
+        });
+        _transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>()).Returns(new List<Transaction>());
 
-        var service = new InitializationService(_categoryRepository);
+        var service = new InitializationService(_categoryRepository, _accountRepository, _transactionRepository);
         await service.InitializeAsync();
 
         await _categoryRepository.DidNotReceive().SaveCategoryAsync(Arg.Any<Category>());
+        await _accountRepository.DidNotReceive().SaveAccountAsync(Arg.Any<Account>());
+    }
+
+    [Fact]
+    public async Task InitializeAsync_MigriertTransaktionen_OhneAccountAufDefaultKonto()
+    {
+        _categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "1", Name = "Existiert", Icon = "📦", Color = "#007AFF", Typ = TransactionType.Ausgabe }
+        });
+        _accountRepository.GetAccountsAsync().Returns(new List<Account>());
+        _transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>()).Returns(new List<Transaction>
+        {
+            new() { Id = "t1", Titel = "Test", Betrag = 12.34m, KategorieId = "1", AccountId = null }
+        });
+
+        string? defaultAccountId = null;
+        _accountRepository.When(x => x.SaveAccountAsync(Arg.Any<Account>()))
+            .Do(callInfo => defaultAccountId = callInfo.Arg<Account>().Id);
+
+        var service = new InitializationService(_categoryRepository, _accountRepository, _transactionRepository);
+        await service.InitializeAsync();
+
+        Assert.NotNull(defaultAccountId);
+        await _transactionRepository.Received(1).ReplaceAllTransactionsAsync(Arg.Is<IEnumerable<Transaction>>(txs =>
+            txs.Single().AccountId == defaultAccountId));
     }
 }

--- a/Finanzuebersicht.Tests/Core/Services/RecurringGenerationServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/RecurringGenerationServiceTests.cs
@@ -46,6 +46,7 @@ public class RecurringGenerationServiceTests
             Assert.Equal(recurring.Id, t.DauerauftragId);
             Assert.Equal("Weekly", t.Titel);
             Assert.Equal(10m, t.Betrag);
+            Assert.Null(t.AccountId);
         });
 
         // expected last candidate: advance by 7 days until <= today
@@ -170,6 +171,44 @@ public class RecurringGenerationServiceTests
 
         Assert.Contains(saved, t => t.Datum.Date == shifted.Date && t.DauerauftragId == recurring.Id);
         await recurringRepository.Received(1).SaveRecurringTransactionAsync(Arg.Is<RecurringTransaction>(r => r.LetzteAusfuehrung.HasValue));
+    }
+
+    [Fact]
+    public async Task GeneratesTransaction_WithFallbackDefaultAccount_WhenRecurringHasNoAccount()
+    {
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+
+        var recurring = new RecurringTransaction
+        {
+            Id = Guid.NewGuid().ToString(),
+            Titel = "Monthly",
+            Betrag = 20m,
+            Typ = TransactionType.Ausgabe,
+            Startdatum = DateTime.Today.AddMonths(-1),
+            Aktiv = true,
+            KategorieId = "cat-a",
+            Interval = RecurrenceInterval.Monthly,
+            IntervalFactor = 1
+        };
+
+        recurringRepository.GetRecurringTransactionsAsync().Returns(new List<RecurringTransaction> { recurring });
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-default", Name = "Girokonto", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        });
+
+        var saved = new List<Transaction>();
+        transactionRepository.When(x => x.SaveTransactionAsync(Arg.Any<Transaction>()))
+            .Do(call => saved.Add(call.Arg<Transaction>()));
+
+        var service = new RecurringGenerationService(recurringRepository, transactionRepository, accountRepository: accountRepository);
+        await service.GeneratePendingRecurringTransactionsAsync();
+
+        Assert.NotEmpty(saved);
+        Assert.All(saved, t => Assert.Equal("acc-default", t.AccountId));
+        await recurringRepository.Received(1).SaveRecurringTransactionAsync(Arg.Is<RecurringTransaction>(r => r.AccountId == "acc-default"));
     }
 
     [Fact]

--- a/Finanzuebersicht.Tests/Core/Services/ReportingServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/ReportingServiceTests.cs
@@ -18,9 +18,9 @@ public class ReportingServiceTests
         transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>
             {
-                new() { Betrag = 25m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 6, 5) },
-                new() { Betrag = 10m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 6, 6) },
-                new() { Betrag = 100m, KategorieId = "c1", Typ = TransactionType.Einnahme, Datum = new DateTime(2025, 6, 7) }
+                new() { Betrag = 25m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 6, 5), AccountId = "acc-1" },
+                new() { Betrag = 10m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 6, 6), AccountId = "acc-2" },
+                new() { Betrag = 100m, KategorieId = "c1", Typ = TransactionType.Einnahme, Datum = new DateTime(2025, 6, 7), AccountId = "acc-1" }
             });
 
         var service = new ReportingService(transactionRepository, categoryRepository);
@@ -48,9 +48,9 @@ public class ReportingServiceTests
         transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(new List<Transaction>
             {
-                new() { Betrag = 40m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 1, 3) },
-                new() { Betrag = 20m, KategorieId = "c2", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 2, 15) },
-                new() { Betrag = 200m, KategorieId = "c1", Typ = TransactionType.Einnahme, Datum = new DateTime(2025, 3, 1) }
+                new() { Betrag = 40m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 1, 3), AccountId = "acc-1" },
+                new() { Betrag = 20m, KategorieId = "c2", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 2, 15), AccountId = "acc-2" },
+                new() { Betrag = 200m, KategorieId = "c1", Typ = TransactionType.Einnahme, Datum = new DateTime(2025, 3, 1), AccountId = "acc-1" }
             });
 
         var service = new ReportingService(transactionRepository, categoryRepository);
@@ -62,5 +62,32 @@ public class ReportingServiceTests
         Assert.Equal(2, summary.ByCategory.Count);
         Assert.Contains(summary.ByCategory, c => c.CategoryId == "c1" && c.Total == 40m);
         Assert.Contains(summary.ByCategory, c => c.CategoryId == "c2" && c.Total == 20m);
+    }
+
+    [Fact]
+    public async Task GetYearSummaryAsync_IgnoresAccountAssignment()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "c1", Name = "Essen", Color = "#FF0000", Icon = "🛒" }
+        });
+
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Betrag = 40m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 1, 3), AccountId = "acc-1" },
+                new() { Betrag = 20m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 2, 15), AccountId = "acc-2" }
+            });
+
+        var service = new ReportingService(transactionRepository, categoryRepository);
+
+        var summary = await service.GetYearSummaryAsync(2025);
+
+        Assert.Equal(60m, summary.Total);
+        Assert.Single(summary.ByCategory);
+        Assert.Equal("Essen", summary.ByCategory[0].CategoryName);
     }
 }

--- a/Finanzuebersicht.Tests/Core/Services/ReportingServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/ReportingServiceTests.cs
@@ -90,4 +90,29 @@ public class ReportingServiceTests
         Assert.Single(summary.ByCategory);
         Assert.Equal("Essen", summary.ByCategory[0].CategoryName);
     }
+
+    [Fact]
+    public async Task GetMonthSummaryAsync_ExcludesTransfers()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(new List<Category>
+        {
+            new() { Id = "c1", Name = "Essen", Color = "#FF0000", Icon = "🛒" }
+        });
+
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Betrag = 25m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 6, 5), IsTransfer = false },
+                new() { Betrag = 40m, KategorieId = "c1", Typ = TransactionType.Ausgabe, Datum = new DateTime(2025, 6, 6), IsTransfer = true }
+            });
+
+        var service = new ReportingService(transactionRepository, categoryRepository);
+
+        var summary = await service.GetMonthSummaryAsync(2025, 6);
+
+        Assert.Equal(25m, summary.Total);
+    }
 }

--- a/Finanzuebersicht.Tests/Services/AccountStoreTests.cs
+++ b/Finanzuebersicht.Tests/Services/AccountStoreTests.cs
@@ -1,0 +1,83 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Tests.Services;
+
+public class AccountStoreTests : IDisposable
+{
+    private readonly string _testDir;
+    private readonly AccountStore _store;
+
+    public AccountStoreTests()
+    {
+        _testDir = Path.Combine(Path.GetTempPath(), $"account_test_{Guid.NewGuid():N}");
+        Directory.CreateDirectory(_testDir);
+        _store = new AccountStore(_testDir);
+    }
+
+    public void Dispose()
+    {
+        try { Directory.Delete(_testDir, true); } catch { }
+    }
+
+    [Fact]
+    public async Task SaveAndGet_ReturnsSavedAccount()
+    {
+        var account = new Account
+        {
+            Name = "Girokonto",
+            Type = AccountType.Girokonto
+        };
+
+        await _store.SaveAccountAsync(account);
+        var accounts = await _store.GetAccountsAsync();
+
+        Assert.Single(accounts, a => a.Id == account.Id && a.Name == "Girokonto");
+    }
+
+    [Fact]
+    public async Task Update_ReplacesExistingAccount()
+    {
+        var account = new Account { Name = "Girokonto", Type = AccountType.Girokonto };
+        await _store.SaveAccountAsync(account);
+
+        account.Name = "Hauptkonto";
+        account.Type = AccountType.Tagesgeld;
+        await _store.SaveAccountAsync(account);
+
+        var accounts = await _store.GetAccountsAsync();
+        Assert.Single(accounts);
+        Assert.Equal("Hauptkonto", accounts[0].Name);
+        Assert.Equal(AccountType.Tagesgeld, accounts[0].Type);
+    }
+
+    [Fact]
+    public async Task Delete_RemovesAccount()
+    {
+        var account = new Account { Name = "Girokonto", Type = AccountType.Girokonto };
+        await _store.SaveAccountAsync(account);
+
+        await _store.DeleteAccountAsync(account.Id);
+
+        var accounts = await _store.GetAccountsAsync();
+        Assert.Empty(accounts);
+    }
+
+    [Fact]
+    public async Task ReplaceAll_ReplacesExistingAccountsWithNewList()
+    {
+        await _store.SaveAccountAsync(new Account { Name = "Alt", Type = AccountType.Girokonto });
+
+        var newAccounts = new List<Account>
+        {
+            new() { Name = "Giro", Type = AccountType.Girokonto },
+            new() { Name = "Tagesgeld", Type = AccountType.Tagesgeld }
+        };
+
+        await _store.ReplaceAllAccountsAsync(newAccounts);
+
+        var accounts = await _store.GetAccountsAsync();
+        Assert.Equal(2, accounts.Count);
+        Assert.Contains(accounts, a => a.Name == "Giro");
+        Assert.Contains(accounts, a => a.Name == "Tagesgeld");
+    }
+}

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -40,7 +40,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task FullBackupRestoreCycle_PreserveAllData()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]), _mockDataService);
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]), _mockDataService);
             var backupPath = Path.Combine(_testDir, "backups");
 
             // Setup data
@@ -49,11 +49,15 @@ namespace Finanzuebersicht.Tests.Services
                 new Category { Id = "c1", Name = "Groceries", Icon = "🛒", Color = "#FF5733" },
                 new Category { Id = "c2", Name = "Transport", Icon = "🚗", Color = "#33FF57" }
             };
+            var originalAccounts = new[]
+            {
+                new Account { Id = "a1", Name = "Girokonto", Type = AccountType.Girokonto }
+            };
 
             var originalTransactions = new[]
             {
-                new Transaction { Id = "t1", Titel = "Supermarket", Betrag = 50.5m, Datum = new DateTime(2026, 1, 1), KategorieId = "c1" },
-                new Transaction { Id = "t2", Titel = "Gas", Betrag = 60.0m, Datum = new DateTime(2026, 1, 5), KategorieId = "c2" }
+                new Transaction { Id = "t1", Titel = "Supermarket", Betrag = 50.5m, Datum = new DateTime(2026, 1, 1), KategorieId = "c1", AccountId = "a1" },
+                new Transaction { Id = "t2", Titel = "Gas", Betrag = 60.0m, Datum = new DateTime(2026, 1, 5), KategorieId = "c2", AccountId = "a1" }
             };
 
             var originalRecurring = new[]
@@ -72,6 +76,7 @@ namespace Finanzuebersicht.Tests.Services
             };
 
             _mockDataService.SetCategories(originalCategories);
+            _mockDataService.SetAccounts(originalAccounts);
             _mockDataService.SetTransactions(originalTransactions);
             _mockDataService.SetRecurring(originalRecurring);
             _mockDataService.SetBudgets([new CategoryBudget { Id = "b1", KategorieId = "c1", Betrag = 300m }]);
@@ -93,6 +98,7 @@ namespace Finanzuebersicht.Tests.Services
             // Assert 1: Backup created with correct data
             Assert.NotNull(backup);
             Assert.Equal(2, backup.EntityCounts["categories"]);
+            Assert.Equal(1, backup.EntityCounts["accounts"]);
             Assert.Equal(2, backup.EntityCounts["transactions"]);
             Assert.Equal(1, backup.EntityCounts["recurring"]);
             Assert.Equal(1, backup.EntityCounts["budgets"]);
@@ -116,6 +122,7 @@ namespace Finanzuebersicht.Tests.Services
             Assert.Equal(backup.Id, restoreResult.RestoredMetadata.Id);
 
             var restoredCategories = await _mockDataService.GetCategoriesAsync();
+            var restoredAccounts = await _mockDataService.GetAccountsAsync();
             var restoredTransactions = await _mockDataService.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
             var restoredRecurring = await _mockDataService.GetRecurringTransactionsAsync();
             var restoredBudgets = await _mockDataService.GetBudgetsAsync();
@@ -123,12 +130,14 @@ namespace Finanzuebersicht.Tests.Services
             var restoredTemplates = await _mockDataService.GetTransactionTemplatesAsync();
 
             Assert.Equal(2, restoredCategories.Count);
+            Assert.Single(restoredAccounts);
             Assert.Equal(2, restoredTransactions.Count);
             Assert.Single(restoredRecurring);
             Assert.Single(restoredBudgets);
             Assert.Single(restoredSparziele);
             Assert.Single(restoredTemplates);
             Assert.Contains(restoredCategories, c => c.Id == "c1" && c.Name == "Groceries");
+            Assert.Contains(restoredAccounts, a => a.Id == "a1" && a.Name == "Girokonto");
             Assert.Contains(restoredTransactions, t => t.Id == "t1" && t.Betrag == 50.5m);
             Assert.Contains(restoredRecurring, r => r.Id == "r1" && r.Titel == "Rent");
             Assert.Contains(restoredBudgets, b => b.Id == "b1" && b.Betrag == 300m);
@@ -140,7 +149,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task MultipleBackups_ListsInCorrectOrder()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
             var categories = new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } };
             _mockDataService.SetCategories(categories);
@@ -164,7 +173,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task BackupWithEmptyDatabase_CreatesValidBackup()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
             // No data set
 
@@ -182,7 +191,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task DeleteBackup_RemovesBackupFile()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
             var category = new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" };
             _mockDataService.SetCategories(new[] { category });
@@ -202,7 +211,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ExportAsCSV_ContainsAllTransactionData()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var categories = new[]
             {
                 new Category { Id = "c1", Name = "Food", Icon = "🍕", Color = "#FF0000" }
@@ -242,7 +251,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task BackupSettings_PersistsBackupMetadata()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
             _mockDataService.SetCategories(new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } });
 
@@ -265,7 +274,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreNonexistentBackup_ReturnsFailed()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
 
             // Act
@@ -282,7 +291,7 @@ namespace Finanzuebersicht.Tests.Services
             // Arrange: create backup, then corrupt the ZIP before restoring.
             // The restore fails at extraction (before any ReplaceAll* write occurs),
             // so the existing data must remain untouched.
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
 
             var originalCategories = new[] { new Category { Id = "c1", Name = "Groceries" } };
@@ -316,7 +325,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackup_WriteFailsAndRollbackFails_DataMayBeInconsistentIsTrue()
         {
             // Arrange: create a valid backup
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var backupPath = Path.Combine(_testDir, "backups");
 
             _mockDataService.SetCategories([new Category { Id = "c1", Name = "Original" }]);
@@ -324,7 +333,7 @@ namespace Finanzuebersicht.Tests.Services
 
             // Use a data service that fails on both write AND rollback
             var failingDataService = new FailingMockDataService();
-            var failingService = new BackupService(failingDataService, failingDataService, failingDataService, failingDataService, failingDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var failingService = new BackupService(failingDataService, failingDataService, failingDataService, failingDataService, failingDataService, failingDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
 
             // Act
             var result = await failingService.RestoreBackupAsync(backupPath, metadata.Id);
@@ -336,9 +345,10 @@ namespace Finanzuebersicht.Tests.Services
 
         // Mock implementations
 #pragma warning disable CS0618
-        private class MockDataService : IDataService, ITransactionTemplateRepository
+        private class MockDataService : IDataService, IAccountRepository, ITransactionTemplateRepository
         {
             private List<Category> _categories = [];
+            private List<Account> _accounts = [];
             private List<Transaction> _transactions = [];
             private List<RecurringTransaction> _recurring = [];
             private List<CategoryBudget> _budgets = [];
@@ -346,6 +356,7 @@ namespace Finanzuebersicht.Tests.Services
             private List<TransactionTemplate> _transactionTemplates = [];
 
             public void SetCategories(IEnumerable<Category> categories) => _categories = categories.ToList();
+            public void SetAccounts(IEnumerable<Account> accounts) => _accounts = accounts.ToList();
             public void SetTransactions(IEnumerable<Transaction> transactions) => _transactions = transactions.ToList();
             public void SetRecurring(IEnumerable<RecurringTransaction> recurring) => _recurring = recurring.ToList();
             public void SetBudgets(IEnumerable<CategoryBudget> budgets) => _budgets = budgets.ToList();
@@ -353,6 +364,7 @@ namespace Finanzuebersicht.Tests.Services
             public void SetTransactionTemplates(IEnumerable<TransactionTemplate> templates) => _transactionTemplates = templates.ToList();
 
             public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(_categories.ToList());
+            public Task<List<Account>> GetAccountsAsync() => Task.FromResult(_accounts.ToList());
             public Task SaveCategoryAsync(Category category)
             {
                 var idx = _categories.FindIndex(c => c.Id == category.Id);
@@ -361,6 +373,14 @@ namespace Finanzuebersicht.Tests.Services
             }
             public Task DeleteCategoryAsync(string id) { _categories.RemoveAll(c => c.Id == id); return Task.CompletedTask; }
             public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories) { _categories = categories.ToList(); return Task.CompletedTask; }
+            public Task SaveAccountAsync(Account account)
+            {
+                var idx = _accounts.FindIndex(a => a.Id == account.Id);
+                if (idx >= 0) _accounts[idx] = account; else _accounts.Add(account);
+                return Task.CompletedTask;
+            }
+            public Task DeleteAccountAsync(string id) { _accounts.RemoveAll(a => a.Id == id); return Task.CompletedTask; }
+            public Task ReplaceAllAccountsAsync(IEnumerable<Account> accounts) { _accounts = accounts.ToList(); return Task.CompletedTask; }
 
             public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum)
                 => Task.FromResult(_transactions.Where(t => t.Datum >= vonDatum && t.Datum <= bisDatum).ToList());
@@ -438,22 +458,26 @@ namespace Finanzuebersicht.Tests.Services
         /// Used to test the scenario where restore fails AND rollback also fails.
         /// </summary>
 #pragma warning disable CS0618
-        private class FailingMockDataService : IDataService
+        private class FailingMockDataService : IDataService, IAccountRepository
         {
             public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(new List<Category>());
+            public Task<List<Account>> GetAccountsAsync() => Task.FromResult(new List<Account>());
             public Task<List<Transaction>> GetTransactionsAsync(DateTime v, DateTime b) => Task.FromResult(new List<Transaction>());
             public Task<List<RecurringTransaction>> GetRecurringTransactionsAsync() => Task.FromResult(new List<RecurringTransaction>());
             public Task<List<CategoryBudget>> GetBudgetsAsync() => Task.FromResult(new List<CategoryBudget>());
             public Task<List<SparZiel>> GetSparZieleAsync() => Task.FromResult(new List<SparZiel>());
 
             public Task ReplaceAllCategoriesAsync(IEnumerable<Category> c) => Task.FromException(new InvalidOperationException("Simulated write failure"));
+            public Task ReplaceAllAccountsAsync(IEnumerable<Account> a) => Task.FromException(new InvalidOperationException("Simulated write failure"));
             public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> t) => Task.FromException(new InvalidOperationException("Simulated write failure"));
             public Task ReplaceAllRecurringTransactionsAsync(IEnumerable<RecurringTransaction> r) => Task.FromException(new InvalidOperationException("Simulated write failure"));
             public Task ReplaceAllBudgetsAsync(IEnumerable<CategoryBudget> b) => Task.FromException(new InvalidOperationException("Simulated write failure"));
             public Task ReplaceAllSparZieleAsync(IEnumerable<SparZiel> s) => Task.FromException(new InvalidOperationException("Simulated write failure"));
 
             public Task SaveCategoryAsync(Category c) => Task.CompletedTask;
+            public Task SaveAccountAsync(Account a) => Task.CompletedTask;
             public Task DeleteCategoryAsync(string id) => Task.CompletedTask;
+            public Task DeleteAccountAsync(string id) => Task.CompletedTask;
             public Task SaveTransactionAsync(Transaction t) => Task.CompletedTask;
             public Task DeleteTransactionAsync(string id) => Task.CompletedTask;
             public Task<Category?> GetMostCommonCategoryForPayeeAsync(string p, double c = 0.5, CancellationToken ct = default) => Task.FromResult<Category?>(null);

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -390,7 +390,17 @@ namespace Finanzuebersicht.Tests.Services
                 if (idx >= 0) _transactions[idx] = transaction; else _transactions.Add(transaction);
                 return Task.CompletedTask;
             }
+            public Task SaveTransactionsAsync(IEnumerable<Transaction> transactions)
+            {
+                foreach (var transaction in transactions)
+                {
+                    var idx = _transactions.FindIndex(t => t.Id == transaction.Id);
+                    if (idx >= 0) _transactions[idx] = transaction; else _transactions.Add(transaction);
+                }
+                return Task.CompletedTask;
+            }
             public Task DeleteTransactionAsync(string id) { _transactions.RemoveAll(t => t.Id == id); return Task.CompletedTask; }
+            public Task DeleteTransferGroupAsync(string transferGroupId) { _transactions.RemoveAll(t => t.TransferGroupId == transferGroupId); return Task.CompletedTask; }
             public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions) { _transactions = transactions.ToList(); return Task.CompletedTask; }
             public Task<Category?> GetMostCommonCategoryForPayeeAsync(
                 string payee,
@@ -479,7 +489,9 @@ namespace Finanzuebersicht.Tests.Services
             public Task DeleteCategoryAsync(string id) => Task.CompletedTask;
             public Task DeleteAccountAsync(string id) => Task.CompletedTask;
             public Task SaveTransactionAsync(Transaction t) => Task.CompletedTask;
+            public Task SaveTransactionsAsync(IEnumerable<Transaction> transactions) => Task.CompletedTask;
             public Task DeleteTransactionAsync(string id) => Task.CompletedTask;
+            public Task DeleteTransferGroupAsync(string transferGroupId) => Task.CompletedTask;
             public Task<Category?> GetMostCommonCategoryForPayeeAsync(string p, double c = 0.5, CancellationToken ct = default) => Task.FromResult<Category?>(null);
             public Task SaveRecurringTransactionAsync(RecurringTransaction r) => Task.CompletedTask;
             public Task DeleteRecurringTransactionAsync(string id) => Task.CompletedTask;

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -39,7 +39,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task CreateBackupAsync_CreatesValidZipFile()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             _mockDataService.SetCategories(new[]
             {
                 new Category { Id = "cat1", Name = "Test", Icon = "🏠", Color = "#000" }
@@ -64,7 +64,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task CreateBackupAsync_ZipContainsAllRequiredFiles()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             _mockDataService.SetCategories(new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } });
 
             // Act
@@ -75,6 +75,7 @@ namespace Finanzuebersicht.Tests.Services
             using (var zipArchive = ZipFile.OpenRead(zipPath))
             {
                 Assert.NotNull(zipArchive.GetEntry("categories.json"));
+                Assert.NotNull(zipArchive.GetEntry("accounts.json"));
                 Assert.NotNull(zipArchive.GetEntry("transactions.json"));
                 Assert.NotNull(zipArchive.GetEntry("recurring.json"));
                 Assert.NotNull(zipArchive.GetEntry("budgets.json"));
@@ -88,10 +89,14 @@ namespace Finanzuebersicht.Tests.Services
         public async Task CreateBackupAsync_MetadataHasCorrectEntityCounts()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var categories = new[] { 
                 new Category { Id = "1", Name = "Cat1", Icon = "🏠", Color = "#000" },
                 new Category { Id = "2", Name = "Cat2", Icon = "🛒", Color = "#111" }
+            };
+            var accounts = new[]
+            {
+                new Account { Id = "a1", Name = "Girokonto", Type = AccountType.Girokonto }
             };
             var transactions = new[] {
                 new Transaction { Id = "t1", Titel = "T1", Betrag = 100m, Datum = DateTime.Now, KategorieId = "1" },
@@ -103,6 +108,7 @@ namespace Finanzuebersicht.Tests.Services
             };
 
             _mockDataService.SetCategories(categories);
+            _mockDataService.SetAccounts(accounts);
             _mockDataService.SetTransactions(transactions);
             _mockDataService.SetRecurring(recurring);
 
@@ -111,6 +117,7 @@ namespace Finanzuebersicht.Tests.Services
 
             // Assert
             Assert.Equal(2, metadata.EntityCounts["categories"]);
+            Assert.Equal(1, metadata.EntityCounts["accounts"]);
             Assert.Equal(3, metadata.EntityCounts["transactions"]);
             Assert.Equal(1, metadata.EntityCounts["recurring"]);
         }
@@ -119,7 +126,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task CreateBackupAsync_ZipContainsBudgetsAndSparZiele()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             _mockDataService.SetBudgets(new[]
             {
                 new CategoryBudget { Id = "b1", KategorieId = "cat1", Betrag = 200m, Jahr = 2026, Monat = 1 },
@@ -150,7 +157,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ListBackupsAsync_ReturnsBackupsInReverseChronologicalOrder()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             _mockDataService.SetCategories(new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } });
 
             // Create backups with small delays
@@ -170,7 +177,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ListBackupsAsync_ReturnsEmptyWhenDirectoryDoesNotExist()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var nonExistentPath = Path.Combine(_testBackupDir, "nonexistent");
 
             // Act
@@ -184,7 +191,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackupAsync_FailsWhenFileDoesNotExist()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
 
             // Act
             var result = await service.RestoreBackupAsync(_testBackupDir, "nonexistent_id");
@@ -198,7 +205,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackupAsync_ValidatesZipIntegrity()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var corruptedZipPath = Path.Combine(_testBackupDir, "backup_corrupted.zip");
             File.WriteAllText(corruptedZipPath, "This is not a valid ZIP file");
 
@@ -214,7 +221,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackupAsync_DetectsMissingRequiredFiles()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var incompleteZipPath = Path.Combine(_testBackupDir, "backup_incomplete.zip");
 
             // Create incomplete ZIP (missing files)
@@ -226,6 +233,14 @@ namespace Finanzuebersicht.Tests.Services
                 {
                     writer.Write("[]");
                 }
+                WriteJsonToZip(zipArchive, "backup.metadata.json", new BackupMetadata
+                {
+                    Id = "incomplete",
+                    CreatedAt = DateTime.UtcNow,
+                    SchemaVersion = 3,
+                    FileName = "backup_incomplete.zip",
+                    EntityCounts = new Dictionary<string, int>()
+                });
             }
 
             // Act
@@ -240,7 +255,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task RestoreBackupAsync_ValidatesSchemaVersion()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var wrongVersionZipPath = Path.Combine(_testBackupDir, "backup_wrongversion.zip");
 
             // Create backup with wrong schema version
@@ -273,7 +288,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ExportAsCSVAsync_CreatesValidCsvStream()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var categories = new[] { new Category { Id = "1", Name = "Lebensmittel", Icon = "🛒", Color = "#000" } };
             var transactions = new[] {
                 new Transaction { Id = "t1", Titel = "Supermarkt", Betrag = 50.50m, Datum = new DateTime(2026, 3, 11), 
@@ -302,7 +317,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task ExportAsCSVAsync_EscapesCsvSpecialCharacters()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             var categories = new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } };
             var transactions = new[] {
                 new Transaction { Id = "t1", Titel = "Titel \"mit Anführungszeichen\"", Betrag = 100m, 
@@ -327,7 +342,7 @@ namespace Finanzuebersicht.Tests.Services
         public async Task DeleteBackupAsync_RemovesBackupFile()
         {
             // Arrange
-            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator()]));
+            var service = new BackupService(_mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockDataService, _mockSettingsService, new DataMigrationService([new V1ToV2Migrator(), new V2ToV3Migrator()]));
             _mockDataService.SetCategories(new[] { new Category { Id = "1", Name = "Test", Icon = "🏠", Color = "#000" } });
             var metadata = await service.CreateBackupAsync(_testBackupDir);
             var zipPath = Path.Combine(_testBackupDir, metadata.FileName);
@@ -358,15 +373,17 @@ namespace Finanzuebersicht.Tests.Services
     // ========== Mock-Implementierungen ==========
 
 #pragma warning disable CS0618
-    internal class MockDataService : IDataService
+    internal class MockDataService : IDataService, IAccountRepository
     {
         private List<Category> _categories = [];
+        private List<Account> _accounts = [];
         private List<Transaction> _transactions = [];
         private List<RecurringTransaction> _recurring = [];
         private List<CategoryBudget> _budgets = [];
         private List<SparZiel> _sparziele = [];
 
         public void SetCategories(IEnumerable<Category> categories) => _categories = categories.ToList();
+        public void SetAccounts(IEnumerable<Account> accounts) => _accounts = accounts.ToList();
         public void SetTransactions(IEnumerable<Transaction> transactions) => _transactions = transactions.ToList();
         public void SetRecurring(IEnumerable<RecurringTransaction> recurring) => _recurring = recurring.ToList();
         public void SetBudgets(IEnumerable<CategoryBudget> budgets) => _budgets = budgets.ToList();
@@ -374,9 +391,13 @@ namespace Finanzuebersicht.Tests.Services
 
         // ICategoryRepository
         public Task<List<Category>> GetCategoriesAsync() => Task.FromResult(_categories);
+        public Task<List<Account>> GetAccountsAsync() => Task.FromResult(_accounts);
         public Task SaveCategoryAsync(Category category) => Task.CompletedTask;
         public Task DeleteCategoryAsync(string id) => Task.CompletedTask;
         public Task ReplaceAllCategoriesAsync(IEnumerable<Category> categories) { _categories = categories.ToList(); return Task.CompletedTask; }
+        public Task SaveAccountAsync(Account account) => Task.CompletedTask;
+        public Task DeleteAccountAsync(string id) => Task.CompletedTask;
+        public Task ReplaceAllAccountsAsync(IEnumerable<Account> accounts) { _accounts = accounts.ToList(); return Task.CompletedTask; }
 
         // ITransactionRepository
         public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum) 

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -403,7 +403,9 @@ namespace Finanzuebersicht.Tests.Services
         public Task<List<Transaction>> GetTransactionsAsync(DateTime vonDatum, DateTime bisDatum) 
             => Task.FromResult(_transactions.Where(t => t.Datum >= vonDatum && t.Datum <= bisDatum).ToList());
         public Task SaveTransactionAsync(Transaction transaction) => Task.CompletedTask;
+        public Task SaveTransactionsAsync(IEnumerable<Transaction> transactions) => Task.CompletedTask;
         public Task DeleteTransactionAsync(string id) => Task.CompletedTask;
+        public Task DeleteTransferGroupAsync(string transferGroupId) => Task.CompletedTask;
         public Task ReplaceAllTransactionsAsync(IEnumerable<Transaction> transactions) { _transactions = transactions.ToList(); return Task.CompletedTask; }
         public Task<Category?> GetMostCommonCategoryForPayeeAsync(
             string payee,

--- a/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/DataConsistencyFlowIntegrationTests.cs
@@ -317,9 +317,27 @@ namespace Finanzuebersicht.Tests.Services
                 return Task.CompletedTask;
             }
 
+            public Task SaveTransactionsAsync(IEnumerable<Transaction> transactions)
+            {
+                foreach (var transaction in transactions)
+                {
+                    var existing = _transactions.FirstOrDefault(t => t.Id == transaction.Id);
+                    if (existing != null)
+                        _transactions.Remove(existing);
+                    _transactions.Add(transaction);
+                }
+                return Task.CompletedTask;
+            }
+
             public Task DeleteTransactionAsync(string id)
             {
                 _transactions.RemoveAll(t => t.Id == id);
+                return Task.CompletedTask;
+            }
+
+            public Task DeleteTransferGroupAsync(string transferGroupId)
+            {
+                _transactions.RemoveAll(t => t.TransferGroupId == transferGroupId);
                 return Task.CompletedTask;
             }
 

--- a/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
@@ -1,5 +1,6 @@
 using System.Collections.ObjectModel;
 using Finanzuebersicht.Application.UseCases.Categories;
+using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.ViewModels;
@@ -22,6 +23,8 @@ public class CategoriesViewModelTests
             categoryRepository,
             Substitute.For<ITransactionRepository>(),
             Substitute.For<IRecurringTransactionRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<ITransactionTemplateRepository>(),
             out _);
 
         await sut.LoadKategorienCommand.ExecuteAsync(null);
@@ -48,11 +51,19 @@ public class CategoriesViewModelTests
         var recurringTransactionRepository = Substitute.For<IRecurringTransactionRepository>();
         recurringTransactionRepository.GetRecurringTransactionsAsync()
             .Returns(Task.FromResult(new List<RecurringTransaction>()));
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Girokonto", Type = AccountType.Girokonto, SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        }));
+        var templateRepository = Substitute.For<ITransactionTemplateRepository>();
 
         var sut = CreateSut(
             categoryRepository,
             transactionRepository,
             recurringTransactionRepository,
+            accountRepository,
+            templateRepository,
             out var dialogService);
 
         sut.Kategorien = new ObservableCollection<Category> { categoryToDelete };
@@ -74,6 +85,8 @@ public class CategoriesViewModelTests
             categoryRepository,
             Substitute.For<ITransactionRepository>(),
             Substitute.For<IRecurringTransactionRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<ITransactionTemplateRepository>(),
             out var dialogService);
 
         sut.Kategorien = new ObservableCollection<Category> { categoryToDelete };
@@ -94,6 +107,8 @@ public class CategoriesViewModelTests
             Substitute.For<ICategoryRepository>(),
             Substitute.For<ITransactionRepository>(),
             Substitute.For<IRecurringTransactionRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<ITransactionTemplateRepository>(),
             out _,
             out var navigationService);
 
@@ -111,6 +126,8 @@ public class CategoriesViewModelTests
         ICategoryRepository categoryRepository,
         ITransactionRepository transactionRepository,
         IRecurringTransactionRepository recurringTransactionRepository,
+        IAccountRepository accountRepository,
+        ITransactionTemplateRepository templateRepository,
         out IDialogService dialogService,
         out INavigationService navigationService)
     {
@@ -129,6 +146,8 @@ public class CategoriesViewModelTests
         return new CategoriesViewModel(
             new DeleteCategoryUseCase(categoryRepository, transactionRepository, recurringTransactionRepository),
             new LoadCategoriesUseCase(categoryRepository),
+            new LoadAccountsUseCase(accountRepository),
+            new DeleteAccountUseCase(accountRepository, transactionRepository, templateRepository),
             localizationService,
             navigationService,
             dialogService);
@@ -138,12 +157,16 @@ public class CategoriesViewModelTests
         ICategoryRepository categoryRepository,
         ITransactionRepository transactionRepository,
         IRecurringTransactionRepository recurringTransactionRepository,
+        IAccountRepository accountRepository,
+        ITransactionTemplateRepository templateRepository,
         out IDialogService dialogService)
     {
         return CreateSut(
             categoryRepository,
             transactionRepository,
             recurringTransactionRepository,
+            accountRepository,
+            templateRepository,
             out dialogService,
             out _);
     }

--- a/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
@@ -122,6 +122,29 @@ public class CategoriesViewModelTests
                 object.ReferenceEquals(parameters["Category"], category)));
     }
 
+    [Fact]
+    public async Task ToggleKontoArchivierung_WhenConfirmed_UpdatesAccount()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        var account = new Account { Id = "acc-1", Name = "Giro", IsArchived = false };
+        accountRepository.GetAccountsAsync().Returns(new List<Account> { account });
+
+        var sut = CreateSut(
+            Substitute.For<ICategoryRepository>(),
+            Substitute.For<ITransactionRepository>(),
+            Substitute.For<IRecurringTransactionRepository>(),
+            accountRepository,
+            Substitute.For<ITransactionTemplateRepository>(),
+            out var dialogService);
+
+        dialogService.ShowConfirmationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.FromResult(true));
+
+        await sut.ToggleKontoArchivierungCommand.ExecuteAsync(account);
+
+        await accountRepository.Received(1).SaveAccountAsync(Arg.Is<Account>(a => a.Id == "acc-1" && a.IsArchived));
+    }
+
     private static CategoriesViewModel CreateSut(
         ICategoryRepository categoryRepository,
         ITransactionRepository transactionRepository,
@@ -147,6 +170,7 @@ public class CategoriesViewModelTests
             new DeleteCategoryUseCase(categoryRepository, transactionRepository, recurringTransactionRepository),
             new LoadCategoriesUseCase(categoryRepository),
             new LoadAccountsUseCase(accountRepository),
+            new ToggleAccountArchiveUseCase(accountRepository),
             new DeleteAccountUseCase(accountRepository, transactionRepository, templateRepository),
             localizationService,
             navigationService,

--- a/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
@@ -1,5 +1,6 @@
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Models;
 using Finanzuebersicht.Tests.TestHelpers;
 using Finanzuebersicht.ViewModels;
 
@@ -30,6 +31,8 @@ public class DashboardViewModelTests
         var recurringTransactionRepository = Substitute.For<IRecurringTransactionRepository>();
         var budgetRepository = Substitute.For<IBudgetRepository>();
         var reportingService = Substitute.For<IReportingService>();
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>()));
         var localizationService = Substitute.For<ILocalizationService>();
         var navigationService = Substitute.For<INavigationService>();
         var forecastService = Substitute.For<IForecastService>();
@@ -37,14 +40,14 @@ public class DashboardViewModelTests
 
         return new DashboardViewModel(
             new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringTransactionRepository, budgetRepository),
-            new LoadDashboardYearUseCase(reportingService),
+            new LoadDashboardYearUseCase(transactionRepository, categoryRepository),
             new LoadForecastUseCase(forecastService),
             new GetDueRecurringWithHintsUseCase(recurringTransactionRepository),
             budgetRepository,
-            reportingService,
             localizationService,
             navigationService,
             transactionRepository,
+            accountRepository,
             clock);
     }
 }

--- a/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
@@ -190,6 +190,37 @@ public class TransactionsViewModelTests
     }
 
     [Fact]
+    public async Task DeleteTransaktion_WhenTransfer_DeletesWholeGroup()
+    {
+        var deleteRepository = Substitute.For<ITransactionRepository>();
+        deleteRepository.DeleteTransferGroupAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+        deleteRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>()));
+
+        var viewModel = CreateSut(
+            deleteRepository,
+            Substitute.For<ICategoryRepository>(),
+            Substitute.For<ITransactionRepository>(),
+            Substitute.For<ICategoryRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<IAccountRepository>(),
+            out var dialogService,
+            out _,
+            out _,
+            out _,
+            deleteRepository);
+
+        dialogService.ShowConfirmationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.FromResult(true));
+
+        var transaction = new Transaction { Id = "tx-1", Titel = "Umbuchung", IsTransfer = true, TransferGroupId = "grp-1" };
+
+        await viewModel.DeleteTransaktionCommand.ExecuteAsync(transaction);
+
+        await deleteRepository.Received(1).DeleteTransferGroupAsync("grp-1");
+    }
+
+    [Fact]
     public async Task ImportCsv_NavigatesToPreviewRoute()
     {
         var parser = Substitute.For<IStatementParser>();

--- a/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
@@ -27,15 +27,25 @@ public class TransactionsViewModelTests
         categoryRepository.GetCategoriesAsync()
             .Returns(Task.FromResult(new List<Category>()));
 
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync()
+            .Returns(Task.FromResult(new List<Account>()));
+
         var searchCategoryRepository = Substitute.For<ICategoryRepository>();
         searchCategoryRepository.GetCategoriesAsync()
             .Returns(Task.FromResult(new List<Category>()));
+
+        var searchAccountRepository = Substitute.For<IAccountRepository>();
+        searchAccountRepository.GetAccountsAsync()
+            .Returns(Task.FromResult(new List<Account>()));
 
         var viewModel = CreateSut(
             transactionRepository,
             categoryRepository,
             searchTransactionRepository,
             searchCategoryRepository,
+            accountRepository,
+            searchAccountRepository,
             out _,
             out _,
             out _,
@@ -86,15 +96,25 @@ public class TransactionsViewModelTests
         categoryRepository.GetCategoriesAsync()
             .Returns(Task.FromResult(new List<Category>()));
 
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync()
+            .Returns(Task.FromResult(new List<Account>()));
+
         var searchCategoryRepository = Substitute.For<ICategoryRepository>();
         searchCategoryRepository.GetCategoriesAsync()
             .Returns(Task.FromResult(new List<Category>()));
+
+        var searchAccountRepository = Substitute.For<IAccountRepository>();
+        searchAccountRepository.GetAccountsAsync()
+            .Returns(Task.FromResult(new List<Account>()));
 
         var viewModel = CreateSut(
             transactionRepository,
             categoryRepository,
             searchTransactionRepository,
             searchCategoryRepository,
+            accountRepository,
+            searchAccountRepository,
             out _,
             out _,
             out _,
@@ -123,6 +143,8 @@ public class TransactionsViewModelTests
             Substitute.For<ICategoryRepository>(),
             Substitute.For<ITransactionRepository>(),
             Substitute.For<ICategoryRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<IAccountRepository>(),
             out var dialogService,
             out _,
             out _,
@@ -149,6 +171,8 @@ public class TransactionsViewModelTests
             Substitute.For<ICategoryRepository>(),
             Substitute.For<ITransactionRepository>(),
             Substitute.For<ICategoryRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<IAccountRepository>(),
             out var dialogService,
             out _,
             out _,
@@ -181,8 +205,12 @@ public class TransactionsViewModelTests
         importCategoryRepository.GetCategoriesAsync()
             .Returns(Task.FromResult(new List<Category>()));
 
+        var importAccountRepository = Substitute.For<IAccountRepository>();
+        importAccountRepository.GetAccountsAsync()
+            .Returns(Task.FromResult(new List<Account>()));
+
         var importLogger = Substitute.For<ILogger<ImportService>>();
-        var importService = new ImportService([parser], importRepository, importLogger, importCategoryRepository);
+        var importService = new ImportService([parser], importRepository, importLogger, importCategoryRepository, null, importAccountRepository);
 
         var pickedFile = new PickFileResult("test.csv", () => Task.FromResult<Stream>(new MemoryStream()));
         var filePicker = Substitute.For<IFilePicker>();
@@ -195,6 +223,8 @@ public class TransactionsViewModelTests
             Substitute.For<ICategoryRepository>(),
             Substitute.For<ITransactionRepository>(),
             Substitute.For<ICategoryRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<IAccountRepository>(),
             out _,
             out _,
             out _,
@@ -214,6 +244,8 @@ public class TransactionsViewModelTests
         ICategoryRepository loadCategoryRepository,
         ITransactionRepository searchTransactionRepository,
         ICategoryRepository searchCategoryRepository,
+        IAccountRepository loadAccountRepository,
+        IAccountRepository searchAccountRepository,
         out IDialogService dialogService,
         out ILocalizationService localizationService,
         out IMainThreadDispatcher dispatcher,
@@ -248,20 +280,23 @@ public class TransactionsViewModelTests
             [],
             Substitute.For<ITransactionRepository>(),
             Substitute.For<ILogger<ImportService>>(),
-            Substitute.For<ICategoryRepository>());
+            Substitute.For<ICategoryRepository>(),
+            null,
+            Substitute.For<IAccountRepository>());
 
         deleteTransactionRepository ??= Substitute.For<ITransactionRepository>();
         deleteTransactionRepository.DeleteTransactionAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
 
         return new TransactionsViewModel(
             new DeleteTransactionUseCase(deleteTransactionRepository),
-            new LoadTransactionsMonthUseCase(loadTransactionRepository, loadCategoryRepository),
-            new SearchTransactionsUseCase(searchTransactionRepository, searchCategoryRepository),
+            new LoadTransactionsMonthUseCase(loadTransactionRepository, loadCategoryRepository, loadAccountRepository),
+            new SearchTransactionsUseCase(searchTransactionRepository, searchCategoryRepository, searchAccountRepository),
             navigationService,
             importService,
             dialogService,
             localizationService,
             loadCategoryRepository,
+            loadAccountRepository,
             dispatcher,
             filePicker,
             appEvents,

--- a/Finanzuebersicht/AppShell.xaml
+++ b/Finanzuebersicht/AppShell.xaml
@@ -30,7 +30,7 @@
             Route="RecurringTransactionsPage" />
 
         <ShellContent
-            Title="Verwaltung"
+            Title="{loc:Translate Nav_Verwaltung}"
             Icon="categories.png"
             ContentTemplate="{DataTemplate views:CategoriesPage}"
             Route="CategoriesPage" />

--- a/Finanzuebersicht/AppShell.xaml
+++ b/Finanzuebersicht/AppShell.xaml
@@ -30,7 +30,7 @@
             Route="RecurringTransactionsPage" />
 
         <ShellContent
-            Title="{loc:Translate Nav_Kategorien}"
+            Title="Verwaltung"
             Icon="categories.png"
             ContentTemplate="{DataTemplate views:CategoriesPage}"
             Route="CategoriesPage" />

--- a/Finanzuebersicht/AppShell.xaml.cs
+++ b/Finanzuebersicht/AppShell.xaml.cs
@@ -10,6 +10,7 @@ public partial class AppShell : Shell
 		InitializeComponent();
 
 		Routing.RegisterRoute(Routes.TransactionDetail, typeof(TransactionDetailPage));
+		Routing.RegisterRoute(Routes.TransferDetail, typeof(TransferDetailPage));
 		Routing.RegisterRoute(Routes.RecurringTransactionDetail, typeof(RecurringTransactionDetailPage));
 		Routing.RegisterRoute(Routes.CategoryDetail, typeof(CategoryDetailPage));
 		Routing.RegisterRoute(Routes.AccountDetail, typeof(AccountDetailPage));

--- a/Finanzuebersicht/AppShell.xaml.cs
+++ b/Finanzuebersicht/AppShell.xaml.cs
@@ -12,6 +12,7 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute(Routes.TransactionDetail, typeof(TransactionDetailPage));
 		Routing.RegisterRoute(Routes.RecurringTransactionDetail, typeof(RecurringTransactionDetailPage));
 		Routing.RegisterRoute(Routes.CategoryDetail, typeof(CategoryDetailPage));
+		Routing.RegisterRoute(Routes.AccountDetail, typeof(AccountDetailPage));
 		Routing.RegisterRoute(Routes.RecurringInstanceShift, typeof(RecurringInstanceShiftPage));
 		Routing.RegisterRoute(Routes.Settings, typeof(SettingsPage));
 		Routing.RegisterRoute(Routes.BackupList, typeof(BackupListPage));

--- a/Finanzuebersicht/Converters/AccountArchiveActionConverter.cs
+++ b/Finanzuebersicht/Converters/AccountArchiveActionConverter.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Converters;
+
+public class AccountArchiveActionConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var isArchived = value switch
+        {
+            bool b => b,
+            Finanzuebersicht.Models.Account account => account.IsArchived,
+            _ => false
+        };
+
+        return isArchived
+            ? LocalizationResourceManager.Current["Btn_Aktivieren"]
+            : LocalizationResourceManager.Current["Btn_Archivieren"];
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/Finanzuebersicht/Converters/AccountIdToNameConverter.cs
+++ b/Finanzuebersicht/Converters/AccountIdToNameConverter.cs
@@ -1,0 +1,21 @@
+using System.Globalization;
+
+namespace Finanzuebersicht.Converters;
+
+public class AccountIdToNameConverter : IMultiValueConverter
+{
+    public object Convert(object[] values, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (values.Length < 1 || values[0] is not string accountId || string.IsNullOrEmpty(accountId))
+            return string.Empty;
+
+        if (values.Length >= 2 && values[1] is IDictionary<string, string> accountMap
+            && accountMap.TryGetValue(accountId, out var name))
+            return name;
+
+        return string.Empty;
+    }
+
+    public object[] ConvertBack(object value, Type[] targetTypes, object? parameter, CultureInfo culture)
+        => throw new NotImplementedException();
+}

--- a/Finanzuebersicht/Converters/AccountTypeToLocalizedStringConverter.cs
+++ b/Finanzuebersicht/Converters/AccountTypeToLocalizedStringConverter.cs
@@ -1,0 +1,28 @@
+using System.Globalization;
+using Finanzuebersicht.Models;
+using Microsoft.Maui.Controls;
+
+namespace Finanzuebersicht.Converters;
+
+public class AccountTypeToLocalizedStringConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        if (value is not AccountType accountType)
+            return string.Empty;
+
+        return accountType switch
+        {
+            AccountType.Girokonto => LocalizationResourceManager.Current["AccountType_Girokonto"],
+            AccountType.Tagesgeld => LocalizationResourceManager.Current["AccountType_Tagesgeld"],
+            AccountType.Kreditkarte => LocalizationResourceManager.Current["AccountType_Kreditkarte"],
+            AccountType.Bargeld => LocalizationResourceManager.Current["AccountType_Bargeld"],
+            AccountType.Depot => LocalizationResourceManager.Current["AccountType_Depot"],
+            AccountType.Sonstiges => LocalizationResourceManager.Current["AccountType_Sonstiges"],
+            _ => accountType.ToString()
+        };
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+        => throw new NotSupportedException();
+}

--- a/Finanzuebersicht/Converters/AccountTypeToLocalizedStringConverter.cs
+++ b/Finanzuebersicht/Converters/AccountTypeToLocalizedStringConverter.cs
@@ -1,5 +1,6 @@
 using System.Globalization;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
 using Microsoft.Maui.Controls;
 
 namespace Finanzuebersicht.Converters;

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -79,6 +79,7 @@ public static class MauiProgram
         builder.Services.AddTransient<RecurringInstanceShiftPage>();
 		builder.Services.AddTransient<CategoriesPage>();
 		builder.Services.AddTransient<CategoryDetailPage>();
+		builder.Services.AddTransient<AccountDetailPage>();
 		builder.Services.AddTransient<SettingsPage>();
 		builder.Services.AddTransient<SparZielePage>();
 		builder.Services.AddTransient<BackupListPage>();

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -74,6 +74,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<DashboardPage>();
 		builder.Services.AddTransient<TransactionsPage>();
 		builder.Services.AddTransient<TransactionDetailPage>();
+		builder.Services.AddTransient<TransferDetailPage>();
 		builder.Services.AddTransient<RecurringTransactionsPage>();
 		builder.Services.AddTransient<RecurringTransactionDetailPage>();
         builder.Services.AddTransient<RecurringInstanceShiftPage>();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -27,6 +27,7 @@
   <data name="Lbl_Betrag" xml:space="preserve"><value>Betrag</value></data>
   <data name="Lbl_Titel" xml:space="preserve"><value>Titel</value></data>
   <data name="Lbl_Kategorie" xml:space="preserve"><value>Kategorie</value></data>
+  <data name="Lbl_Konto" xml:space="preserve"><value>Konto</value></data>
   <data name="Lbl_Datum" xml:space="preserve"><value>Datum</value></data>
   <data name="Lbl_Startdatum" xml:space="preserve"><value>Startdatum</value></data>
   <data name="Lbl_Enddatum" xml:space="preserve"><value>Enddatum</value></data>
@@ -72,6 +73,7 @@
   <data name="Hint_Beschreibung" xml:space="preserve"><value>Beschreibung</value></data>
   <data name="Hint_Titelbeispiel" xml:space="preserve"><value>z.B. Miete, Netflix, Gehalt</value></data>
   <data name="Hint_KategorieWaehlen" xml:space="preserve"><value>Kategorie wählen</value></data>
+  <data name="Hint_KontoWaehlen" xml:space="preserve"><value>Konto wählen</value></data>
   <data name="Hint_iCloudTipp" xml:space="preserve"><value>💡 Tipp: Wähle einen Ordner in iCloud Drive, um die Daten automatisch zu sichern.</value></data>
 
   <!-- Empty States -->

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -10,6 +10,7 @@
   <data name="Nav_Transaktionen" xml:space="preserve"><value>Transaktionen</value></data>
   <data name="Nav_Dauerauftraege" xml:space="preserve"><value>Daueraufträge</value></data>
   <data name="Nav_Kategorien" xml:space="preserve"><value>Kategorien</value></data>
+  <data name="Nav_Verwaltung" xml:space="preserve"><value>Verwaltung</value></data>
   <data name="Nav_Einstellungen" xml:space="preserve"><value>Einstellungen</value></data>
 
   <!-- Page Titles -->
@@ -18,6 +19,9 @@
   <data name="Title_NeueKategorie" xml:space="preserve"><value>Neue Kategorie</value></data>
   <data name="Title_KategorieBearbeiten" xml:space="preserve"><value>Kategorie bearbeiten</value></data>
   <data name="Title_Jahresansicht" xml:space="preserve"><value>Jahresansicht</value></data>
+  <data name="Title_Umbuchung" xml:space="preserve"><value>Umbuchung</value></data>
+  <data name="Title_KontoHinzufuegen" xml:space="preserve"><value>Konto hinzufügen</value></data>
+  <data name="Title_KontoBearbeiten" xml:space="preserve"><value>Konto bearbeiten</value></data>
 
   <!-- Labels -->
   <data name="Lbl_Name" xml:space="preserve"><value>Name</value></data>
@@ -29,6 +33,12 @@
   <data name="Lbl_Kategorie" xml:space="preserve"><value>Kategorie</value></data>
   <data name="Lbl_Konto" xml:space="preserve"><value>Konto</value></data>
   <data name="Lbl_AlleKonten" xml:space="preserve"><value>Alle Konten</value></data>
+  <data name="Lbl_Archiviert" xml:space="preserve"><value>Archiviert</value></data>
+  <data name="Lbl_VonKonto" xml:space="preserve"><value>Von Konto</value></data>
+  <data name="Lbl_NachKonto" xml:space="preserve"><value>Nach Konto</value></data>
+  <data name="Btn_Archivieren" xml:space="preserve"><value>Archivieren</value></data>
+  <data name="Btn_Aktivieren" xml:space="preserve"><value>Aktivieren</value></data>
+  <data name="Hint_Systemkonto" xml:space="preserve"><value>Systemkonto kann nicht archiviert oder gelöscht werden.</value></data>
   <data name="Lbl_Datum" xml:space="preserve"><value>Datum</value></data>
   <data name="Lbl_Startdatum" xml:space="preserve"><value>Startdatum</value></data>
   <data name="Lbl_Enddatum" xml:space="preserve"><value>Enddatum</value></data>
@@ -85,6 +95,8 @@
   <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>Keine Daten für diesen Zeitraum</value></data>
   <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>Keine Daten für dieses Jahr</value></data>
   <data name="Empty_NochKeineTransaktionen" xml:space="preserve"><value>Noch keine Transaktionen vorhanden</value></data>
+  <data name="Empty_KeineKonten" xml:space="preserve"><value>Keine Konten vorhanden</value></data>
+  <data name="Empty_KontenHinweis" xml:space="preserve"><value>Lege ein Konto an, um Transaktionen und Daueraufträge zuzuordnen.</value></data>
   <data name="Btn_ZuTransaktionen" xml:space="preserve"><value>Erste Transaktion hinzufügen</value></data>
 
   <!-- Error Messages -->
@@ -96,6 +108,7 @@
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Fehler beim Speichern: {0}</value></data>
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Löschen: {0}</value></data>
   <data name="Err_LadenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Laden: {0}</value></data>
+  <data name="Err_TransferKontenUnterschiedlich" xml:space="preserve"><value>Bitte unterschiedliche Quell- und Zielkonten auswählen.</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Ordner konnte nicht gewählt werden: {0}</value></data>
   <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>Die Suche konnte nicht abgeschlossen werden.</value></data>
 
@@ -277,6 +290,7 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_VorherigesJahr" xml:space="preserve"><value>Vorheriges Jahr</value></data>
   <data name="A11y_NaechstesJahr" xml:space="preserve"><value>Nächstes Jahr</value></data>
   <data name="A11y_TransaktionHinzufuegen" xml:space="preserve"><value>Neue Transaktion hinzufügen</value></data>
+  <data name="A11y_UmbuchungHinzufuegen" xml:space="preserve"><value>Neue Umbuchung hinzufügen</value></data>
   <data name="A11y_KategorieHinzufuegen" xml:space="preserve"><value>Neue Kategorie hinzufügen</value></data>
   <data name="A11y_SparZielHinzufuegen" xml:space="preserve"><value>Neues Sparziel hinzufügen</value></data>
   <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Neuen Dauerauftrag hinzufügen</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -28,6 +28,7 @@
   <data name="Lbl_Titel" xml:space="preserve"><value>Titel</value></data>
   <data name="Lbl_Kategorie" xml:space="preserve"><value>Kategorie</value></data>
   <data name="Lbl_Konto" xml:space="preserve"><value>Konto</value></data>
+  <data name="Lbl_AlleKonten" xml:space="preserve"><value>Alle Konten</value></data>
   <data name="Lbl_Datum" xml:space="preserve"><value>Datum</value></data>
   <data name="Lbl_Startdatum" xml:space="preserve"><value>Startdatum</value></data>
   <data name="Lbl_Enddatum" xml:space="preserve"><value>Enddatum</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -109,6 +109,7 @@
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Löschen: {0}</value></data>
   <data name="Err_LadenFehlgeschlagen" xml:space="preserve"><value>Fehler beim Laden: {0}</value></data>
   <data name="Err_TransferKontenUnterschiedlich" xml:space="preserve"><value>Bitte unterschiedliche Quell- und Zielkonten auswählen.</value></data>
+  <data name="Err_UmbuchungNichtBearbeitbar" xml:space="preserve"><value>Umbuchungen können nicht als Einzelbuchung bearbeitet werden.</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Ordner konnte nicht gewählt werden: {0}</value></data>
   <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>Die Suche konnte nicht abgeschlossen werden.</value></data>
 
@@ -119,6 +120,8 @@
   <data name="Dlg_DauerauftragLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
   <data name="Dlg_TransaktionLoeschen" xml:space="preserve"><value>Transaktion löschen</value></data>
   <data name="Dlg_TransaktionLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
+  <data name="Dlg_UmbuchungLoeschen" xml:space="preserve"><value>Umbuchung löschen</value></data>
+  <data name="Dlg_UmbuchungLoeschenFrage" xml:space="preserve"><value>Umbuchung "{0}" wirklich löschen? Beide Buchungen werden entfernt.</value></data>
   <data name="Dlg_SparZielLoeschen" xml:space="preserve"><value>Sparziel löschen</value></data>
   <data name="Dlg_SparZielLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
 

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -286,4 +286,10 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_HintBetrag" xml:space="preserve"><value>Betrag eingeben, z. B. 12,50</value></data>
   <data name="A11y_HintTitel" xml:space="preserve"><value>Kurze Beschreibung der Transaktion</value></data>
   <data name="A11y_HintBudget" xml:space="preserve"><value>Leer lassen für kein Budgetlimit</value></data>
+  <data name="AccountType_Girokonto" xml:space="preserve"><value>Girokonto</value></data>
+  <data name="AccountType_Tagesgeld" xml:space="preserve"><value>Tagesgeld</value></data>
+  <data name="AccountType_Kreditkarte" xml:space="preserve"><value>Kreditkarte</value></data>
+  <data name="AccountType_Bargeld" xml:space="preserve"><value>Bargeld</value></data>
+  <data name="AccountType_Depot" xml:space="preserve"><value>Wertpapierdepot</value></data>
+  <data name="AccountType_Sonstiges" xml:space="preserve"><value>Sonstiges</value></data>
 </root>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -10,6 +10,7 @@
   <data name="Nav_Transaktionen" xml:space="preserve"><value>Transactions</value></data>
   <data name="Nav_Dauerauftraege" xml:space="preserve"><value>Recurring</value></data>
   <data name="Nav_Kategorien" xml:space="preserve"><value>Categories</value></data>
+  <data name="Nav_Verwaltung" xml:space="preserve"><value>Management</value></data>
   <data name="Nav_Einstellungen" xml:space="preserve"><value>Settings</value></data>
 
   <!-- Page Titles -->
@@ -18,6 +19,9 @@
   <data name="Title_NeueKategorie" xml:space="preserve"><value>New Category</value></data>
   <data name="Title_KategorieBearbeiten" xml:space="preserve"><value>Edit Category</value></data>
   <data name="Title_Jahresansicht" xml:space="preserve"><value>Year Overview</value></data>
+  <data name="Title_Umbuchung" xml:space="preserve"><value>Transfer</value></data>
+  <data name="Title_KontoHinzufuegen" xml:space="preserve"><value>Add account</value></data>
+  <data name="Title_KontoBearbeiten" xml:space="preserve"><value>Edit account</value></data>
 
   <!-- Labels -->
   <data name="Lbl_Name" xml:space="preserve"><value>Name</value></data>
@@ -29,6 +33,12 @@
   <data name="Lbl_Kategorie" xml:space="preserve"><value>Category</value></data>
   <data name="Lbl_Konto" xml:space="preserve"><value>Account</value></data>
   <data name="Lbl_AlleKonten" xml:space="preserve"><value>All Accounts</value></data>
+  <data name="Lbl_Archiviert" xml:space="preserve"><value>Archived</value></data>
+  <data name="Lbl_VonKonto" xml:space="preserve"><value>From account</value></data>
+  <data name="Lbl_NachKonto" xml:space="preserve"><value>To account</value></data>
+  <data name="Btn_Archivieren" xml:space="preserve"><value>Archive</value></data>
+  <data name="Btn_Aktivieren" xml:space="preserve"><value>Activate</value></data>
+  <data name="Hint_Systemkonto" xml:space="preserve"><value>System account cannot be archived or deleted.</value></data>
   <data name="Lbl_Datum" xml:space="preserve"><value>Date</value></data>
   <data name="Lbl_Startdatum" xml:space="preserve"><value>Start Date</value></data>
   <data name="Lbl_Enddatum" xml:space="preserve"><value>End Date</value></data>
@@ -85,6 +95,8 @@
   <data name="Empty_KeineDashboardDaten" xml:space="preserve"><value>No data for this period</value></data>
   <data name="Empty_KeineJahresDaten" xml:space="preserve"><value>No data for this year</value></data>
   <data name="Empty_NochKeineTransaktionen" xml:space="preserve"><value>No transactions yet</value></data>
+  <data name="Empty_KeineKonten" xml:space="preserve"><value>No accounts yet</value></data>
+  <data name="Empty_KontenHinweis" xml:space="preserve"><value>Create an account to assign transactions and recurring items.</value></data>
   <data name="Btn_ZuTransaktionen" xml:space="preserve"><value>Add First Transaction</value></data>
 
   <!-- Error Messages -->
@@ -96,6 +108,7 @@
   <data name="Err_SpeichernFehlgeschlagen" xml:space="preserve"><value>Error saving: {0}</value></data>
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Error deleting: {0}</value></data>
   <data name="Err_LadenFehlgeschlagen" xml:space="preserve"><value>Error loading data: {0}</value></data>
+  <data name="Err_TransferKontenUnterschiedlich" xml:space="preserve"><value>Please select different source and target accounts.</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Folder could not be selected: {0}</value></data>
   <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>The search could not be completed.</value></data>
 
@@ -277,6 +290,7 @@ Please restart the app.</value></data>
   <data name="A11y_VorherigesJahr" xml:space="preserve"><value>Previous year</value></data>
   <data name="A11y_NaechstesJahr" xml:space="preserve"><value>Next year</value></data>
   <data name="A11y_TransaktionHinzufuegen" xml:space="preserve"><value>Add new transaction</value></data>
+  <data name="A11y_UmbuchungHinzufuegen" xml:space="preserve"><value>Add new transfer</value></data>
   <data name="A11y_KategorieHinzufuegen" xml:space="preserve"><value>Add new category</value></data>
   <data name="A11y_SparZielHinzufuegen" xml:space="preserve"><value>Add new savings goal</value></data>
   <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Add new recurring transaction</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -27,6 +27,7 @@
   <data name="Lbl_Betrag" xml:space="preserve"><value>Amount</value></data>
   <data name="Lbl_Titel" xml:space="preserve"><value>Title</value></data>
   <data name="Lbl_Kategorie" xml:space="preserve"><value>Category</value></data>
+  <data name="Lbl_Konto" xml:space="preserve"><value>Account</value></data>
   <data name="Lbl_Datum" xml:space="preserve"><value>Date</value></data>
   <data name="Lbl_Startdatum" xml:space="preserve"><value>Start Date</value></data>
   <data name="Lbl_Enddatum" xml:space="preserve"><value>End Date</value></data>
@@ -72,6 +73,7 @@
   <data name="Hint_Beschreibung" xml:space="preserve"><value>Description</value></data>
   <data name="Hint_Titelbeispiel" xml:space="preserve"><value>e.g. Rent, Netflix, Salary</value></data>
   <data name="Hint_KategorieWaehlen" xml:space="preserve"><value>Select Category</value></data>
+  <data name="Hint_KontoWaehlen" xml:space="preserve"><value>Select Account</value></data>
   <data name="Hint_iCloudTipp" xml:space="preserve"><value>💡 Tip: Choose a folder in iCloud Drive to automatically back up your data.</value></data>
 
   <!-- Empty States -->

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -28,6 +28,7 @@
   <data name="Lbl_Titel" xml:space="preserve"><value>Title</value></data>
   <data name="Lbl_Kategorie" xml:space="preserve"><value>Category</value></data>
   <data name="Lbl_Konto" xml:space="preserve"><value>Account</value></data>
+  <data name="Lbl_AlleKonten" xml:space="preserve"><value>All Accounts</value></data>
   <data name="Lbl_Datum" xml:space="preserve"><value>Date</value></data>
   <data name="Lbl_Startdatum" xml:space="preserve"><value>Start Date</value></data>
   <data name="Lbl_Enddatum" xml:space="preserve"><value>End Date</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -109,6 +109,7 @@
   <data name="Err_LoeschenFehlgeschlagen" xml:space="preserve"><value>Error deleting: {0}</value></data>
   <data name="Err_LadenFehlgeschlagen" xml:space="preserve"><value>Error loading data: {0}</value></data>
   <data name="Err_TransferKontenUnterschiedlich" xml:space="preserve"><value>Please select different source and target accounts.</value></data>
+  <data name="Err_UmbuchungNichtBearbeitbar" xml:space="preserve"><value>Transfers cannot be edited as a single transaction.</value></data>
   <data name="Err_OrdnerNichtWaehlbar" xml:space="preserve"><value>Folder could not be selected: {0}</value></data>
   <data name="Err_SucheFehlgeschlagen" xml:space="preserve"><value>The search could not be completed.</value></data>
 
@@ -119,6 +120,8 @@
   <data name="Dlg_DauerauftragLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
   <data name="Dlg_TransaktionLoeschen" xml:space="preserve"><value>Delete Transaction</value></data>
   <data name="Dlg_TransaktionLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
+  <data name="Dlg_UmbuchungLoeschen" xml:space="preserve"><value>Delete Transfer</value></data>
+  <data name="Dlg_UmbuchungLoeschenFrage" xml:space="preserve"><value>Really delete transfer "{0}"? Both entries will be removed.</value></data>
   <data name="Dlg_SparZielLoeschen" xml:space="preserve"><value>Delete Savings Goal</value></data>
   <data name="Dlg_SparZielLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
 

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -286,4 +286,10 @@ Please restart the app.</value></data>
   <data name="A11y_HintBetrag" xml:space="preserve"><value>Enter amount, e.g. 12.50</value></data>
   <data name="A11y_HintTitel" xml:space="preserve"><value>Short description of the transaction</value></data>
   <data name="A11y_HintBudget" xml:space="preserve"><value>Leave empty for no budget limit</value></data>
+  <data name="AccountType_Girokonto" xml:space="preserve"><value>Checking account</value></data>
+  <data name="AccountType_Tagesgeld" xml:space="preserve"><value>Savings account</value></data>
+  <data name="AccountType_Kreditkarte" xml:space="preserve"><value>Credit card</value></data>
+  <data name="AccountType_Bargeld" xml:space="preserve"><value>Cash</value></data>
+  <data name="AccountType_Depot" xml:space="preserve"><value>Securities account</value></data>
+  <data name="AccountType_Sonstiges" xml:space="preserve"><value>Other</value></data>
 </root>

--- a/Finanzuebersicht/Views/AccountDetailPage.xaml
+++ b/Finanzuebersicht/Views/AccountDetailPage.xaml
@@ -19,9 +19,28 @@
             <VerticalStackLayout Spacing="4">
                 <Label Text="{loc:Translate Lbl_Typ}" FontSize="13" TextColor="Gray" />
                 <Picker ItemsSource="{Binding VerfuegbareTypen}"
-                        SelectedItem="{Binding Type}"
+                        SelectedItem="{Binding SelectedTypeOption}"
+                        ItemDisplayBinding="{Binding DisplayName}"
                         FontSize="16" />
             </VerticalStackLayout>
+
+            <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                <Label Text="Archiviert"
+                       FontSize="16"
+                       VerticalTextAlignment="Center" />
+                <Switch Grid.Column="1"
+                        IsToggled="{Binding IsArchived}"
+                        IsEnabled="{Binding CanArchive}" />
+            </Grid>
+
+            <Label Text="{Binding ArchiveStatusText}"
+                   FontSize="12"
+                   TextColor="Gray" />
+
+            <Label Text="{Binding SystemAccountHint}"
+                   FontSize="12"
+                   TextColor="Gray"
+                   IsVisible="{Binding IsSystemAccount}" />
 
             <Button Text="{loc:Translate Btn_Speichern}"
                     Command="{Binding SaveCommand}"

--- a/Finanzuebersicht/Views/AccountDetailPage.xaml
+++ b/Finanzuebersicht/Views/AccountDetailPage.xaml
@@ -25,7 +25,7 @@
             </VerticalStackLayout>
 
             <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
-                <Label Text="Archiviert"
+                <Label Text="{loc:Translate Lbl_Archiviert}"
                        FontSize="16"
                        VerticalTextAlignment="Center" />
                 <Switch Grid.Column="1"

--- a/Finanzuebersicht/Views/AccountDetailPage.xaml
+++ b/Finanzuebersicht/Views/AccountDetailPage.xaml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             x:Class="Finanzuebersicht.Views.AccountDetailPage"
+             x:DataType="vm:AccountDetailViewModel"
+             Title="{Binding PageTitle}">
+
+    <ScrollView Padding="16">
+        <VerticalStackLayout Spacing="20">
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Name}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding Name}" Placeholder="{loc:Translate Lbl_Konto}"
+                       FontSize="16" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Typ}" FontSize="13" TextColor="Gray" />
+                <Picker ItemsSource="{Binding VerfuegbareTypen}"
+                        SelectedItem="{Binding Type}"
+                        FontSize="16" />
+            </VerticalStackLayout>
+
+            <Button Text="{loc:Translate Btn_Speichern}"
+                    Command="{Binding SaveCommand}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                    TextColor="White"
+                    CornerRadius="12"
+                    HeightRequest="50"
+                    FontSize="16"
+                    FontAttributes="Bold"
+                    Margin="0,20,0,0" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Finanzuebersicht/Views/AccountDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/AccountDetailPage.xaml.cs
@@ -1,0 +1,19 @@
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Views;
+
+public partial class AccountDetailPage : ContentPage, IQueryAttributable
+{
+    public AccountDetailPage(AccountDetailViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (BindingContext is IApplyQueryAttributes vm)
+            vm.ApplyQueryAttributes(query);
+    }
+}

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -7,62 +7,123 @@
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.CategoriesPage"
              x:DataType="vm:CategoriesViewModel"
-             Title="Kategorien">
+             Title="Verwaltung">
 
     <Grid>
-        <RefreshView Command="{Binding LoadKategorienCommand}"
-                     IsRefreshing="{Binding IsLoading}">
-        <CollectionView ItemsSource="{Binding Kategorien}"
-                        SelectionMode="None">
-            <CollectionView.EmptyView>
-                <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
-                    <Label Text="{loc:Translate Empty_KeineKategorien}" FontSize="16"
-                           HorizontalTextAlignment="Center" TextColor="Gray" />
-                </VerticalStackLayout>
-            </CollectionView.EmptyView>
+        <Grid RowDefinitions="Auto, *">
+            <Grid Grid.Row="0" ColumnDefinitions="*,*" Padding="16,12" ColumnSpacing="8">
+                <Button Text="{loc:Translate Nav_Kategorien}"
+                        Command="{Binding ShowKategorienCommand}" />
+                <Button Grid.Column="1"
+                        Text="{loc:Translate Lbl_Konto}"
+                        Command="{Binding ShowKontenCommand}" />
+            </Grid>
 
-            <CollectionView.ItemTemplate>
-                <DataTemplate x:DataType="models:Category">
-                    <SwipeView>
-                        <SwipeView.RightItems>
-                            <SwipeItems>
-                                <SwipeItem Text="{loc:Translate Btn_Loeschen}"
-                                           BackgroundColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
-                                           Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=DeleteKategorieCommand}"
-                                           CommandParameter="{Binding .}" />
-                            </SwipeItems>
-                        </SwipeView.RightItems>
-
-                        <Grid ColumnDefinitions="50, *, Auto" Padding="16,12" ColumnSpacing="12">
-                            <Grid.GestureRecognizers>
-                                <TapGestureRecognizer
-                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=GoToDetailCommand}"
-                                    CommandParameter="{Binding .}" />
-                            </Grid.GestureRecognizers>
-                            <Border Grid.Column="0" BackgroundColor="{Binding Color}"
-                                    StrokeShape="RoundRectangle 12"
-                                    Stroke="Transparent"
-                                    WidthRequest="44" HeightRequest="44"
-                                    Padding="0" HorizontalOptions="Center" VerticalOptions="Center">
-                                <Label Text="{Binding Icon}" FontSize="20"
-                                       HorizontalOptions="Center" VerticalOptions="Center" />
-                            </Border>
-
-                            <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
-                                <Label Text="{Binding Name}" FontSize="16" FontAttributes="Bold" />
-                                <Label Text="{Binding Typ}" FontSize="13" TextColor="Gray" />
+            <Grid Grid.Row="1">
+                <RefreshView Command="{Binding LoadKategorienCommand}"
+                             IsRefreshing="{Binding IsLoading}"
+                             IsVisible="{Binding IsKategorienVisible}">
+                    <CollectionView ItemsSource="{Binding Kategorien}"
+                                    SelectionMode="None">
+                        <CollectionView.EmptyView>
+                            <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
+                                <Label Text="{loc:Translate Empty_KeineKategorien}" FontSize="16"
+                                       HorizontalTextAlignment="Center" TextColor="Gray" />
                             </VerticalStackLayout>
+                        </CollectionView.EmptyView>
 
-                            <Label Grid.Column="2" Text="{loc:Translate Btn_Next}" FontSize="24" TextColor="Gray"
-                                VerticalOptions="Center" />
-                        </Grid>
-                    </SwipeView>
-                </DataTemplate>
-            </CollectionView.ItemTemplate>
-        </CollectionView>
-    </RefreshView>
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="models:Category">
+                                <SwipeView>
+                                    <SwipeView.RightItems>
+                                        <SwipeItems>
+                                            <SwipeItem Text="{loc:Translate Btn_Loeschen}"
+                                                       BackgroundColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
+                                                       Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=DeleteKategorieCommand}"
+                                                       CommandParameter="{Binding .}" />
+                                        </SwipeItems>
+                                    </SwipeView.RightItems>
 
-        <!-- FAB -->
+                                    <Grid ColumnDefinitions="50, *, Auto" Padding="16,12" ColumnSpacing="12">
+                                        <Grid.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=GoToDetailCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        </Grid.GestureRecognizers>
+                                        <Border Grid.Column="0" BackgroundColor="{Binding Color}"
+                                                StrokeShape="RoundRectangle 12"
+                                                Stroke="Transparent"
+                                                WidthRequest="44" HeightRequest="44"
+                                                Padding="0" HorizontalOptions="Center" VerticalOptions="Center">
+                                            <Label Text="{Binding Icon}" FontSize="20"
+                                                   HorizontalOptions="Center" VerticalOptions="Center" />
+                                        </Border>
+
+                                        <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
+                                            <Label Text="{Binding Name}" FontSize="16" FontAttributes="Bold" />
+                                            <Label Text="{Binding Typ}" FontSize="13" TextColor="Gray" />
+                                        </VerticalStackLayout>
+
+                                        <Label Grid.Column="2" Text="{loc:Translate Btn_Next}" FontSize="24" TextColor="Gray"
+                                            VerticalOptions="Center" />
+                                    </Grid>
+                                </SwipeView>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </RefreshView>
+
+                <RefreshView Command="{Binding LoadKategorienCommand}"
+                             IsRefreshing="{Binding IsLoading}"
+                             IsVisible="{Binding IsKontenVisible}">
+                    <CollectionView ItemsSource="{Binding Konten}"
+                                    SelectionMode="None">
+                        <CollectionView.EmptyView>
+                            <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
+                                <Label Text="{loc:Translate Lbl_Konto}" FontSize="16"
+                                       HorizontalTextAlignment="Center" TextColor="Gray" />
+                            </VerticalStackLayout>
+                        </CollectionView.EmptyView>
+
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="models:Account">
+                                <Grid ColumnDefinitions="50, *, Auto" Padding="16,12" ColumnSpacing="12">
+                                    <Grid.GestureRecognizers>
+                                        <TapGestureRecognizer
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=GoToDetailCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    </Grid.GestureRecognizers>
+                                    <Border Grid.Column="0"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
+                                            StrokeShape="RoundRectangle 12"
+                                            Stroke="Transparent"
+                                            WidthRequest="44" HeightRequest="44"
+                                            Padding="0" HorizontalOptions="Center" VerticalOptions="Center">
+                                        <Label Text="🏦" FontSize="20"
+                                               HorizontalOptions="Center" VerticalOptions="Center" />
+                                    </Border>
+
+                                    <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
+                                        <Label Text="{Binding Name}" FontSize="16" FontAttributes="Bold" />
+                                        <Label Text="{Binding Type}" FontSize="13" TextColor="Gray" />
+                                    </VerticalStackLayout>
+
+                                    <Button Grid.Column="2"
+                                            Text="{loc:Translate Btn_Loeschen}"
+                                            IsVisible="{Binding CanDelete}"
+                                            BackgroundColor="Transparent"
+                                            TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=DeleteKontoCommand}"
+                                            CommandParameter="{Binding .}" />
+                                </Grid>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
+                </RefreshView>
+            </Grid>
+
+        </Grid>
+
         <Button Text="{loc:Translate Btn_Hinzufuegen}"
                 FontSize="28" TextColor="White"
                 BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -4,10 +4,15 @@
              xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
+             xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.CategoriesPage"
              x:DataType="vm:CategoriesViewModel"
              Title="Verwaltung">
+
+    <views:BaseContentPage.Resources>
+        <conv:AccountTypeToLocalizedStringConverter x:Key="AccountTypeToLocalizedStringConverter" />
+    </views:BaseContentPage.Resources>
 
     <Grid>
         <Grid RowDefinitions="Auto, *">
@@ -80,8 +85,13 @@
                                     SelectionMode="None">
                         <CollectionView.EmptyView>
                             <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
-                                <Label Text="{loc:Translate Lbl_Konto}" FontSize="16"
+                               <Label Text="Keine Konten vorhanden" FontSize="16"
                                        HorizontalTextAlignment="Center" TextColor="Gray" />
+                               <Label Text="Lege ein Konto an, um Transaktionen und Daueraufträge zuzuordnen."
+                                      Margin="0,6,0,0"
+                                      FontSize="13"
+                                      HorizontalTextAlignment="Center"
+                                      TextColor="Gray" />
                             </VerticalStackLayout>
                         </CollectionView.EmptyView>
 
@@ -105,16 +115,35 @@
 
                                     <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
                                         <Label Text="{Binding Name}" FontSize="16" FontAttributes="Bold" />
-                                        <Label Text="{Binding Type}" FontSize="13" TextColor="Gray" />
+                                       <Label Text="{Binding Type, Converter={StaticResource AccountTypeToLocalizedStringConverter}}" FontSize="13" TextColor="Gray" />
+                                       <HorizontalStackLayout Spacing="6">
+                                           <Label Text="System"
+                                                  IsVisible="{Binding IsSystemAccount}"
+                                                  FontSize="11"
+                                                  TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
+                                           <Label Text="Archiviert"
+                                                  IsVisible="{Binding IsArchived}"
+                                                  FontSize="11"
+                                                  TextColor="Gray" />
+                                       </HorizontalStackLayout>
                                     </VerticalStackLayout>
 
-                                    <Button Grid.Column="2"
-                                            Text="{loc:Translate Btn_Loeschen}"
-                                            IsVisible="{Binding CanDelete}"
-                                            BackgroundColor="Transparent"
-                                            TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
-                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=DeleteKontoCommand}"
-                                            CommandParameter="{Binding .}" />
+                                    <VerticalStackLayout Grid.Column="2" Spacing="4" VerticalOptions="Center">
+                                        <Button Text="{loc:Translate Btn_Loeschen}"
+                                                IsVisible="{Binding CanDelete}"
+                                                BackgroundColor="Transparent"
+                                                FontSize="12"
+                                                TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=DeleteKontoCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        <Button Text="{Binding ArchiveActionText}"
+                                                IsVisible="{Binding CanArchive}"
+                                                BackgroundColor="Transparent"
+                                                FontSize="12"
+                                                TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=ToggleKontoArchivierungCommand}"
+                                                CommandParameter="{Binding .}" />
+                                    </VerticalStackLayout>
                                 </Grid>
                             </DataTemplate>
                         </CollectionView.ItemTemplate>

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -8,10 +8,11 @@
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.CategoriesPage"
              x:DataType="vm:CategoriesViewModel"
-             Title="Verwaltung">
+             Title="{loc:Translate Nav_Verwaltung}">
 
     <views:BaseContentPage.Resources>
         <conv:AccountTypeToLocalizedStringConverter x:Key="AccountTypeToLocalizedStringConverter" />
+        <conv:AccountArchiveActionConverter x:Key="AccountArchiveActionConverter" />
     </views:BaseContentPage.Resources>
 
     <Grid>
@@ -85,9 +86,9 @@
                                     SelectionMode="None">
                         <CollectionView.EmptyView>
                             <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
-                               <Label Text="Keine Konten vorhanden" FontSize="16"
+                               <Label Text="{loc:Translate Empty_KeineKonten}" FontSize="16"
                                        HorizontalTextAlignment="Center" TextColor="Gray" />
-                               <Label Text="Lege ein Konto an, um Transaktionen und Daueraufträge zuzuordnen."
+                               <Label Text="{loc:Translate Empty_KontenHinweis}"
                                       Margin="0,6,0,0"
                                       FontSize="13"
                                       HorizontalTextAlignment="Center"
@@ -117,11 +118,11 @@
                                         <Label Text="{Binding Name}" FontSize="16" FontAttributes="Bold" />
                                        <Label Text="{Binding Type, Converter={StaticResource AccountTypeToLocalizedStringConverter}}" FontSize="13" TextColor="Gray" />
                                        <HorizontalStackLayout Spacing="6">
-                                           <Label Text="System"
+                                           <Label Text="{loc:Translate Btn_System}"
                                                   IsVisible="{Binding IsSystemAccount}"
                                                   FontSize="11"
                                                   TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
-                                           <Label Text="Archiviert"
+                                           <Label Text="{loc:Translate Lbl_Archiviert}"
                                                   IsVisible="{Binding IsArchived}"
                                                   FontSize="11"
                                                   TextColor="Gray" />
@@ -136,7 +137,7 @@
                                                 TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
                                                 Command="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=DeleteKontoCommand}"
                                                 CommandParameter="{Binding .}" />
-                                        <Button Text="{Binding ArchiveActionText}"
+                                        <Button Text="{Binding IsArchived, Converter={StaticResource AccountArchiveActionConverter}}"
                                                 IsVisible="{Binding CanArchive}"
                                                 BackgroundColor="Transparent"
                                                 FontSize="12"

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -51,6 +51,18 @@
                     </Grid>
                 </Border>
 
+                <Grid ColumnDefinitions="70,*" ColumnSpacing="8">
+                    <Label Grid.Column="0"
+                           Text="{loc:Translate Lbl_Konto}"
+                           FontSize="13"
+                           TextColor="Gray"
+                           VerticalTextAlignment="Center" />
+                    <Picker Grid.Column="1"
+                            ItemsSource="{Binding AvailableKonten}"
+                            ItemDisplayBinding="{Binding DisplayName}"
+                            SelectedItem="{Binding SelectedKontoFilterItem}" />
+                </Grid>
+
                 <!-- Global Empty State – keine Transaktionen vorhanden -->
                 <VerticalStackLayout Spacing="16" HorizontalOptions="Center" Margin="0,40,0,0"
                                      IsVisible="{Binding HasAnyData, Converter={StaticResource InvertBool}}">

--- a/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
@@ -56,6 +56,15 @@
                         FontSize="16" />
             </VerticalStackLayout>
 
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Konto}" FontSize="13" TextColor="Gray" />
+                <Picker ItemsSource="{Binding Accounts}"
+                        SelectedItem="{Binding SelectedAccount}"
+                        ItemDisplayBinding="{Binding Name}"
+                        Title="{loc:Translate Hint_KontoWaehlen}"
+                        FontSize="16" />
+            </VerticalStackLayout>
+
             <!-- Startdatum -->
             <VerticalStackLayout Spacing="4">
                 <Label Text="{loc:Translate Lbl_Startdatum}" FontSize="13" TextColor="Gray" />

--- a/Finanzuebersicht/Views/TransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/TransactionDetailPage.xaml
@@ -64,6 +64,16 @@
                         FontSize="16" />
             </VerticalStackLayout>
 
+            <!-- Konto -->
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Konto}" FontSize="13" TextColor="Gray" />
+                <Picker ItemsSource="{Binding Accounts}"
+                        SelectedItem="{Binding SelectedAccount}"
+                        ItemDisplayBinding="{Binding Name}"
+                        Title="{loc:Translate Hint_KontoWaehlen}"
+                        FontSize="16" />
+            </VerticalStackLayout>
+
             <!-- Speichern -->
             <Button Text="{loc:Translate Btn_Speichern}" Command="{Binding SaveCommand}"
                     BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" TextColor="White"

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -14,6 +14,7 @@
         <conv:TransactionTypToColorConverter x:Key="TypToColor" />
         <conv:BetragDisplayConverter x:Key="BetragDisplay" />
         <conv:KategorieIdToIconConverter x:Key="KategorieIdToIcon" />
+        <conv:AccountIdToNameConverter x:Key="AccountIdToName" />
         <conv:InvertBoolConverter x:Key="InvertBool" />
 
         <!-- Shared transaction row layout (tap-only, no swipe).
@@ -46,6 +47,16 @@
                            LineBreakMode="TailTruncation" />
                     <Label Text="{Binding Verwendungszweck}" FontSize="12" TextColor="Gray"
                            LineBreakMode="TailTruncation" />
+                    <Label FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
+                           LineBreakMode="TailTruncation">
+                        <Label.Text>
+                            <MultiBinding Converter="{StaticResource AccountIdToName}">
+                                <Binding Path="AccountId" />
+                                <Binding Source="{RelativeSource AncestorType={x:Type views:BaseContentPage}}"
+                                         Path="BindingContext.AccountMap" />
+                            </MultiBinding>
+                        </Label.Text>
+                    </Label>
                 </VerticalStackLayout>
                 <Label Grid.Column="2"
                        Text="{Binding ., Converter={StaticResource BetragDisplay}}"
@@ -121,6 +132,17 @@
                             ItemsSource="{Binding AvailableKategorien}"
                             ItemDisplayBinding="{Binding DisplayName}"
                             SelectedItem="{Binding SelectedKategorieFilterItem}"
+                            FontSize="14" />
+                </Grid>
+
+                <!-- Konto-Filter -->
+                <Grid ColumnDefinitions="80, *" ColumnSpacing="8">
+                    <Label Grid.Column="0" Text="{loc:Translate Lbl_Konto}"
+                           FontSize="13" TextColor="Gray" VerticalTextAlignment="Center" />
+                    <Picker Grid.Column="1"
+                            ItemsSource="{Binding AvailableKonten}"
+                            ItemDisplayBinding="{Binding DisplayName}"
+                            SelectedItem="{Binding SelectedKontoFilterItem}"
                             FontSize="14" />
                 </Grid>
 

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -371,6 +371,7 @@
                         BackgroundColor="Transparent"
                         WidthRequest="44"
                         HeightRequest="44"
+                        SemanticProperties.Description="{loc:Translate A11y_UmbuchungHinzufuegen}"
                         Command="{Binding GoToTransferCommand}" />
             </HorizontalStackLayout>
             <Button Text="{loc:Translate Btn_Hinzufuegen}"

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -361,10 +361,18 @@
 
         <!-- FABs (immer sichtbar, über Row 4) -->
         <Grid Grid.Row="4" HorizontalOptions="Fill" VerticalOptions="End" Padding="20,0,20,20">
-            <Button Text="{loc:Translate Btn_Import}" FontSize="14" TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                    BackgroundColor="Transparent"
-                    HorizontalOptions="Start" VerticalOptions="End"
-                    Command="{Binding ImportCsvCommand}" />
+            <HorizontalStackLayout Spacing="12" HorizontalOptions="Start" VerticalOptions="End">
+                <Button Text="{loc:Translate Btn_Import}" FontSize="14" TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                        BackgroundColor="Transparent"
+                        Command="{Binding ImportCsvCommand}" />
+                <Button Text="↔"
+                        FontSize="20"
+                        TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                        BackgroundColor="Transparent"
+                        WidthRequest="44"
+                        HeightRequest="44"
+                        Command="{Binding GoToTransferCommand}" />
+            </HorizontalStackLayout>
             <Button Text="{loc:Translate Btn_Hinzufuegen}"
                     FontSize="28" TextColor="White"
                     BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"

--- a/Finanzuebersicht/Views/TransferDetailPage.xaml
+++ b/Finanzuebersicht/Views/TransferDetailPage.xaml
@@ -7,12 +7,12 @@
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.TransferDetailPage"
              x:DataType="vm:TransferDetailViewModel"
-             Title="Umbuchung">
+             Title="{loc:Translate Title_Umbuchung}">
 
     <ScrollView Padding="16">
         <VerticalStackLayout Spacing="20">
             <VerticalStackLayout Spacing="4">
-                <Label Text="Von Konto" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_VonKonto}" FontSize="13" TextColor="Gray" />
                 <Picker ItemsSource="{Binding Accounts}"
                         SelectedItem="{Binding SourceAccount}"
                         ItemDisplayBinding="{Binding Name}"
@@ -20,7 +20,7 @@
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="4">
-                <Label Text="Nach Konto" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_NachKonto}" FontSize="13" TextColor="Gray" />
                 <Picker ItemsSource="{Binding Accounts}"
                         SelectedItem="{Binding TargetAccount}"
                         ItemDisplayBinding="{Binding Name}"

--- a/Finanzuebersicht/Views/TransferDetailPage.xaml
+++ b/Finanzuebersicht/Views/TransferDetailPage.xaml
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
+             xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             xmlns:models="clr-namespace:Finanzuebersicht.Models"
+             xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             x:Class="Finanzuebersicht.Views.TransferDetailPage"
+             x:DataType="vm:TransferDetailViewModel"
+             Title="Umbuchung">
+
+    <ScrollView Padding="16">
+        <VerticalStackLayout Spacing="20">
+            <VerticalStackLayout Spacing="4">
+                <Label Text="Von Konto" FontSize="13" TextColor="Gray" />
+                <Picker ItemsSource="{Binding Accounts}"
+                        SelectedItem="{Binding SourceAccount}"
+                        ItemDisplayBinding="{Binding Name}"
+                        FontSize="16" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="Nach Konto" FontSize="13" TextColor="Gray" />
+                <Picker ItemsSource="{Binding Accounts}"
+                        SelectedItem="{Binding TargetAccount}"
+                        ItemDisplayBinding="{Binding Name}"
+                        FontSize="16" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Betrag}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding AmountText}" Placeholder="{loc:Translate Hint_Betrag}"
+                       Keyboard="Numeric" FontSize="28" FontAttributes="Bold"
+                       HorizontalTextAlignment="Center" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding Title}" FontSize="16" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Verwendungszweck}" FontSize="13" TextColor="Gray" />
+                <Editor Text="{Binding Note}" HeightRequest="100" AutoSize="TextChanges" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Datum}" FontSize="13" TextColor="Gray" />
+                <DatePicker Date="{Binding Date}" FontSize="16"
+                            Format="dd. MMMM yyyy" />
+            </VerticalStackLayout>
+
+            <Button Text="{loc:Translate Btn_Speichern}" Command="{Binding SaveCommand}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                    TextColor="White" CornerRadius="12" HeightRequest="50"
+                    FontSize="16" FontAttributes="Bold"
+                    Margin="0,20,0,0" />
+        </VerticalStackLayout>
+    </ScrollView>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/TransferDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/TransferDetailPage.xaml.cs
@@ -1,0 +1,12 @@
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Views;
+
+public partial class TransferDetailPage : BaseContentPage
+{
+    public TransferDetailPage(TransferDetailViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}


### PR DESCRIPTION
## Überblick
Dieser PR erweitert den Multi-Account-Stand auf ein durchgängiges Nutzungsniveau inkl. Verwaltung, Umbuchungen, Konto-Filter im Dashboard sowie Archivierung.

## Enthaltene Änderungen
- **Kontoverwaltung in "Verwaltung"**
  - Konto-Liste + Konto-Detail inkl. Anlegen/Bearbeiten/Löschen
  - Schutz für Systemkonto (nicht lösch-/archivierbar)
  - Konto-Typen lokalisiert dargestellt
- **Transaktionen & Daueraufträge mit Konto-Bezug**
  - Kontoauswahl in Detailseiten
  - Kontofilter in Transaktionsliste/Suche
  - Daueraufträge um `AccountId` erweitert
- **Umbuchungs-Flow**
  - Neue Umbuchungsseite (Quelle/Ziel/Betrag/Datum)
  - Paarbuchung mit `IsTransfer` + gemeinsamer `TransferGroupId`
  - Löschen einer Umbuchung entfernt die gesamte Gruppe
  - Einzelbearbeitung von Transfer-Legs wird blockiert
- **Reporting / Dashboard+**
  - Transfers aus Ausgaben-Summen ausgeschlossen
  - Dashboard um Konto-Filter erweitert (Monat/Jahr + Trend)
- **Konten archivieren**
  - `Account.IsArchived`
  - Archivieren/Reaktivieren in Verwaltung
  - Archivierte Konten aus Neuanlage-Pickern ausgeblendet
  - Fallback: bereits referenzierte archivierte Konten bleiben auswählbar
- **Infra / Migration / Backup**
  - Account-Store + Repositories/DI ergänzt
  - Initialisierung/Migration/Backup für Konten erweitert

## Qualität
- UseCases, ViewModels und Services wurden um passende Tests ergänzt/angepasst.
- Build-/Regression-Hotfix enthalten: fehlender Import im `AccountTypeToLocalizedStringConverter`.

## Hinweise
- Scope ist bewusst auf funktionale Erweiterung und Datenintegrität ausgelegt; kein Breaking Change in vorhandenen Benutzerflüssen beabsichtigt.
