### PR TITLE
🐛 fix(ui): polish SelectionField popup dismiss and disabled state

### DIFF
--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -267,7 +267,6 @@ public static class ResourceKeys
     public const string Lbl_VonDatum = nameof(Lbl_VonDatum);
     public const string Lbl_BisDatum = nameof(Lbl_BisDatum);
     public const string Hint_SucheTransaktionen = nameof(Hint_SucheTransaktionen);
-    public const string Hint_SucheAuswahl = nameof(Hint_SucheAuswahl);
     public const string Hint_IntervallWaehlen = nameof(Hint_IntervallWaehlen);
     public const string A11y_FilterUmschalten = nameof(A11y_FilterUmschalten);
     public const string Lbl_DauerauftraegeFaellig = nameof(Lbl_DauerauftraegeFaellig);

--- a/Finanzuebersicht/Controls/SelectionField.xaml.cs
+++ b/Finanzuebersicht/Controls/SelectionField.xaml.cs
@@ -100,7 +100,7 @@ public partial class SelectionField : ContentView
 
     private async void OnTapped(object? sender, TappedEventArgs e)
     {
-        if (ItemsSource is null)
+        if (!IsEnabled || ItemsSource is null)
             return;
 
         var popup = new SelectionPopup(ItemsSource, SelectedItem, DisplayMemberPath);

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -268,7 +268,6 @@ Bitte starte die App neu.</value></data>
   <data name="Lbl_VonDatum" xml:space="preserve"><value>Von</value></data>
   <data name="Lbl_BisDatum" xml:space="preserve"><value>Bis</value></data>
   <data name="Hint_SucheTransaktionen" xml:space="preserve"><value>Transaktionen suchen…</value></data>
-  <data name="Hint_SucheAuswahl" xml:space="preserve"><value>Suchen…</value></data>
   <data name="Hint_IntervallWaehlen" xml:space="preserve"><value>Intervall wählen</value></data>
   <data name="A11y_FilterUmschalten" xml:space="preserve"><value>Filter umschalten</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} Daueraufträge bald fällig</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -268,7 +268,6 @@ Please restart the app.</value></data>
   <data name="Lbl_VonDatum" xml:space="preserve"><value>From</value></data>
   <data name="Lbl_BisDatum" xml:space="preserve"><value>To</value></data>
   <data name="Hint_SucheTransaktionen" xml:space="preserve"><value>Search transactions…</value></data>
-  <data name="Hint_SucheAuswahl" xml:space="preserve"><value>Search…</value></data>
   <data name="Hint_IntervallWaehlen" xml:space="preserve"><value>Select interval</value></data>
   <data name="A11y_FilterUmschalten" xml:space="preserve"><value>Toggle filters</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} recurring transactions due soon</value></data>

--- a/Finanzuebersicht/Views/Popups/SelectionPopup.cs
+++ b/Finanzuebersicht/Views/Popups/SelectionPopup.cs
@@ -17,7 +17,7 @@ public class SelectionPopup : Popup<object>
         BackgroundColor = Colors.Transparent;
         Padding = 0;
         Margin = new Thickness(20);
-        CanBeDismissedByTappingOutsideOfPopup = false;
+        CanBeDismissedByTappingOutsideOfPopup = true;
         Content = CreateContent(items, selectedItem, displayMemberPath);
     }
 


### PR DESCRIPTION
## Summary
- Allow dismissing `SelectionPopup` by tapping outside (no forced selection)
- Respect `IsEnabled` on `SelectionField` so disabled rows (e.g. import preview) cannot open the popup
- Remove unused `Hint_SucheAuswahl` string resources left over from the removed selection list page

## Test plan
- [ ] Open any `SelectionField` (e.g. Dauerauftrag interval) and dismiss via outside tap — selection unchanged
- [ ] Select an item from the popup — value updates as before
- [ ] Import preview: rows with `CanEditCategory = false` do not open the popup on tap
- [ ] Build succeeds on Mac Catalyst


Made with [Cursor](https://cursor.com)