### PR TITLE
feat(accounts): Anfangssaldo pro Konto

### DIFF
--- a/.cursor/rules/app-domain.mdc
+++ b/.cursor/rules/app-domain.mdc
@@ -1,0 +1,26 @@
+---
+description: Finanzübersicht Domänenindex — verweist auf copilot-instructions.md
+alwaysApply: true
+---
+
+# Finanzübersicht — Cursor Domänenindex
+
+**Vollständige Referenz:** `.github/copilot-instructions.md` (zuerst lesen bei Architektur-, Build- oder Feature-Fragen).
+
+## Schnellreferenz
+
+- **Stack:** .NET 10 MAUI, Clean Architecture + MVVM, JSON-Persistenz, DE/EN
+- **Tabs:** Dashboard · Transaktionen · Daueraufträge · Verwaltung (Kategorien/Konten) · Sparziele · Einstellungen (Toolbar)
+- **Neuer Code:** ViewModel → Use Case → `I*Repository` (nicht `IDataService`)
+- **ViewModels:** `Finanzuebersicht.Presentation/ViewModels/` — in `PresentationServiceCollectionExtensions` registrieren
+- **Build macOS:** `dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst` → `maccatalyst-arm64/Finanzübersicht.app`
+
+## Konten & Salden (Issues #212–#214)
+
+- `GetAccountBalancesUseCase`: Saldo = Σ Buchungen (Transfers korrekt)
+- Liste mit Saldo: Verwaltung → Konten
+- Anfangssaldo, Dashboard-Übersicht, manueller Abgleich → siehe Issues, nicht neu erfinden
+
+## Nicht wiederholen
+
+Vor Konten-/Saldo-Feature-Vorschlägen: `copilot-instructions.md` + Issues #212–#214 prüfen.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,128 +1,209 @@
 # Copilot Instructions – Finanzübersicht
 
+> **Für AI-Assistenten (Copilot & Cursor):** Diese Datei ist die zentrale Projektreferenz.
+> Cursor lädt zusätzlich `.cursor/rules/app-domain.mdc` (kompakter Domänenindex mit Issue-Links).
+> Vor Feature-Analysen: hier lesen, nicht von Null starten.
+
 ## Project Overview
 
-A personal finance overview app built with **.NET 10 and .NET MAUI**, targeting **iOS and macOS** (Mac Catalyst). Data is persisted locally via JSON files (`LocalDataService`); CloudKit support requires a paid Apple Developer account. Architecture follows **MVVM**. Languages: German and English supported; additional languages possible but not actively maintained.
+Personal finance app built with **.NET 10** and **.NET MAUI**, targeting **macOS (Mac Catalyst)** and **iOS**.
+Data is persisted locally as JSON. Architecture: **Clean Architecture + MVVM**.
+Languages: **German and English** (`AppResources.resx` / `AppResources.de.resx`).
+
+Current version baseline: `version.json` → `1.11` (patch = git height via Nerdbank.GitVersioning).
 
 ## Build & Run
 
 ```bash
 dotnet restore
 
-# Build for macOS (Mac Catalyst)
-dotnet build -f net10.0-maccatalyst
+# Tests (CI quick path — no MAUI workload required)
+dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj -c Release
+
+# Build macOS (Mac Catalyst) — build MAUI project only, not whole solution
+dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst -c Debug
 
 # Build for iOS
-dotnet build -f net10.0-ios
-
-# Run tests
-dotnet test Finanzuebersicht.Tests
+dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-ios
 ```
 
-> Xcode version validation is disabled in the `.csproj` (`ValidateXcodeVersion=false`) due to SDK/Xcode version mismatch.
+> `ValidateXcodeVersion=false` in the `.csproj` due to SDK/Xcode version tolerance.
+> `TreatWarningsAsErrors=true` globally in `Directory.Build.props`.
 
 ### Running on macOS (Mac Catalyst)
 
-`dotnet run` and `-t:Run` fail due to macOS sandboxing. To launch the app, copy it to `/Applications` first:
+`dotnet run` and `-t:Run` fail due to macOS sandboxing. Copy the `.app` to `/Applications` first:
 
 ```bash
-cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-x64/Finanzübersicht.app /Applications/
+# Apple Silicon (arm64) — typical on modern Macs
+cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/
 open /Applications/Finanzübersicht.app
+
+# Intel (x64)
+cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-x64/Finanzübersicht.app /Applications/
 ```
 
-For a one-liner after every build:
+One-liner after build (adjust `arm64` / `x64` as needed):
 
 ```bash
-dotnet build -f net10.0-maccatalyst && cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-x64/Finanzübersicht.app /Applications/ && open /Applications/Finanzübersicht.app
+dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst -c Debug \
+  && cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/ \
+  && open /Applications/Finanzübersicht.app
 ```
 
 ## Architecture
 
