### PR TITLE
🐛 fix(dashboard): show account balance on first filter selection

### DIFF
--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -127,10 +127,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private KategorieFilterItem? selectedKontoFilterItem;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasSelectedAccountSaldo))]
     private string? selectedAccountId;
 
     [ObservableProperty]
-    [NotifyPropertyChangedFor(nameof(HasSelectedAccountSaldo))]
     private decimal selectedAccountSaldo;
 
     public bool HasSelectedAccountSaldo => !string.IsNullOrWhiteSpace(SelectedAccountId);
@@ -193,6 +193,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     partial void OnSelectedAccountIdChanged(string? value)
     {
+        _ = UpdateSelectedAccountSaldoAsync();
         _ = LoadDashboard();
     }
 

--- a/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
@@ -78,6 +78,36 @@ public class DashboardViewModelTests
         Assert.Equal(2500m, viewModel.SelectedAccountSaldo);
     }
 
+    [Fact]
+    public async Task SelectedKontoFilterItem_NotifiesHasSelectedAccountSaldo()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Giro", OpeningBalance = 100m }
+        }));
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>()));
+
+        var viewModel = CreateSut(accountRepository, transactionRepository);
+        await viewModel.LoadDashboardCommand.ExecuteAsync(null);
+
+        var notified = false;
+        viewModel.PropertyChanged += (_, e) =>
+        {
+            if (e.PropertyName == nameof(DashboardViewModel.HasSelectedAccountSaldo))
+                notified = true;
+        };
+
+        viewModel.SelectedKontoFilterItem = viewModel.AvailableKonten.First(k => k.Id == "acc-1");
+        await Task.Delay(50);
+
+        Assert.True(viewModel.HasSelectedAccountSaldo);
+        Assert.True(notified);
+    }
+
     private static DashboardViewModel CreateSut()
     {
         var accountRepository = Substitute.For<IAccountRepository>();


### PR DESCRIPTION
## Summary
- Fix dashboard account balance row not appearing on the first account selection after "All accounts"
- Notify `HasSelectedAccountSaldo` when `SelectedAccountId` changes (not only when the saldo value updates)
- Load account saldo immediately on filter change, independent of the full dashboard reload

## Test plan
- [ ] Dashboard: switch from "All accounts" to any account — balance row appears immediately with correct amount
- [ ] Switch to another account — balance updates correctly
- [ ] Switch back to "All accounts" — balance row hides again
- [ ] Unit tests pass (`DashboardViewModelTests`)


Made with [Cursor](https://cursor.com)