### PR TITLE
✨ feat(ui): scroll hint on settings and recurring detail pages

### DIFF
--- a/Finanzuebersicht/Views/RecurringInstanceShiftPage.xaml
+++ b/Finanzuebersicht/Views/RecurringInstanceShiftPage.xaml
@@ -8,7 +8,7 @@
              Title="{loc:Translate Title_ShiftInstance}">
 
     <ScrollView Padding="16">
-        <VerticalStackLayout Spacing="16">
+        <VerticalStackLayout Spacing="16" Padding="0,0,0,24">
             <Label Text="{loc:Translate Lbl_OriginalDatum}" FontSize="13" TextColor="Gray" />
             <Label Text="{Binding InstanceDate, StringFormat='{0:dd.MM.yyyy}'}" FontSize="18" />
 

--- a/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
@@ -15,8 +15,9 @@
         <conv:TypButtonColorConverter x:Key="TypButtonColor" />
     </views:BaseContentPage.Resources>
 
-    <ScrollView Padding="16">
-        <VerticalStackLayout Spacing="20">
+    <Grid RowDefinitions="*, Auto">
+        <ScrollView Grid.Row="0" Padding="16">
+            <VerticalStackLayout Spacing="20" Padding="0,0,0,24">
 
             <!-- Typ-Auswahl -->
             <Grid ColumnDefinitions="*, *" ColumnSpacing="8">
@@ -138,6 +139,14 @@
                     <Button Text="{loc:Translate Btn_ShiftInstance}" Command="{Binding GoToShiftCommand}" BackgroundColor="{StaticResource Einnahme}" TextColor="White" />
                 </HorizontalStackLayout>
 
-        </VerticalStackLayout>
-    </ScrollView>
+            </VerticalStackLayout>
+        </ScrollView>
+        <Label Grid.Row="1"
+               Text="▼"
+               FontSize="10"
+               HorizontalTextAlignment="Center"
+               Padding="0,2,0,6"
+               InputTransparent="True"
+               TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray600}}" />
+    </Grid>
 </views:BaseContentPage>

--- a/Finanzuebersicht/Views/SettingsPage.xaml
+++ b/Finanzuebersicht/Views/SettingsPage.xaml
@@ -8,8 +8,9 @@
              Title="Einstellungen"
              BackgroundColor="{AppThemeBinding Light={StaticResource PageBackground}, Dark={StaticResource PageBackgroundDark}}">
 
-    <ScrollView Padding="16">
-        <VerticalStackLayout Spacing="24">
+    <Grid RowDefinitions="*, Auto">
+        <ScrollView Grid.Row="0" Padding="16">
+            <VerticalStackLayout Spacing="24" Padding="0,0,0,24">
 
             <!-- Darstellung -->
             <Border StrokeShape="RoundRectangle 12"
@@ -224,6 +225,14 @@
                 </VerticalStackLayout>
             </Border>
 
-        </VerticalStackLayout>
-    </ScrollView>
+            </VerticalStackLayout>
+        </ScrollView>
+        <Label Grid.Row="1"
+               Text="▼"
+               FontSize="10"
+               HorizontalTextAlignment="Center"
+               Padding="0,2,0,6"
+               InputTransparent="True"
+               TextColor="{AppThemeBinding Light={StaticResource Gray500}, Dark={StaticResource Gray600}}" />
+    </Grid>
 </ContentPage>

--- a/Finanzuebersicht/Views/TransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/TransactionDetailPage.xaml
@@ -5,10 +5,15 @@
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.TransactionDetailPage"
              x:DataType="vm:TransactionDetailViewModel"
              Title="{loc:Translate Title_Transaktion}">
+
+    <views:BaseContentPage.Resources>
+        <conv:TypButtonColorConverter x:Key="TypButtonColor" />
+    </views:BaseContentPage.Resources>
 
     <ScrollView Padding="16">
         <VerticalStackLayout Spacing="20">
@@ -99,9 +104,4 @@
 
         </VerticalStackLayout>
     </ScrollView>
-
-    <views:BaseContentPage.Resources>
-        <local:TypButtonColorConverter x:Key="TypButtonColor"
-                                       xmlns:local="clr-namespace:Finanzuebersicht.Converters" />
-    </views:BaseContentPage.Resources>
 </views:BaseContentPage>


### PR DESCRIPTION
## Summary
- Adds a fixed **▼** scroll affordance on long form pages where Mac Catalyst hides scrollbars until scrolling starts.
- Applied only where needed: **Einstellungen** and **Dauerauftrag bearbeiten**.
- Adds bottom padding so content is not hidden behind the tab bar.
- Fixes `TransactionDetailPage` resource dictionary placement (converter was below page content).

## Test plan
- [ ] Open Einstellungen → ▼ visible at bottom, page scrolls to all sections
- [ ] Open Dauerauftrag bearbeiten → ▼ visible, scroll to Speichern/Ausnahmen works
- [ ] Transaktion/Konto/Kategorie bearbeiten → no ▼, normal scroll only
- [ ] Termin verschieben → no ▼, content not clipped by tab bar


Made with [Cursor](https://cursor.com)