-**MVVM** using `CommunityToolkit.Mvvm` source generators:
+Layered clean architecture with MVVM (`CommunityToolkit.Mvvm` source generators):
 
-- `Finanzuebersicht.Core/` – Shared .NET 10 class library (models, services, interfaces)
-- `Finanzuebersicht/` – .NET MAUI app (ViewModels, Views, Converters, platform code)
-- `Finanzuebersicht.Tests/` – xUnit test project (references Core only)
+| Project | Role |
+|---------|------|
+| `Finanzuebersicht.Core` | Models, repository interfaces, domain services (forecast, categorization, migrations) |
+| `Finanzuebersicht.Application` | Use cases (orchestration, no UI/IO) |
+| `Finanzuebersicht.Infrastructure` | JSON stores, `LocalDataService`, backup, settings, import parsers |
+| `Finanzuebersicht.Presentation` | ViewModels, navigation abstractions (`Routes`, `INavigationService`) |
+| `Finanzuebersicht` | MAUI app: Views (XAML), Converters, Charts, `MauiProgram`, platform code |
+| `Finanzuebersicht.Tests` | xUnit + NSubstitute; references Core, Application, Infrastructure, Presentation |
 
-Navigation: Shell with 5 tabs (Dashboard, Transaktionen, Daueraufträge, Kategorien, Einstellungen) + 3 detail pages via Shell routing.
+**Data flow:** View → ViewModel → Use Case → Repository (`I*Repository`) → JSON Store
+
+**Legacy:** `IDataService` / `DataServiceFacade` still registered for compatibility — **new code uses repository interfaces and use cases**.
+
+**DI entry points:**
+- `MauiProgram.cs` — app services, pages
+- `AddInfrastructureServices()` — stores + repositories
+- `AddApplicationUseCases()` — all use cases
+- `AddPresentationViewModels()` — ViewModels (`Finanzuebersicht.Presentation`)
+
+## Navigation
+
+**5 tabs** (`AppShell.xaml`):
+
+| Tab | Page | Purpose |
+|-----|------|---------|
+| Dashboard | `DashboardPage` | Month/year overview, budgets, due recurring, account filter, cashflow link |
+| Transaktionen | `TransactionsPage` | Transaction list, search, templates, account filter |
+| Daueraufträge | `RecurringTransactionsPage` | Recurring transactions |
+| Verwaltung | `CategoriesPage` | Toggle: **Kategorien** / **Konten** (accounts with balance) |
+| Sparziele | `SparZielePage` | Savings goals |
+
+**Toolbar:** Einstellungen → `SettingsPage`
+
+**Shell routes** (`Routes.cs`): TransactionDetail, TransferDetail, RecurringTransactionDetail, RecurringInstanceShift, CategoryDetail, AccountDetail, Settings, BackupList, ImportPreview, Cashflow
+
+## Feature Domains (quick reference)
+
+### Accounts & balances
+- `GetAccountBalancesUseCase` — Saldo = Σ transactions per account (transfers affect both sides)
+- Account list with balance: **Verwaltung → Konten** (`CategoriesViewModel`, `AccountListItem`)
+- Dashboard shows single-account balance when filter is set (not total overview yet)
+- **Planned:** Opening balance (#212), dashboard overview (#213), manual reconciliation (#214)
+
+### Dashboard
+- `LoadDashboardMonthUseCase`, `LoadDashboardYearUseCase`, `LoadForecastUseCase`
+- Due recurring widget with book/skip/shift actions
+
+### Cashflow
+- `LoadCashflowOutlookUseCase` — 30-day outlook per account (`CashflowPage`, linked from Dashboard)
+- Forward-looking cashflow, **not** account balance
+
+### Import
+- CSV import (DKB parser), import preview, auto-categorization (`KeywordCategorizationStrategy`, `HistoricalCategorizationStrategy`)
+- No Open Banking / bank API integration
+
+### Other
+- Sparziele with transaction linking and completion forecast
+- Backup/restore (ZIP/JSON), configurable data path
+- CloudKit code exists but disabled (requires paid Apple Developer account)
 
 ## Data Persistence
 
-- All CRUD goes through `IDataService` → `LocalDataService` (Singleton, JSON files)
-- Storage path configurable via `SettingsService` ("DataPath" key), default: `LocalApplicationData/Finanzuebersicht`
-- CloudKit code exists (`CloudKitDataService`) but is disabled (requires paid Apple Developer account)
-- Recurring transaction auto-generation runs on `App.OnStart()` and `Window.Resumed`
+- JSON files per entity in configurable data directory (`SettingsService` key `DataPath`)
+- Default macOS path: `~/Library/Application Support/Finanzuebersicht` (`AppPaths`)
+- Stores: `CategoryStore`, `AccountStore`, `TransactionStore`, `RecurringStore`, `BudgetStore`, `SparZielStore`, `TransactionTemplateStore`
+- `LocalDataService` coordinates stores and implements all `I*Repository` interfaces
+- Schema migrations via `IDataMigrator` (V1→V2, V2→V3)
+- Recurring auto-generation on `App.OnStart()` and `Window.Resumed`
 
 ## Key Conventions
 
-- `CommunityToolkit.Mvvm` source generators everywhere — no manual `INotifyPropertyChanged`
-- All services and ViewModels registered in `MauiProgram.cs` via DI (`AddSingleton` / `AddTransient`)
-- Pages receive their ViewModel via constructor injection
-- `OnAppearing()` triggers data loading via command execution
+- `CommunityToolkit.Mvvm` source generators — no manual `INotifyPropertyChanged`
+- ViewModels live in `Finanzuebersicht.Presentation/ViewModels/` (namespace `Finanzuebersicht.ViewModels`)
+- Register new ViewModels in `PresentationServiceCollectionExtensions.cs`
+- Pages in `Finanzuebersicht/Views/`, registered in `MauiProgram.cs`
+- Pages receive ViewModels via constructor injection; `OnAppearing()` triggers `Load*Command`
+- Navigation from ViewModels via `INavigationService` + `Routes` constants (no direct View type references)
 - Monetary values: `decimal` in C#, formatted with `CultureInfo.CurrentCulture`
 - Use `Border` with `StrokeShape="RoundRectangle"` instead of deprecated `Frame`
-- Colors defined in `Resources/Styles/Colors.xaml` (Apple System Colors palette)
-- Light/Dark mode via `AppThemeBinding` — avoid hardcoded color values in XAML
-- Multi-language support (German and English); additional languages possible but not maintained
+- Colors in `Resources/Styles/Colors.xaml` — use `AppThemeBinding`, no hardcoded colors in XAML
+- Localization: add keys to `AppResources.resx` + `AppResources.de.resx` + `ResourceKeys.cs`
 
 ## Versioning
 
-Automatic **SemVer** via **Nerdbank.GitVersioning** (`version.json` in repo root):
+Automatic **SemVer** via **Nerdbank.GitVersioning** (`version.json`):
 
-- Version = `<major>.<minor>.<git-height>` (e.g., `0.1.5` = 5 commits since 0.1.0)
-- MAUI `ApplicationDisplayVersion` and `ApplicationVersion` are set automatically at build time
-- **Bump version:** edit `version.json` or run `nbgv set-version <new-version>`
-- **Current version:** run `nbgv get-version`
-- `publicReleaseRefSpec`: `main` and `release/v*` branches produce stable versions
-- Cloud build numbers enabled for CI pipelines
+- Version = `<major>.<minor>.<git-height>` (e.g. `1.11.5`)
+- Bump: edit `version.json` or `nbgv set-version <version>`
+- Current: `nbgv get-version`
+- Stable releases: `main` and `release/v*` branches
 
 ## Git Branching Strategy
 
-**`main` is protected** — no direct commits to `main`. It is always release-ready.
-
-All feature development targets `develop`. When a milestone is complete, `develop` is merged into `main` via PR, then tagged to trigger a release.
+**`main` is protected** — release-ready only. All development targets `develop`.
 
 ```
-main              ← stable, release-ready (merge from develop when milestone complete)
-develop           ← integration branch for ongoing work
-├── feature/*     ← new features (e.g., feature/cloud-sync)
-├── fix/*         ← bug fixes (e.g., fix/dark-mode-contrast)
-├── chore/*       ← tooling, deps, config (e.g., chore/update-packages)
-└── release/v*    ← release preparation (e.g., release/v1.0)
+main              ← stable (merge from develop when milestone complete)
+develop           ← integration branch
+├── feature/*     ← new features
+├── fix/*         ← bug fixes
+├── chore/*       ← tooling, deps, config
+└── release/v*    ← release preparation
 ```
 
 **Workflow:**
-1. Create branch from `develop`: `git checkout develop && git checkout -b feature/<name>`
-2. Make changes, commit following conventions below
-3. Push branch and create Pull Request targeting `develop`
-4. When milestone is complete: PR `develop` → `main`, then tag to release
+1. Branch from `develop`: `git checkout develop && git checkout -b feature/<name>`
+2. Push and open PR targeting `develop`
+3. Milestone complete: PR `develop` → `main`, then tag
 
-**Branch naming:** `<type>/<short-description>` in kebab-case (English)
+Branch naming: `<type>/<short-description>` in kebab-case (English)
 
 ## Project Structure
 
 ```
-Finanzuebersicht.slnx              ← Solution file
-version.json                       ← Nerdbank.GitVersioning config
-Directory.Build.props              ← Shared MSBuild properties (nbgv package)
+Finanzuebersicht.slnx
+version.json
+Directory.Build.props              ← TreatWarningsAsErrors, Nerdbank.GitVersioning
 
-Finanzuebersicht.Core/             ← Shared library (net10.0)
-├── Models/                        ← Transaction, Category, RecurringTransaction, etc.
-└── Services/                      ← IDataService, LocalDataService, SettingsService, InitializationService
+Finanzuebersicht.Core/             ← net10.0
+├── Models/                        ← Transaction, Category, Account, SparZiel, …
+├── Services/                      ← I*Repository, IClock, ForecastService, ImportService, …
+└── Constants/
 
-Finanzuebersicht/                  ← MAUI app (net10.0-ios, net10.0-maccatalyst)
+Finanzuebersicht.Application/      ← net10.0
+└── UseCases/                      ← Dashboard, Accounts, Transactions, Recurring, SparZiele, …
+
+Finanzuebersicht.Infrastructure/     ← net10.0
+├── Services/                      ← *Store, LocalDataService, BackupService, SettingsService
+└── DependencyInjection/
+
+Finanzuebersicht.Presentation/       ← net10.0
+├── ViewModels/
+├── Navigation/                    ← Routes.cs
+└── Services/                      ← IDialogService, INavigationService, …
+
+Finanzuebersicht/                    ← net10.0-ios, net10.0-maccatalyst
 ├── MauiProgram.cs
-├── App.xaml / App.xaml.cs
-├── AppShell.xaml / AppShell.xaml.cs
-├── ViewModels/                    ← DashboardVM, TransactionsVM, SettingsVM, etc.
+├── AppShell.xaml
 ├── Views/                         ← XAML pages
-├── Converters/                    ← Value converters for UI
-├── Handlers/                      ← Custom Shell renderer (FastShellRenderer)
-├── Resources/Styles/              ← Colors.xaml, Styles.xaml
-└── Platforms/                     ← iOS, MacCatalyst
+├── Converters/
+├── Charts/
+├── Resources/Strings/             ← AppResources.resx, AppResources.de.resx
+└── Platforms/
 
-Finanzuebersicht.Tests/            ← xUnit tests (net10.0, references Core only)
-└── Services/                      ← LocalDataService, InitializationService tests
+Finanzuebersicht.Tests/              ← net10.0
+├── Application/UseCases/
+├── ViewModels/
+├── Infrastructure/
+└── Services/
 ```
 
 ## Git Commit Conventions
@@ -153,36 +234,18 @@ Finanzuebersicht.Tests/            ← xUnit tests (net10.0, references Core onl
 | 🚀 | `deploy` | Deployment-related changes |
 | 🏗️ | `arch` | Architecture changes (project structure) |
 
-**Scopes:** `core`, `ui`, `viewmodel`, `service`, `model`, `converter`, `test`, `config`, `shell`, `settings`
+**Scopes:** `core`, `ui`, `viewmodel`, `service`, `model`, `converter`, `test`, `config`, `shell`, `settings`, `accounts`, `dashboard`
 
 **Rules:**
-- Subject line: imperative mood, max 72 chars, no period at end
-- Body: wrap at 80 chars, explain *what* and *why* (not *how*)
-- Always list affected files/components in the body
-- Breaking changes: add `BREAKING CHANGE:` in footer
-- Always include `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` trailer
+- Subject: imperative mood, max 72 chars, no period
+- Body: explain *what* and *why*; list affected files/components
+- Breaking changes: `BREAKING CHANGE:` in footer
+- Include `Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>` when pair-programming with Copilot
 
-**Examples:**
+## Open Issues (accounts — do not re-analyse from scratch)
 
-```
-✨ feat(service): add configurable data path for LocalDataService
-
-- LocalDataService now accepts SettingsService to read custom data path
-- Users can choose iCloud Drive folder for automatic backup
-- Falls back to LocalApplicationData when no custom path is set
-
-Affected: LocalDataService.cs, SettingsService.cs, MauiProgram.cs
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
-```
-
-```
-🐛 fix(converter): handle null values in BetragDisplayConverter
-
-- Return "0,00 €" instead of throwing NullReferenceException
-- Added null check for decimal input parameter
-
-Affected: BetragDisplayConverter.cs
-
-Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
-```
+| Issue | Topic |
+|-------|-------|
+| [#212](https://github.com/tom4711/finanzuebersicht/issues/212) | Opening balance per account |
+| [#213](https://github.com/tom4711/finanzuebersicht/issues/213) | Dashboard account overview with total balance |
+| [#214](https://github.com/tom4711/finanzuebersicht/issues/214) | Manual balance reconciliation (no bank API) |

--- a/Finanzuebersicht.Application/UseCases/Accounts/GetAccountBalancesUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/GetAccountBalancesUseCase.cs
@@ -33,12 +33,18 @@ public class GetAccountBalancesUseCase(
         }
 
         return accounts
-            .Select(a => new AccountBalanceSummary
+            .Select(a =>
             {
-                AccountId = a.Id,
-                AccountName = a.Name,
-                IsArchived = a.IsArchived,
-                Saldo = balances[a.Id]
+                var transactionBalance = balances[a.Id];
+                return new AccountBalanceSummary
+                {
+                    AccountId = a.Id,
+                    AccountName = a.Name,
+                    IsArchived = a.IsArchived,
+                    OpeningBalance = a.OpeningBalance,
+                    TransactionBalance = transactionBalance,
+                    Saldo = a.OpeningBalance + transactionBalance
+                };
             })
             .OrderBy(a => a.IsArchived)
             .ThenBy(a => a.AccountName)
@@ -51,5 +57,7 @@ public class AccountBalanceSummary
     public string AccountId { get; set; } = string.Empty;
     public string AccountName { get; set; } = string.Empty;
     public bool IsArchived { get; set; }
+    public decimal OpeningBalance { get; set; }
+    public decimal TransactionBalance { get; set; }
     public decimal Saldo { get; set; }
 }

--- a/Finanzuebersicht.Application/UseCases/Accounts/SaveAccountDetailUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/SaveAccountDetailUseCase.cs
@@ -11,6 +11,8 @@ public class SaveAccountDetailUseCase(IAccountRepository accountRepository)
         string name,
         AccountType type,
         bool isArchived = false,
+        decimal openingBalance = 0m,
+        DateTime? openingBalanceDate = null,
         CancellationToken cancellationToken = default)
     {
         cancellationToken.ThrowIfCancellationRequested();
@@ -19,6 +21,8 @@ public class SaveAccountDetailUseCase(IAccountRepository accountRepository)
         account.Name = name;
         account.Type = type;
         account.IsArchived = account.IsSystemAccount ? false : isArchived;
+        account.OpeningBalance = openingBalance;
+        account.OpeningBalanceDate = openingBalanceDate;
 
         await _accountRepository.SaveAccountAsync(account);
         return account;

--- a/Finanzuebersicht.Core/Models/Account.cs
+++ b/Finanzuebersicht.Core/Models/Account.cs
@@ -7,6 +7,8 @@ public class Account
     public AccountType Type { get; set; } = AccountType.Girokonto;
     public string? SystemKey { get; set; }
     public bool IsArchived { get; set; }
+    public decimal OpeningBalance { get; set; }
+    public DateTime? OpeningBalanceDate { get; set; }
 
     public bool IsSystemAccount => !string.IsNullOrWhiteSpace(SystemKey);
     public bool CanDelete => !IsSystemAccount;

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -241,6 +241,10 @@ public static class ResourceKeys
     public const string Lbl_AlleKategorien = nameof(Lbl_AlleKategorien);
     public const string Lbl_AlleKonten = nameof(Lbl_AlleKonten);
     public const string Lbl_Kontosaldo = nameof(Lbl_Kontosaldo);
+    public const string Lbl_Anfangssaldo = nameof(Lbl_Anfangssaldo);
+    public const string Lbl_AnfangssaldoStichtag = nameof(Lbl_AnfangssaldoStichtag);
+    public const string Hint_Anfangssaldo = nameof(Hint_Anfangssaldo);
+    public const string Fmt_KontoSaldoAufschluesselung = nameof(Fmt_KontoSaldoAufschluesselung);
     public const string Lbl_Archiviert = nameof(Lbl_Archiviert);
     public const string Lbl_VonKonto = nameof(Lbl_VonKonto);
     public const string Lbl_NachKonto = nameof(Lbl_NachKonto);

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Accounts;
@@ -12,11 +13,13 @@ public partial class AccountDetailViewModel(
     SaveAccountDetailUseCase saveAccountDetailUseCase,
     INavigationService navigationService,
     ILocalizationService localizationService,
+    IDialogService dialogService,
     ILogger<AccountDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
 {
     private readonly SaveAccountDetailUseCase _saveAccountDetailUseCase = saveAccountDetailUseCase;
     private readonly INavigationService _navigationService = navigationService;
     private readonly ILocalizationService _loc = localizationService;
+    private readonly IDialogService _dialogService = dialogService;
     private readonly ILogger<AccountDetailViewModel>? _logger = logger;
     private Account? _existingAccount;
 
@@ -31,6 +34,18 @@ public partial class AccountDetailViewModel(
 
     [ObservableProperty]
     private AccountTypeOption? selectedTypeOption;
+
+    [ObservableProperty]
+    private string openingBalanceText = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasOpeningBalanceDate))]
+    private bool useOpeningBalanceDate;
+
+    [ObservableProperty]
+    private DateTime openingBalanceDate = DateTime.Today;
+
+    public bool HasOpeningBalanceDate => UseOpeningBalanceDate;
 
     public string PageTitle => _existingAccount == null
         ? _loc.GetString(ResourceKeys.Title_KontoHinzufuegen)
@@ -67,6 +82,9 @@ public partial class AccountDetailViewModel(
                 Name = value.Name;
                 Type = value.Type;
                 IsArchived = value.IsArchived;
+                OpeningBalanceText = value.OpeningBalance.ToString("F2", CultureInfo.CurrentCulture);
+                UseOpeningBalanceDate = value.OpeningBalanceDate.HasValue;
+                OpeningBalanceDate = value.OpeningBalanceDate ?? DateTime.Today;
                 SelectedTypeOption = VerfuegbareTypen.FirstOrDefault(t => t.Value == value.Type);
                 OnPropertyChanged(nameof(PageTitle));
                 OnPropertyChanged(nameof(IsSystemAccount));
@@ -88,9 +106,46 @@ public partial class AccountDetailViewModel(
     {
         if (string.IsNullOrWhiteSpace(Name)) return;
 
-        Type = SelectedTypeOption?.Value ?? Type;
-        await _saveAccountDetailUseCase.ExecuteAsync(_existingAccount, Name, Type, IsArchived);
-        await _navigationService.GoBackAsync();
+        if (!TryParseOpeningBalance(out var openingBalance))
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        try
+        {
+            Type = SelectedTypeOption?.Value ?? Type;
+            var openingBalanceDate = UseOpeningBalanceDate ? OpeningBalanceDate : (DateTime?)null;
+            await _saveAccountDetailUseCase.ExecuteAsync(
+                _existingAccount, Name, Type, IsArchived, openingBalance, openingBalanceDate);
+            await _navigationService.GoBackAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "AccountDetailViewModel: Save failed");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    private bool TryParseOpeningBalance(out decimal openingBalance)
+    {
+        if (string.IsNullOrWhiteSpace(OpeningBalanceText))
+        {
+            openingBalance = 0m;
+            return true;
+        }
+
+        return decimal.TryParse(
+            OpeningBalanceText,
+            NumberStyles.Number,
+            CultureInfo.CurrentCulture,
+            out openingBalance);
     }
 }
 

--- a/Finanzuebersicht.Presentation/ViewModels/AccountListItem.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountListItem.cs
@@ -1,11 +1,24 @@
+using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.ViewModels;
 
-public class AccountListItem(Account account, decimal saldo)
+public class AccountListItem
 {
-    public Account Account { get; } = account;
-    public decimal Saldo { get; } = saldo;
+    public AccountListItem(Account account, AccountBalanceSummary? summary = null)
+    {
+        Account = account;
+        var balance = summary ?? new AccountBalanceSummary { AccountId = account.Id };
+        Saldo = balance.Saldo;
+        OpeningBalance = balance.OpeningBalance;
+        TransactionBalance = balance.TransactionBalance;
+    }
+
+    public Account Account { get; }
+    public decimal Saldo { get; }
+    public decimal OpeningBalance { get; }
+    public decimal TransactionBalance { get; }
+    public string? BalanceBreakdownText { get; init; }
 
     public string Name => Account.Name;
     public AccountType Type => Account.Type;
@@ -13,4 +26,5 @@ public class AccountListItem(Account account, decimal saldo)
     public bool IsArchived => Account.IsArchived;
     public bool CanDelete => Account.CanDelete;
     public bool CanArchive => Account.CanArchive;
+    public bool ShowBalanceBreakdown => !string.IsNullOrWhiteSpace(BalanceBreakdownText);
 }

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -1,4 +1,5 @@
 using System.Collections.ObjectModel;
+using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Accounts;
@@ -70,12 +71,24 @@ public partial class CategoriesViewModel(
             Kategorien = new ObservableCollection<Category>(liste);
             var accounts = await _loadAccountsUseCase.ExecuteAsync();
             var balances = await _getAccountBalancesUseCase.ExecuteAsync();
-            var balanceById = balances.ToDictionary(b => b.AccountId, b => b.Saldo);
+            var balanceById = balances.ToDictionary(b => b.AccountId);
             Konten = new ObservableCollection<AccountListItem>(
                 accounts
                     .OrderBy(a => a.IsArchived)
                     .ThenBy(a => a.Name)
-                    .Select(a => new AccountListItem(a, balanceById.GetValueOrDefault(a.Id))));
+                    .Select(a =>
+                    {
+                        balanceById.TryGetValue(a.Id, out var summary);
+                        return new AccountListItem(a, summary)
+                        {
+                            BalanceBreakdownText = summary is { OpeningBalance: not 0 }
+                                ? _loc.GetString(
+                                    ResourceKeys.Fmt_KontoSaldoAufschluesselung,
+                                    summary.OpeningBalance.ToString("C", CultureInfo.CurrentCulture),
+                                    summary.TransactionBalance.ToString("C", CultureInfo.CurrentCulture))
+                                : null
+                        };
+                    }));
         }
         catch (Exception ex)
         {

--- a/Finanzuebersicht.Tests/Application/UseCases/Accounts/AccountUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/Accounts/AccountUseCaseTests.cs
@@ -121,4 +121,74 @@ public class AccountUseCaseTests
         Assert.Equal(700m, result.First(b => b.AccountId == "acc-1").Saldo);
         Assert.Equal(300m, result.First(b => b.AccountId == "acc-2").Saldo);
     }
+
+    [Fact]
+    public async Task GetAccountBalancesUseCase_IncludesOpeningBalance()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Giro", OpeningBalance = 1000m }
+        });
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Typ = TransactionType.Ausgabe, Betrag = 200m, AccountId = "acc-1" }
+            });
+
+        var sut = new GetAccountBalancesUseCase(accountRepository, transactionRepository);
+        var result = await sut.ExecuteAsync();
+        var balance = result.Single();
+
+        Assert.Equal(1000m, balance.OpeningBalance);
+        Assert.Equal(-200m, balance.TransactionBalance);
+        Assert.Equal(800m, balance.Saldo);
+    }
+
+    [Fact]
+    public async Task GetAccountBalancesUseCase_LegacyAccountDefaultsOpeningBalanceToZero()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Giro" }
+        });
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new() { Typ = TransactionType.Einnahme, Betrag = 150m, AccountId = "acc-1" }
+            });
+
+        var sut = new GetAccountBalancesUseCase(accountRepository, transactionRepository);
+        var result = await sut.ExecuteAsync();
+        var balance = result.Single();
+
+        Assert.Equal(0m, balance.OpeningBalance);
+        Assert.Equal(150m, balance.TransactionBalance);
+        Assert.Equal(150m, balance.Saldo);
+    }
+
+    [Fact]
+    public async Task SaveAccountDetailUseCase_PersistsOpeningBalance()
+    {
+        var repository = Substitute.For<IAccountRepository>();
+        repository.SaveAccountAsync(Arg.Any<Account>()).Returns(Task.CompletedTask);
+
+        var sut = new SaveAccountDetailUseCase(repository);
+        var stichtag = new DateTime(2026, 1, 1);
+
+        var saved = await sut.ExecuteAsync(null, "Tagesgeld", AccountType.Tagesgeld, false, 2500m, stichtag);
+
+        await repository.Received(1).SaveAccountAsync(Arg.Is<Account>(a =>
+            a.Name == "Tagesgeld" &&
+            a.Type == AccountType.Tagesgeld &&
+            a.OpeningBalance == 2500m &&
+            a.OpeningBalanceDate == stichtag));
+        Assert.Equal(2500m, saved.OpeningBalance);
+        Assert.Equal(stichtag, saved.OpeningBalanceDate);
+    }
 }

