### PR TITLE
feat(dashboard): Kontenübersicht mit Gesamtsaldo

### DIFF
--- a/.cursor/rules/app-domain.mdc
+++ b/.cursor/rules/app-domain.mdc
@@ -15,11 +15,11 @@ alwaysApply: true
 - **ViewModels:** `Finanzuebersicht.Presentation/ViewModels/` — in `PresentationServiceCollectionExtensions` registrieren
 - **Build macOS:** `dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst` → `maccatalyst-arm64/Finanzübersicht.app`
 
-## Konten & Salden (Issues #212–#214)
+## Konten & Salden
 
-- `GetAccountBalancesUseCase`: Saldo = Σ Buchungen (Transfers korrekt)
-- Liste mit Saldo: Verwaltung → Konten
-- Anfangssaldo, Dashboard-Übersicht, manueller Abgleich → siehe Issues, nicht neu erfinden
+- `GetAccountBalancesUseCase`: Saldo = Anfangssaldo + Σ Buchungen (Transfers korrekt)
+- Liste mit Saldo: Verwaltung → Konten; Dashboard: Kontenübersicht-Karte + Gesamtsaldo
+- Manueller Abgleich (ohne Bank-API) → Issue #214 (offen)
 
 ## Nicht wiederholen
 

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -245,6 +245,10 @@ public static class ResourceKeys
     public const string Lbl_AnfangssaldoStichtag = nameof(Lbl_AnfangssaldoStichtag);
     public const string Hint_Anfangssaldo = nameof(Hint_Anfangssaldo);
     public const string Fmt_KontoSaldoAufschluesselung = nameof(Fmt_KontoSaldoAufschluesselung);
+    public const string Lbl_KontenUebersicht = nameof(Lbl_KontenUebersicht);
+    public const string Lbl_Gesamtsaldo = nameof(Lbl_Gesamtsaldo);
+    public const string Lbl_GesamtsaldoAktiv = nameof(Lbl_GesamtsaldoAktiv);
+    public const string A11y_KontoUebersichtTippen = nameof(A11y_KontoUebersichtTippen);
     public const string Lbl_Archiviert = nameof(Lbl_Archiviert);
     public const string Lbl_VonKonto = nameof(Lbl_VonKonto);
     public const string Lbl_NachKonto = nameof(Lbl_NachKonto);

--- a/Finanzuebersicht.Presentation/ViewModels/AccountOverviewItem.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountOverviewItem.cs
@@ -1,0 +1,9 @@
+namespace Finanzuebersicht.ViewModels;
+
+public class AccountOverviewItem
+{
+    public required string AccountId { get; init; }
+    public required string Name { get; init; }
+    public decimal Saldo { get; init; }
+    public decimal AnteilProzent { get; init; }
+}

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -40,7 +40,14 @@ public partial class CategoriesViewModel(
     private ObservableCollection<Category> kategorien = [];
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowGesamtSaldoHeader))]
     private ObservableCollection<AccountListItem> konten = [];
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(ShowGesamtSaldoHeader))]
+    private decimal gesamtSaldoAktiv;
+
+    public bool ShowGesamtSaldoHeader => Konten.Any(k => !k.IsArchived);
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsKategorienVisible))]
@@ -89,6 +96,7 @@ public partial class CategoriesViewModel(
                                 : null
                         };
                     }));
+            GesamtSaldoAktiv = balances.Where(b => !b.IsArchived).Sum(b => b.Saldo);
         }
         catch (Exception ex)
         {

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -136,6 +136,15 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     public bool HasSelectedAccountSaldo => !string.IsNullOrWhiteSpace(SelectedAccountId);
 
     [ObservableProperty]
+    private decimal gesamtSaldo;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasKontenUebersicht))]
+    private ObservableCollection<AccountOverviewItem> kontenUebersicht = [];
+
+    public bool HasKontenUebersicht => KontenUebersicht.Count > 0;
+
+    [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsYearView))]
     [NotifyPropertyChangedFor(nameof(ShowMonthView))]
     [NotifyPropertyChangedFor(nameof(ShowYearView))]
