### PR TITLE
fix: Dashboard XAML compiled bindings for CI/Release

### DIFF
--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -3,6 +3,7 @@
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
+             xmlns:recurring="clr-namespace:Finanzuebersicht.Application.UseCases.RecurringTransactions;assembly=Finanzuebersicht.Application"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.DashboardPage"
@@ -55,7 +56,7 @@
                                      IsVisible="{Binding HasDueItems}"
                                      BindableLayout.ItemsSource="{Binding DueRecurringItems}">
                     <BindableLayout.ItemTemplate>
-                        <DataTemplate>
+                        <DataTemplate x:DataType="recurring:DueRecurringItem">
                             <Border StrokeShape="RoundRectangle 10"
                                     Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
                                     BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"


### PR DESCRIPTION
## Summary
Fixes failed Release v1.11 and CI full builds (Mac Catalyst + Windows).

## Root cause
`DashboardPage.xaml` DataTemplate for due recurring items was missing `x:DataType`, causing MAUIG2024/MAUIG2045 errors in Release builds.

## Fix
- Add `x:DataType="recurring:DueRecurringItem"` to the due-recurring `DataTemplate` (same pattern as `CashflowPage`).

## Test plan
- [x] 274 unit tests green locally
- [ ] CI full build (Mac Catalyst + Windows)
- [ ] Re-run Release workflow for `v1.11`

Made with [Cursor](https://cursor.com)