--- a/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
@@ -140,7 +140,7 @@ public class CategoriesViewModelTests
         dialogService.ShowConfirmationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
             .Returns(Task.FromResult(true));
 
-        await sut.ToggleKontoArchivierungCommand.ExecuteAsync(new AccountListItem(account, 0m));
+        await sut.ToggleKontoArchivierungCommand.ExecuteAsync(new AccountListItem(account));
 
         await accountRepository.Received(1).SaveAccountAsync(Arg.Is<Account>(a => a.Id == "acc-1" && a.IsArchived));
     }

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -36,6 +36,10 @@
   <data name="Lbl_Konto" xml:space="preserve"><value>Konto</value></data>
   <data name="Lbl_AlleKonten" xml:space="preserve"><value>Alle Konten</value></data>
   <data name="Lbl_Kontosaldo" xml:space="preserve"><value>Kontosaldo</value></data>
+  <data name="Lbl_Anfangssaldo" xml:space="preserve"><value>Anfangssaldo</value></data>
+  <data name="Lbl_AnfangssaldoStichtag" xml:space="preserve"><value>Stichtag (optional)</value></data>
+  <data name="Hint_Anfangssaldo" xml:space="preserve"><value>Stand vor deinen erfassten Buchungen. Änderungen wirken sich auf den Kontosaldo aus.</value></data>
+  <data name="Fmt_KontoSaldoAufschluesselung" xml:space="preserve"><value>Anfangssaldo {0} · Buchungen {1}</value></data>
   <data name="Lbl_Archiviert" xml:space="preserve"><value>Archiviert</value></data>
   <data name="Lbl_VonKonto" xml:space="preserve"><value>Von Konto</value></data>
   <data name="Lbl_NachKonto" xml:space="preserve"><value>Nach Konto</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -36,6 +36,10 @@
   <data name="Lbl_Konto" xml:space="preserve"><value>Account</value></data>
   <data name="Lbl_AlleKonten" xml:space="preserve"><value>All Accounts</value></data>
   <data name="Lbl_Kontosaldo" xml:space="preserve"><value>Account Balance</value></data>