@@ -235,6 +244,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         {
             await EnsureMinJahrLoadedAsync();
             await EnsureAccountFilterLoadedAsync();
+            await UpdateKontenUebersichtAsync();
             await UpdateSelectedAccountSaldoAsync();
             if (IsMonthView)
             {
@@ -287,6 +297,33 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
         var balances = await _getAccountBalancesUseCase.ExecuteAsync();
         SelectedAccountSaldo = balances.FirstOrDefault(b => b.AccountId == SelectedAccountId)?.Saldo ?? 0;
+    }
+
+    private async Task UpdateKontenUebersichtAsync()
+    {
+        var balances = await _getAccountBalancesUseCase.ExecuteAsync();
+        var active = balances.Where(b => !b.IsArchived).ToList();
+        GesamtSaldo = active.Sum(b => b.Saldo);
+
+        var maxAbs = active.Count > 0 ? active.Max(b => Math.Abs(b.Saldo)) : 0m;
+        KontenUebersicht = new ObservableCollection<AccountOverviewItem>(
+            active
+                .OrderByDescending(b => Math.Abs(b.Saldo))
+                .Select(b => new AccountOverviewItem
+                {
+                    AccountId = b.AccountId,
+                    Name = b.AccountName,
+                    Saldo = b.Saldo,
+                    AnteilProzent = maxAbs > 0 ? Math.Abs(b.Saldo) / maxAbs * 100 : 0
+                }));
+    }
+
+    [RelayCommand]
+    private Task SelectKontoFromOverview(AccountOverviewItem item)
+    {
+        SelectedKontoFilterItem = AvailableKonten.FirstOrDefault(k => k.Id == item.AccountId)
+            ?? AvailableKonten.FirstOrDefault();
+        return Task.CompletedTask;
     }
 
     private async Task EnsureAccountFilterLoadedAsync()

--- a/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
@@ -10,6 +10,41 @@ namespace Finanzuebersicht.Tests.ViewModels;
 public class CategoriesViewModelTests
 {
     [Fact]
+    public async Task LoadKategorien_SetsGesamtSaldoAktivWithoutArchivedAccounts()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(Task.FromResult(new List<Category>()));
+
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Giro" },
+            new() { Id = "acc-2", Name = "Alt", IsArchived = true }
+        }));
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>
+            {
+                new() { Typ = TransactionType.Einnahme, Betrag = 800m, AccountId = "acc-1" },
+                new() { Typ = TransactionType.Einnahme, Betrag = 400m, AccountId = "acc-2" }
+            }));
+
+        var sut = CreateSut(
+            categoryRepository,
+            transactionRepository,
+            Substitute.For<IRecurringTransactionRepository>(),
+            accountRepository,
+            Substitute.For<ITransactionTemplateRepository>(),
+            out _);
+
+        await sut.LoadKategorienCommand.ExecuteAsync(null);
+
+        Assert.Equal(800m, sut.GesamtSaldoAktiv);
+        Assert.True(sut.ShowGesamtSaldoHeader);
+    }
+
+    [Fact]
     public async Task LoadKategorien_PopulatesKategorien()
     {
         var categoryRepository = Substitute.For<ICategoryRepository>();

--- a/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
@@ -26,20 +26,90 @@ public class DashboardViewModelTests
         Assert.False(viewModel.HasMonthData);
     }
 
-    private static DashboardViewModel CreateSut()
+    [Fact]
+    public async Task LoadDashboard_PopulatesKontenUebersichtForActiveAccounts()
     {
-        var categoryRepository = Substitute.For<ICategoryRepository>();
-        var transactionRepository = Substitute.For<ITransactionRepository>();
-        var recurringTransactionRepository = Substitute.For<IRecurringTransactionRepository>();
-        var budgetRepository = Substitute.For<IBudgetRepository>();
-        var reportingService = Substitute.For<IReportingService>();
         var accountRepository = Substitute.For<IAccountRepository>();
-        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>()));
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Giro" },
+            new() { Id = "acc-2", Name = "Sparkonto", IsArchived = true }
+        }));
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>
+            {
+                new() { Typ = TransactionType.Einnahme, Betrag = 1000m, AccountId = "acc-1", KategorieId = "cat-1" },
+                new() { Typ = TransactionType.Einnahme, Betrag = 500m, AccountId = "acc-2", KategorieId = "cat-1" }
+            }));
+
+        var viewModel = CreateSut(accountRepository, transactionRepository);
+
+        await viewModel.LoadDashboardCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.HasKontenUebersicht);
+        Assert.Equal(1000m, viewModel.GesamtSaldo);
+        Assert.Single(viewModel.KontenUebersicht);
+        Assert.Equal("acc-1", viewModel.KontenUebersicht[0].AccountId);
+    }
+
+    [Fact]
+    public async Task SelectKontoFromOverview_SetsAccountFilter()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Giro" },
+            new() { Id = "acc-2", Name = "Tagesgeld", OpeningBalance = 2500m }
+        }));
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
         transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
             .Returns(Task.FromResult(new List<Transaction>()));
+
+        var viewModel = CreateSut(accountRepository, transactionRepository);
+        await viewModel.LoadDashboardCommand.ExecuteAsync(null);
+
+        var item = viewModel.KontenUebersicht.First(i => i.AccountId == "acc-2");
+        await viewModel.SelectKontoFromOverviewCommand.ExecuteAsync(item);
+
+        Assert.Equal("acc-2", viewModel.SelectedAccountId);
+        Assert.Equal(2500m, viewModel.SelectedAccountSaldo);
+    }
+
+    private static DashboardViewModel CreateSut()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>()));
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>()));
+        return CreateSut(accountRepository, transactionRepository);
+    }
+
+    private static DashboardViewModel CreateSut(
+        IAccountRepository accountRepository,
+        ITransactionRepository transactionRepository)
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(Task.FromResult(new List<Category>
+        {
+            new() { Id = "cat-1", Name = "Sonstiges", Color = "#999999", Icon = "📁" }
+        }));
+
+        var recurringTransactionRepository = Substitute.For<IRecurringTransactionRepository>();
+        recurringTransactionRepository.GetRecurringTransactionsAsync()
+            .Returns(Task.FromResult(new List<RecurringTransaction>()));
+
+        var budgetRepository = Substitute.For<IBudgetRepository>();
+        budgetRepository.GetBudgetsAsync().Returns(Task.FromResult(new List<CategoryBudget>()));
+
         var localizationService = Substitute.For<ILocalizationService>();
         var navigationService = Substitute.For<INavigationService>();
         var forecastService = Substitute.For<IForecastService>();