+  <data name="Lbl_Anfangssaldo" xml:space="preserve"><value>Opening balance</value></data>
+  <data name="Lbl_AnfangssaldoStichtag" xml:space="preserve"><value>As-of date (optional)</value></data>
+  <data name="Hint_Anfangssaldo" xml:space="preserve"><value>Balance before your recorded transactions. Changes affect the account balance.</value></data>
+  <data name="Fmt_KontoSaldoAufschluesselung" xml:space="preserve"><value>Opening balance {0} · Transactions {1}</value></data>
   <data name="Lbl_Archiviert" xml:space="preserve"><value>Archived</value></data>
   <data name="Lbl_VonKonto" xml:space="preserve"><value>From account</value></data>
   <data name="Lbl_NachKonto" xml:space="preserve"><value>To account</value></data>

--- a/Finanzuebersicht/Views/AccountDetailPage.xaml
+++ b/Finanzuebersicht/Views/AccountDetailPage.xaml
@@ -24,6 +24,31 @@
                         FontSize="16" />
             </VerticalStackLayout>
 
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Anfangssaldo}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding OpeningBalanceText}"
+                       Placeholder="{loc:Translate Hint_Betrag}"
+                       Keyboard="Numeric"
+                       FontSize="16" />
+                <Label Text="{loc:Translate Hint_Anfangssaldo}"
+                       FontSize="12"
+                       TextColor="Gray" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                    <Label Text="{loc:Translate Lbl_AnfangssaldoStichtag}"
+                           FontSize="13"
+                           TextColor="Gray"
+                           VerticalTextAlignment="Center" />
+                    <Switch Grid.Column="1"
+                            IsToggled="{Binding UseOpeningBalanceDate}" />
+                </Grid>
+                <DatePicker Date="{Binding OpeningBalanceDate}"
+                            IsVisible="{Binding HasOpeningBalanceDate}"
+                            FontSize="16" />
+            </VerticalStackLayout>
+
             <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
                 <Label Text="{loc:Translate Lbl_Archiviert}"
                        FontSize="16"

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -129,6 +129,10 @@
                                                   FontSize="11"
                                                   TextColor="Gray" />
                                        </HorizontalStackLayout>
+                                       <Label Text="{Binding BalanceBreakdownText}"
+                                              IsVisible="{Binding ShowBalanceBreakdown}"
+                                              FontSize="12"
+                                              TextColor="Gray" />
                                     </VerticalStackLayout>
 
                                     <VerticalStackLayout Grid.Column="2" Spacing="4" VerticalOptions="Center">


### PR DESCRIPTION
## Summary
- Add `OpeningBalance` and optional `OpeningBalanceDate` to accounts
- Balance formula: Anfangssaldo + sum of transactions (transfers unchanged)
- Account detail UI for editing opening balance
- Account list shows breakdown when opening balance is set

Closes #212

## Test plan
- [x] `dotnet test Finanzuebersicht.Tests` (280 tests)
- [ ] New account with opening balance 3.000 € → saldo correct before any transactions
- [ ] Edit opening balance → saldo updates in Verwaltung → Konten
- [ ] Existing accounts without opening balance behave as before (0 €)


Made with [Cursor](https://cursor.com)