+        forecastService.GetMovingAverageAsync(Arg.Any<int>(), Arg.Any<int>(), Arg.Any<int>(), Arg.Any<string?>())
+            .Returns(Task.FromResult(new ForecastResult()));
         var clock = new FixedClock(new DateTime(2026, 3, 15));
 
         return new DashboardViewModel(

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -40,6 +40,10 @@
   <data name="Lbl_AnfangssaldoStichtag" xml:space="preserve"><value>Stichtag (optional)</value></data>
   <data name="Hint_Anfangssaldo" xml:space="preserve"><value>Stand vor deinen erfassten Buchungen. Änderungen wirken sich auf den Kontosaldo aus.</value></data>
   <data name="Fmt_KontoSaldoAufschluesselung" xml:space="preserve"><value>Anfangssaldo {0} · Buchungen {1}</value></data>
+  <data name="Lbl_KontenUebersicht" xml:space="preserve"><value>Kontenübersicht</value></data>
+  <data name="Lbl_Gesamtsaldo" xml:space="preserve"><value>Gesamtsaldo</value></data>
+  <data name="Lbl_GesamtsaldoAktiv" xml:space="preserve"><value>Gesamtsaldo (aktive Konten)</value></data>
+  <data name="A11y_KontoUebersichtTippen" xml:space="preserve"><value>Tippen, um dieses Konto zu filtern</value></data>
   <data name="Lbl_Archiviert" xml:space="preserve"><value>Archiviert</value></data>
   <data name="Lbl_VonKonto" xml:space="preserve"><value>Von Konto</value></data>
   <data name="Lbl_NachKonto" xml:space="preserve"><value>Nach Konto</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -40,6 +40,10 @@
   <data name="Lbl_AnfangssaldoStichtag" xml:space="preserve"><value>As-of date (optional)</value></data>
   <data name="Hint_Anfangssaldo" xml:space="preserve"><value>Balance before your recorded transactions. Changes affect the account balance.</value></data>
   <data name="Fmt_KontoSaldoAufschluesselung" xml:space="preserve"><value>Opening balance {0} · Transactions {1}</value></data>
+  <data name="Lbl_KontenUebersicht" xml:space="preserve"><value>Account overview</value></data>
+  <data name="Lbl_Gesamtsaldo" xml:space="preserve"><value>Total balance</value></data>
+  <data name="Lbl_GesamtsaldoAktiv" xml:space="preserve"><value>Total balance (active accounts)</value></data>
+  <data name="A11y_KontoUebersichtTippen" xml:space="preserve"><value>Tap to filter by this account</value></data>
   <data name="Lbl_Archiviert" xml:space="preserve"><value>Archived</value></data>
   <data name="Lbl_VonKonto" xml:space="preserve"><value>From account</value></data>
   <data name="Lbl_NachKonto" xml:space="preserve"><value>To account</value></data>

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -86,6 +86,24 @@
                              IsVisible="{Binding IsKontenVisible}">
                     <CollectionView ItemsSource="{Binding Konten}"
                                     SelectionMode="None">
+                        <CollectionView.Header>
+                            <Border Padding="16,12"
+                                    StrokeThickness="0"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
+                                    IsVisible="{Binding ShowGesamtSaldoHeader}">
+                                <Grid ColumnDefinitions="*, Auto">
+                                    <Label Text="{loc:Translate Lbl_GesamtsaldoAktiv}"
+                                           FontSize="14"
+                                           FontAttributes="Bold"
+                                           VerticalTextAlignment="Center" />
+                                    <Label Grid.Column="1"
+                                           Text="{Binding GesamtSaldoAktiv, Converter={StaticResource Currency}}"
+                                           FontSize="16"
+                                           FontAttributes="Bold"
+                                           TextColor="{Binding GesamtSaldoAktiv, Converter={StaticResource BilanzColor}}" />
+                                </Grid>
+                            </Border>
+                        </CollectionView.Header>
                         <CollectionView.EmptyView>
                             <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
                                <Label Text="{loc:Translate Empty_KeineKonten}" FontSize="16"

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -84,6 +84,58 @@
                     </BindableLayout.ItemTemplate>
                 </VerticalStackLayout>
 
+                <Border StrokeShape="RoundRectangle 12"
+                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                        Padding="14"
+                        IsVisible="{Binding HasKontenUebersicht}">
+                    <VerticalStackLayout Spacing="12">
+                        <Label Text="{loc:Translate Lbl_KontenUebersicht}"
+                               FontSize="16"
+                               FontAttributes="Bold" />
+                        <Grid ColumnDefinitions="*, Auto">
+                            <Label Text="{loc:Translate Lbl_Gesamtsaldo}"
+                                   FontSize="14"
+                                   TextColor="Gray"
+                                   VerticalTextAlignment="Center" />
+                            <Label Grid.Column="1"
+                                   Text="{Binding GesamtSaldo, Converter={StaticResource Currency}}"
+                                   FontSize="20"
+                                   FontAttributes="Bold"
+                                   TextColor="{Binding GesamtSaldo, Converter={StaticResource BilanzColor}}" />
+                        </Grid>
+                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding KontenUebersicht}"
+                                             Spacing="10">
+                            <BindableLayout.ItemTemplate>
+                                <DataTemplate x:DataType="vm:AccountOverviewItem">
+                                    <VerticalStackLayout Spacing="4"
+                                                         SemanticProperties.Hint="{loc:Translate A11y_KontoUebersichtTippen}">
+                                        <VerticalStackLayout.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:DashboardViewModel}}, Path=SelectKontoFromOverviewCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        </VerticalStackLayout.GestureRecognizers>
+                                        <Grid ColumnDefinitions="*, Auto">
+                                            <Label Text="{Binding Name}"
+                                                   FontSize="14"
+                                                   VerticalTextAlignment="Center" />
+                                            <Label Grid.Column="1"
+                                                   Text="{Binding Saldo, Converter={StaticResource Currency}}"
+                                                   FontSize="14"
+                                                   FontAttributes="Bold"
+                                                   TextColor="{Binding Saldo, Converter={StaticResource BilanzColor}}" />
+                                        </Grid>
+                                        <ProgressBar
+                                            Progress="{Binding AnteilProzent, Converter={StaticResource ProzentToWidth}}"
+                                            ProgressColor="{Binding Saldo, Converter={StaticResource BilanzColor}}"
+                                            BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}" />
+                                    </VerticalStackLayout>
+                                </DataTemplate>
+                            </BindableLayout.ItemTemplate>
+                        </VerticalStackLayout>
+                    </VerticalStackLayout>
+                </Border>
+
                 <Grid ColumnDefinitions="70,*" ColumnSpacing="8">
                     <Label Grid.Column="0"
                            Text="{loc:Translate Lbl_Konto}"


### PR DESCRIPTION
## Summary
- Dashboard card: total balance + per-account bars with tap-to-filter
- Verwaltung → Konten: header with total balance of active accounts
- Builds on opening balance from #212

Closes #213

**Merge order:** Merge PR for #212 first, then retarget this PR to `develop` (or merge after #212 lands).

## Test plan
- [x] `dotnet test Finanzuebersicht.Tests` (280 tests)
- [ ] Dashboard shows Gesamtsaldo and account bars
- [ ] Tap account in overview → dashboard filter set
- [ ] Archived accounts excluded from overview and total
- [ ] Gesamtsaldo header visible in Verwaltung → Konten


Made with [Cursor](https://cursor.com)