### PR TITLE
Draft: Release v1.14 — Erste Schritte & Vertrauen

### DIFF
--- a/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -21,6 +21,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<ToggleAccountArchiveUseCase>();
         services.AddTransient<DeleteAccountUseCase>();
         services.AddTransient<GetAccountBalancesUseCase>();
+        services.AddTransient<ReconcileAccountBalanceUseCase>();
 
         services.AddTransient<LoadDashboardMonthUseCase>();
         services.AddTransient<LoadDashboardYearUseCase>();
@@ -40,6 +41,8 @@ public static class ApplicationServiceCollectionExtensions
 
         services.AddTransient<LoadTransactionDetailDataUseCase>();
         services.AddTransient<DeleteTransactionUseCase>();
+        services.AddTransient<RestoreTransactionUseCase>();
+        services.AddTransient<HasAnyTransactionsUseCase>();
         services.AddTransient<LoadTransactionsMonthUseCase>();
         services.AddTransient<LoadTransactionTemplatesUseCase>();
         services.AddTransient<SearchTransactionsUseCase>();

--- a/Finanzuebersicht.Application/UseCases/Accounts/ReconcileAccountBalanceUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/ReconcileAccountBalanceUseCase.cs
@@ -1,0 +1,53 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Accounts;
+
+public class ReconcileAccountBalanceUseCase(
+    IAccountRepository accountRepository,
+    GetAccountBalancesUseCase getAccountBalancesUseCase,
+    SaveAccountDetailUseCase saveAccountDetailUseCase)
+{
+    public async Task<AccountBalanceReconciliationResult> ExecuteAsync(
+        string accountId,
+        decimal actualBalance,
+        CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var accounts = await accountRepository.GetAccountsAsync();
+        var account = accounts.FirstOrDefault(a => a.Id == accountId)
+            ?? throw new InvalidOperationException("Account not found.");
+
+        var summaries = await getAccountBalancesUseCase.ExecuteAsync(cancellationToken);
+        var summary = summaries.FirstOrDefault(s => s.AccountId == accountId)
+            ?? throw new InvalidOperationException("Account balance not found.");
+
+        var delta = actualBalance - summary.Saldo;
+        var newOpeningBalance = account.OpeningBalance + delta;
+
+        await saveAccountDetailUseCase.ExecuteAsync(
+            account,
+            account.Name,
+            account.Type,
+            account.IsArchived,
+            newOpeningBalance,
+            account.OpeningBalanceDate,
+            cancellationToken);
+
+        return new AccountBalanceReconciliationResult
+        {
+            CalculatedBalance = summary.Saldo,
+            ActualBalance = actualBalance,
+            Delta = delta,
+            NewOpeningBalance = newOpeningBalance
+        };
+    }
+}
+
+public class AccountBalanceReconciliationResult
+{
+    public decimal CalculatedBalance { get; set; }
+    public decimal ActualBalance { get; set; }
+    public decimal Delta { get; set; }
+    public decimal NewOpeningBalance { get; set; }
+}

--- a/Finanzuebersicht.Application/UseCases/Transactions/HasAnyTransactionsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/HasAnyTransactionsUseCase.cs
@@ -1,0 +1,13 @@
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public class HasAnyTransactionsUseCase(ITransactionRepository transactionRepository)
+{
+    public async Task<bool> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var transactions = await transactionRepository.GetTransactionsAsync(
+            new DateTime(1900, 1, 1),
+            new DateTime(2100, 12, 31, 23, 59, 59));
+        return transactions.Count > 0;
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Transactions/RestoreTransactionUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/RestoreTransactionUseCase.cs
@@ -1,0 +1,12 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public class RestoreTransactionUseCase(ITransactionRepository transactionRepository)
+{
+    public async Task ExecuteAsync(Transaction transaction, CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        await transactionRepository.SaveTransactionAsync(transaction);
+    }
+}

--- a/Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
+++ b/Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
@@ -15,7 +15,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
+++ b/Finanzuebersicht.Core/Finanzuebersicht.Core.csproj
@@ -14,6 +14,7 @@
   </ItemGroup>
 
   <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
   </ItemGroup>
 

--- a/Finanzuebersicht.Core/Services/SettingsKeys.cs
+++ b/Finanzuebersicht.Core/Services/SettingsKeys.cs
@@ -36,5 +36,10 @@ namespace Finanzuebersicht.Core.Services
         /// Maximale Anzahl aufzubewahrende Backups (Standard: 10).
         /// </summary>
         public const string MaxBackupsToKeep = "MaxBackupsToKeep";
+
+        /// <summary>
+        /// Whether the first-run onboarding wizard was completed (true/false).
+        /// </summary>
+        public const string OnboardingCompleted = "OnboardingCompleted";
     }
 }

--- a/Finanzuebersicht.Infrastructure/Finanzuebersicht.Infrastructure.csproj
+++ b/Finanzuebersicht.Infrastructure/Finanzuebersicht.Infrastructure.csproj
@@ -18,7 +18,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
 </Project>

--- a/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
@@ -34,7 +34,13 @@ public static class PresentationServiceCollectionExtensions
         services.AddTransient<BackupViewModel>();
         services.AddTransient<AboutViewModel>(sp =>
             new AboutViewModel(appAssembly, sp.GetService<Microsoft.Extensions.Logging.ILogger<AboutViewModel>>()));
-        services.AddTransient<SettingsViewModel>();
+        services.AddTransient<SettingsViewModel>(sp =>
+            new SettingsViewModel(
+                sp.GetRequiredService<AppearanceViewModel>(),
+                sp.GetRequiredService<StorageViewModel>(),
+                sp.GetRequiredService<BackupViewModel>(),
+                sp.GetRequiredService<AboutViewModel>(),
+                sp.GetRequiredService<INavigationService>()));
         services.AddTransient<SparZieleViewModel>();
         services.AddTransient<BackupListViewModel>();
         services.AddTransient<ImportPreviewViewModel>();

--- a/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ public static class PresentationServiceCollectionExtensions
         services.AddTransient<BackupListViewModel>();
         services.AddTransient<ImportPreviewViewModel>();
         services.AddTransient<CashflowViewModel>();
+        services.AddTransient<OnboardingViewModel>();
 
         return services;
     }

--- a/Finanzuebersicht.Presentation/Finanzuebersicht.Presentation.csproj
+++ b/Finanzuebersicht.Presentation/Finanzuebersicht.Presentation.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Finanzuebersicht.Presentation/Navigation/Routes.cs
+++ b/Finanzuebersicht.Presentation/Navigation/Routes.cs
@@ -16,4 +16,5 @@ public static class Routes
     public static readonly string BackupList = "BackupListPage";
     public static readonly string ImportPreview = "ImportPreviewPage";
     public static readonly string Cashflow = "CashflowPage";
+    public static readonly string Onboarding = "OnboardingPage";
 }

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -75,6 +75,13 @@ public static class ResourceKeys
     public const string Btn_Duplizieren = nameof(Btn_Duplizieren);
     public const string Btn_Verwenden = nameof(Btn_Verwenden);
     public const string Btn_AlsVorlageSpeichern = nameof(Btn_AlsVorlageSpeichern);
+    public const string Btn_Weiter = nameof(Btn_Weiter);
+    public const string Btn_Fertig = nameof(Btn_Fertig);
+    public const string Btn_Ueberspringen = nameof(Btn_Ueberspringen);
+    public const string Btn_Zurueck = nameof(Btn_Zurueck);
+    public const string Btn_Abgleichen = nameof(Btn_Abgleichen);
+    public const string Btn_ErsteTransaktion = nameof(Btn_ErsteTransaktion);
+    public const string Btn_ErsterDauerauftrag = nameof(Btn_ErsterDauerauftrag);
 
     // Hints / Placeholders
     public const string Hint_Kategoriename = nameof(Hint_Kategoriename);
@@ -313,9 +320,34 @@ public static class ResourceKeys
     public const string Btn_BackupWiederherstellen = nameof(Btn_BackupWiederherstellen);
     public const string Empty_KeineBackupsVorhanden = nameof(Empty_KeineBackupsVorhanden);
     public const string Empty_ImportVorschauLeer = nameof(Empty_ImportVorschauLeer);
+    public const string Empty_HintTransaktionen = nameof(Empty_HintTransaktionen);
+    public const string Empty_HintDauerauftraege = nameof(Empty_HintDauerauftraege);
+    public const string Empty_HintSparZiele = nameof(Empty_HintSparZiele);
+    public const string Empty_HintCashflow = nameof(Empty_HintCashflow);
     public const string Ttl_ImportVorschau = nameof(Ttl_ImportVorschau);
     public const string Msg_BackupRestoreConfirmTitle = nameof(Msg_BackupRestoreConfirmTitle);
     public const string Msg_BackupRestoreConfirmBody = nameof(Msg_BackupRestoreConfirmBody);
+
+    // v1.14 — Feedback, Onboarding, Saldo-Abgleich
+    public const string Msg_Gespeichert = nameof(Msg_Gespeichert);
+    public const string Msg_Geloescht = nameof(Msg_Geloescht);
+    public const string Btn_Rueckgaengig = nameof(Btn_Rueckgaengig);
+    public const string Lbl_BerechneterSaldo = nameof(Lbl_BerechneterSaldo);
+    public const string Lbl_IstSaldo = nameof(Lbl_IstSaldo);
+    public const string Hint_SaldoAbgleich = nameof(Hint_SaldoAbgleich);
+    public const string Msg_SaldoAbgeglichen = nameof(Msg_SaldoAbgeglichen);
+    public const string Onboarding_PageTitle = nameof(Onboarding_PageTitle);
+    public const string Onboarding_TitleWelcome = nameof(Onboarding_TitleWelcome);
+    public const string Onboarding_TitleAccount = nameof(Onboarding_TitleAccount);
+    public const string Onboarding_TitleFirstTransaction = nameof(Onboarding_TitleFirstTransaction);
+    public const string Onboarding_TitleBackup = nameof(Onboarding_TitleBackup);
+    public const string Onboarding_DescWelcome = nameof(Onboarding_DescWelcome);
+    public const string Onboarding_DescAccount = nameof(Onboarding_DescAccount);
+    public const string Onboarding_DescFirstTransaction = nameof(Onboarding_DescFirstTransaction);
+    public const string Onboarding_DescBackup = nameof(Onboarding_DescBackup);
+    public const string Onboarding_Btn_Anfangssaldo = nameof(Onboarding_Btn_Anfangssaldo);
+    public const string Onboarding_Btn_ErsteTransaktion = nameof(Onboarding_Btn_ErsteTransaktion);
+    public const string Onboarding_Btn_Einstellungen = nameof(Onboarding_Btn_Einstellungen);
 
     // Accessibility
     public const string A11y_VorherigerMonat = nameof(A11y_VorherigerMonat);

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -346,13 +346,16 @@ public static class ResourceKeys
     public const string Onboarding_TitleAccount = nameof(Onboarding_TitleAccount);
     public const string Onboarding_TitleFirstTransaction = nameof(Onboarding_TitleFirstTransaction);
     public const string Onboarding_TitleBackup = nameof(Onboarding_TitleBackup);
+    public const string Onboarding_TitleDone = nameof(Onboarding_TitleDone);
     public const string Onboarding_DescWelcome = nameof(Onboarding_DescWelcome);
     public const string Onboarding_DescAccount = nameof(Onboarding_DescAccount);
     public const string Onboarding_DescFirstTransaction = nameof(Onboarding_DescFirstTransaction);
     public const string Onboarding_DescBackup = nameof(Onboarding_DescBackup);
+    public const string Onboarding_DescDone = nameof(Onboarding_DescDone);
     public const string Onboarding_Btn_Anfangssaldo = nameof(Onboarding_Btn_Anfangssaldo);
     public const string Onboarding_Btn_ErsteTransaktion = nameof(Onboarding_Btn_ErsteTransaktion);
     public const string Onboarding_Btn_Einstellungen = nameof(Onboarding_Btn_Einstellungen);
+    public const string Onboarding_Btn_ZumDashboard = nameof(Onboarding_Btn_ZumDashboard);
 
     // Accessibility
     public const string A11y_VorherigerMonat = nameof(A11y_VorherigerMonat);

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -324,6 +324,11 @@ public static class ResourceKeys
     public const string Empty_HintDauerauftraege = nameof(Empty_HintDauerauftraege);
     public const string Empty_HintSparZiele = nameof(Empty_HintSparZiele);
     public const string Empty_HintCashflow = nameof(Empty_HintCashflow);
+    public const string Empty_HintKategorien = nameof(Empty_HintKategorien);
+    public const string Empty_HintBackups = nameof(Empty_HintBackups);
+    public const string Lbl_Hilfe = nameof(Lbl_Hilfe);
+    public const string Hint_EinrichtungWiederholen = nameof(Hint_EinrichtungWiederholen);
+    public const string Btn_EinrichtungWiederholen = nameof(Btn_EinrichtungWiederholen);
     public const string Ttl_ImportVorschau = nameof(Ttl_ImportVorschau);
     public const string Msg_BackupRestoreConfirmTitle = nameof(Msg_BackupRestoreConfirmTitle);
     public const string Msg_BackupRestoreConfirmBody = nameof(Msg_BackupRestoreConfirmBody);

--- a/Finanzuebersicht.Presentation/Services/IFeedbackService.cs
+++ b/Finanzuebersicht.Presentation/Services/IFeedbackService.cs
@@ -1,0 +1,6 @@
+namespace Finanzuebersicht.Presentation.Services;
+
+public interface IFeedbackService
+{
+    Task ShowSnackbarAsync(string message, string? actionText = null, Func<Task>? onActionAsync = null);
+}

--- a/Finanzuebersicht.Presentation/Services/IOnboardingCoordinator.cs
+++ b/Finanzuebersicht.Presentation/Services/IOnboardingCoordinator.cs
@@ -1,0 +1,7 @@
+namespace Finanzuebersicht.Presentation.Services;
+
+public interface IOnboardingCoordinator
+{
+    Task<bool> ShouldShowOnboardingAsync(CancellationToken cancellationToken = default);
+    void MarkCompleted();
+}

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 using Microsoft.Extensions.Logging;
 
@@ -11,15 +12,23 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class AccountDetailViewModel(
     SaveAccountDetailUseCase saveAccountDetailUseCase,
+    GetAccountBalancesUseCase getAccountBalancesUseCase,
+    ReconcileAccountBalanceUseCase reconcileAccountBalanceUseCase,
     INavigationService navigationService,
     ILocalizationService localizationService,
     IDialogService dialogService,
+    IFeedbackService feedbackService,
+    IAppEvents appEvents,
     ILogger<AccountDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
 {
     private readonly SaveAccountDetailUseCase _saveAccountDetailUseCase = saveAccountDetailUseCase;
+    private readonly GetAccountBalancesUseCase _getAccountBalancesUseCase = getAccountBalancesUseCase;
+    private readonly ReconcileAccountBalanceUseCase _reconcileAccountBalanceUseCase = reconcileAccountBalanceUseCase;
     private readonly INavigationService _navigationService = navigationService;
     private readonly ILocalizationService _loc = localizationService;
     private readonly IDialogService _dialogService = dialogService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
+    private readonly IAppEvents _appEvents = appEvents;
     private readonly ILogger<AccountDetailViewModel>? _logger = logger;
     private Account? _existingAccount;
 
@@ -45,7 +54,14 @@ public partial class AccountDetailViewModel(
     [ObservableProperty]
     private DateTime openingBalanceDate = DateTime.Today;
 
+    [ObservableProperty]
+    private string calculatedBalanceText = string.Empty;
+
+    [ObservableProperty]
+    private string actualBalanceText = string.Empty;
+
     public bool HasOpeningBalanceDate => UseOpeningBalanceDate;
+    public bool CanReconcile => _existingAccount != null;
 
     public string PageTitle => _existingAccount == null
         ? _loc.GetString(ResourceKeys.Title_KontoHinzufuegen)
@@ -76,22 +92,23 @@ public partial class AccountDetailViewModel(
     {
         set
         {
-            if (value != null)
-            {
-                _existingAccount = value;
-                Name = value.Name;
-                Type = value.Type;
-                IsArchived = value.IsArchived;
-                OpeningBalanceText = value.OpeningBalance.ToString("F2", CultureInfo.CurrentCulture);
-                UseOpeningBalanceDate = value.OpeningBalanceDate.HasValue;
-                OpeningBalanceDate = value.OpeningBalanceDate ?? DateTime.Today;
-                SelectedTypeOption = VerfuegbareTypen.FirstOrDefault(t => t.Value == value.Type);
-                OnPropertyChanged(nameof(PageTitle));
-                OnPropertyChanged(nameof(IsSystemAccount));
-                OnPropertyChanged(nameof(CanArchive));
-                OnPropertyChanged(nameof(SystemAccountHint));
-                OnPropertyChanged(nameof(ArchiveStatusText));
-            }
+            if (value == null) return;
+
+            _existingAccount = value;
+            Name = value.Name;
+            Type = value.Type;
+            IsArchived = value.IsArchived;
+            OpeningBalanceText = value.OpeningBalance.ToString("F2", CultureInfo.CurrentCulture);
+            UseOpeningBalanceDate = value.OpeningBalanceDate.HasValue;
+            OpeningBalanceDate = value.OpeningBalanceDate ?? DateTime.Today;
+            SelectedTypeOption = VerfuegbareTypen.FirstOrDefault(t => t.Value == value.Type);
+            OnPropertyChanged(nameof(PageTitle));
+            OnPropertyChanged(nameof(IsSystemAccount));
+            OnPropertyChanged(nameof(CanArchive));
+            OnPropertyChanged(nameof(SystemAccountHint));
+            OnPropertyChanged(nameof(ArchiveStatusText));
+            OnPropertyChanged(nameof(CanReconcile));
+            _ = LoadCalculatedBalanceAsync();
         }
     }
 
@@ -121,6 +138,8 @@ public partial class AccountDetailViewModel(
             var openingBalanceDate = UseOpeningBalanceDate ? OpeningBalanceDate : (DateTime?)null;
             await _saveAccountDetailUseCase.ExecuteAsync(
                 _existingAccount, Name, Type, IsArchived, openingBalance, openingBalanceDate);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
             await _navigationService.GoBackAsync();
         }
         catch (Exception ex)
@@ -131,6 +150,52 @@ public partial class AccountDetailViewModel(
                 _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
         }
+    }
+
+    [RelayCommand]
+    private async Task Reconcile()
+    {
+        if (_existingAccount == null) return;
+
+        if (!decimal.TryParse(ActualBalanceText, NumberStyles.Number, CultureInfo.CurrentCulture, out var actualBalance))
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        try
+        {
+            var result = await _reconcileAccountBalanceUseCase.ExecuteAsync(_existingAccount.Id, actualBalance);
+            OpeningBalanceText = result.NewOpeningBalance.ToString("F2", CultureInfo.CurrentCulture);
+            _existingAccount.OpeningBalance = result.NewOpeningBalance;
+            await LoadCalculatedBalanceAsync();
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_SaldoAbgeglichen));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "AccountDetailViewModel: Reconcile failed");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    private async Task LoadCalculatedBalanceAsync()
+    {
+        if (_existingAccount == null)
+        {
+            CalculatedBalanceText = string.Empty;
+            return;
+        }
+
+        var summaries = await _getAccountBalancesUseCase.ExecuteAsync();
+        var summary = summaries.FirstOrDefault(s => s.AccountId == _existingAccount.Id);
+        CalculatedBalanceText = summary?.Saldo.ToString("C", CultureInfo.CurrentCulture) ?? string.Empty;
     }
 
     private bool TryParseOpeningBalance(out decimal openingBalance)

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -6,6 +6,7 @@ using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Categories;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 using Microsoft.Extensions.Logging;
 
@@ -21,6 +22,8 @@ public partial class CategoriesViewModel(
     ILocalizationService localizationService,
     INavigationService navigationService,
     IDialogService dialogService,
+    IFeedbackService feedbackService,
+    IAppEvents appEvents,
     ILogger<CategoriesViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel
 {
     private readonly DeleteCategoryUseCase _deleteCategoryUseCase = deleteCategoryUseCase;
@@ -32,6 +35,8 @@ public partial class CategoriesViewModel(
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
+    private readonly IAppEvents _appEvents = appEvents;
     private readonly ILogger<CategoriesViewModel>? _logger = logger;
 
     public System.Windows.Input.ICommand AutoLoadCommand => LoadKategorienCommand;
@@ -125,6 +130,8 @@ public partial class CategoriesViewModel(
         {
             await _deleteCategoryUseCase.ExecuteAsync(kategorie.Id);
             Kategorien.Remove(kategorie);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Geloescht));
         }
         catch (Exception ex)
         {
@@ -151,6 +158,8 @@ public partial class CategoriesViewModel(
         {
             await _deleteAccountUseCase.ExecuteAsync(konto.Account.Id);
             Konten.Remove(konto);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Geloescht));
         }
         catch (Exception ex)
         {

--- a/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Categories;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 using Microsoft.Extensions.Logging;
 using System.Globalization;
@@ -13,6 +14,8 @@ public partial class CategoryDetailViewModel(
     SaveCategoryDetailUseCase saveCategoryDetailUseCase,
     INavigationService navigationService,
     ILocalizationService localizationService,
+    IFeedbackService feedbackService,
+    IAppEvents appEvents,
     SaveCategoryBudgetUseCase? saveCategoryBudgetUseCase = null,
     IBudgetRepository? budgetRepository = null,
     ILogger<CategoryDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
@@ -20,6 +23,8 @@ public partial class CategoryDetailViewModel(
     private readonly SaveCategoryDetailUseCase _saveCategoryDetailUseCase = saveCategoryDetailUseCase;
     private readonly INavigationService _navigationService = navigationService;
     private readonly ILocalizationService _loc = localizationService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
+    private readonly IAppEvents _appEvents = appEvents;
     private readonly SaveCategoryBudgetUseCase? _saveCategoryBudgetUseCase = saveCategoryBudgetUseCase;
     private readonly IBudgetRepository? _budgetRepository = budgetRepository;
     private readonly ILogger<CategoryDetailViewModel>? _logger = logger;
@@ -133,7 +138,9 @@ public partial class CategoryDetailViewModel(
             decimal.TryParse(MonthlyBudgetText, NumberStyles.Any, CultureInfo.CurrentCulture, out var budget);
             await _saveCategoryBudgetUseCase.ExecuteAsync(savedCategory.Id, budget);
         }
+        _appEvents.NotifyDataChanged();
         await _navigationService.GoBackAsync();
+        await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
     }
 }
 

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -18,6 +18,7 @@ public partial class ImportPreviewViewModel(
     IDialogService dialogService,
     ILocalizationService localizationService,
     IAppEvents appEvents,
+    IFeedbackService feedbackService,
     ILogger<ImportPreviewViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel
 {
     private readonly ImportService _importService = importService;
@@ -27,6 +28,7 @@ public partial class ImportPreviewViewModel(
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILocalizationService _loc = localizationService;
     private readonly IAppEvents _appEvents = appEvents;
+    private readonly IFeedbackService _feedbackService = feedbackService;
     private readonly ILogger<ImportPreviewViewModel>? _logger = logger;
 
     private ImportPreviewResult? _activeSession;
@@ -142,12 +144,8 @@ public partial class ImportPreviewViewModel(
             if (result.SaveErrors.Count > 0)
                 summaryLines.Add(string.Format(_loc.GetString(ResourceKeys.Msg_ImportFehlerCount), result.SaveErrors.Count));
 
-            await _dialogService.ShowAlertAsync(
-                _loc.GetString(ResourceKeys.Msg_ImportAbgeschlossen_Title),
-                string.Join("\n", summaryLines),
-                _loc.GetString(ResourceKeys.Btn_OK));
-
-            try { _appEvents.NotifyDataChanged(); } catch { }
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(string.Join(" · ", summaryLines));
 
             _importSessionStore.Clear();
             _loadedPreview = false;

--- a/Finanzuebersicht.Presentation/ViewModels/OnboardingViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/OnboardingViewModel.cs
@@ -1,0 +1,132 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.Resources.Strings;
+
+namespace Finanzuebersicht.ViewModels;
+
+public partial class OnboardingViewModel(
+    IOnboardingCoordinator onboardingCoordinator,
+    INavigationService navigationService,
+    ILocalizationService localizationService,
+    LoadAccountsUseCase loadAccountsUseCase) : ObservableObject
+{
+    private readonly IOnboardingCoordinator _onboardingCoordinator = onboardingCoordinator;
+    private readonly INavigationService _navigationService = navigationService;
+    private readonly ILocalizationService _loc = localizationService;
+    private readonly LoadAccountsUseCase _loadAccountsUseCase = loadAccountsUseCase;
+
+    [ObservableProperty]
+    private int currentStep;
+
+    public int TotalSteps => 4;
+
+    public string StepIndicator => $"{CurrentStep + 1} / {TotalSteps}";
+
+    public bool ShowAccountActions => CurrentStep == 1;
+    public bool ShowTransactionActions => CurrentStep == 2;
+    public bool ShowBackupActions => CurrentStep == 3;
+
+    public string StepTitle => CurrentStep switch
+    {
+        0 => _loc.GetString(ResourceKeys.Onboarding_TitleWelcome),
+        1 => _loc.GetString(ResourceKeys.Onboarding_TitleAccount),
+        2 => _loc.GetString(ResourceKeys.Onboarding_TitleFirstTransaction),
+        _ => _loc.GetString(ResourceKeys.Onboarding_TitleBackup)
+    };
+
+    public string StepDescription => CurrentStep switch
+    {
+        0 => _loc.GetString(ResourceKeys.Onboarding_DescWelcome),
+        1 => _loc.GetString(ResourceKeys.Onboarding_DescAccount),
+        2 => _loc.GetString(ResourceKeys.Onboarding_DescFirstTransaction),
+        _ => _loc.GetString(ResourceKeys.Onboarding_DescBackup)
+    };
+
+    public bool IsLastStep => CurrentStep >= TotalSteps - 1;
+    public bool IsFirstStep => CurrentStep == 0;
+
+    public string PrimaryButtonText => IsLastStep
+        ? _loc.GetString(ResourceKeys.Btn_Fertig)
+        : _loc.GetString(ResourceKeys.Btn_Weiter);
+
+    partial void OnCurrentStepChanged(int value)
+    {
+        OnPropertyChanged(nameof(StepTitle));
+        OnPropertyChanged(nameof(StepDescription));
+        OnPropertyChanged(nameof(IsLastStep));
+        OnPropertyChanged(nameof(IsFirstStep));
+        OnPropertyChanged(nameof(PrimaryButtonText));
+        OnPropertyChanged(nameof(StepIndicator));
+        OnPropertyChanged(nameof(ShowAccountActions));
+        OnPropertyChanged(nameof(ShowTransactionActions));
+        OnPropertyChanged(nameof(ShowBackupActions));
+    }
+
+    [RelayCommand]
+    private void Next()
+    {
+        if (IsLastStep)
+        {
+            Complete();
+            return;
+        }
+
+        CurrentStep++;
+    }
+
+    [RelayCommand]
+    private void Back()
+    {
+        if (CurrentStep > 0)
+            CurrentStep--;
+    }
+
+    [RelayCommand]
+    private void Skip()
+        => Complete();
+
+    [RelayCommand]
+    private async Task OpenDefaultAccount()
+    {
+        var accounts = await _loadAccountsUseCase.ExecuteAsync();
+        var account = accounts.FirstOrDefault(a => !a.IsArchived)
+            ?? accounts.FirstOrDefault();
+        if (account is null) return;
+
+        await _navigationService.GoToAsync(Routes.AccountDetail, new Dictionary<string, object>
+        {
+            ["Account"] = account
+        });
+    }
+
+    [RelayCommand]
+    private async Task OpenNewTransaction()
+    {
+        CompleteNavigationPending();
+        await _navigationService.GoToAsync("//TransactionsPage");
+        await _navigationService.GoToAsync(Routes.TransactionDetail);
+    }
+
+    [RelayCommand]
+    private async Task OpenSettings()
+    {
+        CompleteNavigationPending();
+        await _navigationService.GoToAsync(Routes.Settings);
+    }
+
+    private void CompleteNavigationPending()
+    {
+        _onboardingCoordinator.MarkCompleted();
+        _ = _navigationService.GoBackAsync();
+    }
+
+    private void Complete()
+    {
+        _onboardingCoordinator.MarkCompleted();
+        _ = _navigationService.GoBackAsync();
+    }
+}

--- a/Finanzuebersicht.Presentation/ViewModels/OnboardingViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/OnboardingViewModel.cs
@@ -22,7 +22,7 @@ public partial class OnboardingViewModel(
     [ObservableProperty]
     private int currentStep;
 
-    public int TotalSteps => 4;
+    public int TotalSteps => 5;
 
     public string StepIndicator => $"{CurrentStep + 1} / {TotalSteps}";
 
@@ -35,7 +35,8 @@ public partial class OnboardingViewModel(
         0 => _loc.GetString(ResourceKeys.Onboarding_TitleWelcome),
         1 => _loc.GetString(ResourceKeys.Onboarding_TitleAccount),
         2 => _loc.GetString(ResourceKeys.Onboarding_TitleFirstTransaction),
-        _ => _loc.GetString(ResourceKeys.Onboarding_TitleBackup)
+        3 => _loc.GetString(ResourceKeys.Onboarding_TitleBackup),
+        _ => _loc.GetString(ResourceKeys.Onboarding_TitleDone)
     };
 
     public string StepDescription => CurrentStep switch
@@ -43,14 +44,15 @@ public partial class OnboardingViewModel(
         0 => _loc.GetString(ResourceKeys.Onboarding_DescWelcome),
         1 => _loc.GetString(ResourceKeys.Onboarding_DescAccount),
         2 => _loc.GetString(ResourceKeys.Onboarding_DescFirstTransaction),
-        _ => _loc.GetString(ResourceKeys.Onboarding_DescBackup)
+        3 => _loc.GetString(ResourceKeys.Onboarding_DescBackup),
+        _ => _loc.GetString(ResourceKeys.Onboarding_DescDone)
     };
 
     public bool IsLastStep => CurrentStep >= TotalSteps - 1;
     public bool IsFirstStep => CurrentStep == 0;
 
     public string PrimaryButtonText => IsLastStep
-        ? _loc.GetString(ResourceKeys.Btn_Fertig)
+        ? _loc.GetString(ResourceKeys.Onboarding_Btn_ZumDashboard)
         : _loc.GetString(ResourceKeys.Btn_Weiter);
 
     partial void OnCurrentStepChanged(int value)
@@ -112,11 +114,8 @@ public partial class OnboardingViewModel(
     }
 
     [RelayCommand]
-    private async Task OpenSettings()
-    {
-        CompleteNavigationPending();
-        await _navigationService.GoToAsync(Routes.Settings);
-    }
+    private Task OpenSettings()
+        => _navigationService.GoToAsync(Routes.Settings);
 
     private void CompleteNavigationPending()
     {

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -7,6 +7,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 
 namespace Finanzuebersicht.ViewModels;
@@ -20,6 +21,8 @@ public partial class RecurringTransactionDetailViewModel(
     INavigationService navigationService,
     IDialogService dialogService,
     ILocalizationService localizationService,
+    IFeedbackService feedbackService,
+    IAppEvents appEvents,
     ILogger<RecurringTransactionDetailViewModel>? logger = null,
     Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel, IApplyQueryAttributes
 {
@@ -32,6 +35,8 @@ public partial class RecurringTransactionDetailViewModel(
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILocalizationService _loc = localizationService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
+    private readonly IAppEvents _appEvents = appEvents;
     private readonly ILogger<RecurringTransactionDetailViewModel>? _logger = logger;
     private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
 
@@ -225,7 +230,9 @@ public partial class RecurringTransactionDetailViewModel(
             IntervalFactor,
             ReminderDaysBefore,
             Exceptions.ToList());
+        _appEvents.NotifyDataChanged();
         await _navigationService.GoBackAsync();
+        await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
     }
 
     [RelayCommand]

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionsViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 using Microsoft.Extensions.Logging;
 
@@ -16,6 +17,8 @@ public partial class RecurringTransactionsViewModel(
     ILocalizationService localizationService,
     INavigationService navigationService,
     IDialogService dialogService,
+    IFeedbackService feedbackService,
+    IAppEvents appEvents,
     ILogger<RecurringTransactionsViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel
 {
     private readonly DeleteRecurringTransactionUseCase _deleteRecurringTransactionUseCase = deleteRecurringTransactionUseCase;
@@ -24,6 +27,8 @@ public partial class RecurringTransactionsViewModel(
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
+    private readonly IAppEvents _appEvents = appEvents;
     private readonly ILogger<RecurringTransactionsViewModel>? _logger = logger;
 
     public System.Windows.Input.ICommand AutoLoadCommand => LoadDauerauftraegeCommand;
@@ -80,6 +85,8 @@ public partial class RecurringTransactionsViewModel(
         {
             await _deleteRecurringTransactionUseCase.ExecuteAsync(dauerauftrag.Id);
             Dauerauftraege.Remove(dauerauftrag);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Geloescht));
         }
         catch (Exception ex)
         {

--- a/Finanzuebersicht.Presentation/ViewModels/SettingsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SettingsViewModel.cs
@@ -1,23 +1,23 @@
 using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 
 namespace Finanzuebersicht.ViewModels;
 
-public partial class SettingsViewModel : ObservableObject
+public partial class SettingsViewModel(
+    AppearanceViewModel appearance,
+    StorageViewModel storage,
+    BackupViewModel backup,
+    AboutViewModel about,
+    INavigationService navigationService) : ObservableObject
 {
-    public AppearanceViewModel Appearance { get; }
-    public StorageViewModel Storage { get; }
-    public BackupViewModel Backup { get; }
-    public AboutViewModel About { get; }
+    public AppearanceViewModel Appearance { get; } = appearance;
+    public StorageViewModel Storage { get; } = storage;
+    public BackupViewModel Backup { get; } = backup;
+    public AboutViewModel About { get; } = about;
 
-    public SettingsViewModel(
-        AppearanceViewModel appearance,
-        StorageViewModel storage,
-        BackupViewModel backup,
-        AboutViewModel about)
-    {
-        Appearance = appearance;
-        Storage = storage;
-        Backup = backup;
-        About = about;
-    }
+    [RelayCommand]
+    private Task ShowOnboardingAgain()
+        => navigationService.GoToAsync(Routes.Onboarding);
 }

--- a/Finanzuebersicht.Presentation/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SparZieleViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.SparZiele;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 using Microsoft.Extensions.Logging;
 
@@ -15,6 +16,8 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
     private readonly DeleteSparZielUseCase _deleteUseCase;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
+    private readonly IFeedbackService _feedbackService;
+    private readonly IAppEvents _appEvents;
     private readonly ILogger<SparZieleViewModel>? _logger;
 
     public System.Windows.Input.ICommand AutoLoadCommand => LoadSparZieleCommand;
@@ -55,6 +58,8 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
         DeleteSparZielUseCase deleteUseCase,
         IDialogService dialogService,
         ILocalizationService localizationService,
+        IFeedbackService feedbackService,
+        IAppEvents appEvents,
         ILogger<SparZieleViewModel>? logger = null)
     {
         _loadUseCase = loadUseCase;
@@ -62,6 +67,8 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
         _deleteUseCase = deleteUseCase;
         _dialogService = dialogService;
         _loc = localizationService;
+        _feedbackService = feedbackService;
+        _appEvents = appEvents;
         _logger = logger;
     }
 
@@ -134,6 +141,8 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
             };
 
             await _saveUseCase.ExecuteAsync(ziel);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
         }
         catch (Exception ex)
         {
@@ -156,6 +165,8 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
         {
             await _saveUseCase.ExecuteAsync(ziel);
             await LoadSparZieleCommand.ExecuteAsync(null);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
         }
         catch (Exception ex)
         {
@@ -181,6 +192,8 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
         {
             await _deleteUseCase.ExecuteAsync(id);
             await LoadSparZieleCommand.ExecuteAsync(null);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Geloescht));
         }
         catch (Exception ex)
         {

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
@@ -18,6 +18,8 @@ public partial class TransactionDetailViewModel(
     ILocalizationService localizationService,
     INavigationService navigationService,
     IDialogService dialogService,
+    IFeedbackService feedbackService,
+    IAppEvents appEvents,
     ILogger<TransactionDetailViewModel>? logger = null,
     Finanzuebersicht.Core.Services.IClock? clock = null,
     SaveTransactionTemplateUseCase? saveTransactionTemplateUseCase = null) : ObservableObject, IAutoLoadViewModel, IApplyQueryAttributes
@@ -33,6 +35,8 @@ public partial class TransactionDetailViewModel(
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
+    private readonly IAppEvents _appEvents = appEvents;
     private readonly ILogger<TransactionDetailViewModel>? _logger = logger;
     private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
     private readonly SaveTransactionTemplateUseCase? _saveTransactionTemplateUseCase = saveTransactionTemplateUseCase;
@@ -174,7 +178,9 @@ public partial class TransactionDetailViewModel(
                 Typ,
                 Verwendungszweck,
                 SelectedSparZiel?.Id);
+            _appEvents.NotifyDataChanged();
             await _navigationService.GoBackAsync();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
         }
         catch (Exception ex)
         {

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -13,11 +13,13 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class TransactionsViewModel(
     DeleteTransactionUseCase deleteTransactionUseCase,
+    RestoreTransactionUseCase restoreTransactionUseCase,
     LoadTransactionsMonthUseCase loadTransactionsMonthUseCase,
     SearchTransactionsUseCase searchTransactionsUseCase,
     INavigationService navigationService,
     ImportService importService,
     IDialogService dialogService,
+    IFeedbackService feedbackService,
     ILocalizationService localizationService,
     ICategoryRepository categoryRepository,
     IAccountRepository accountRepository,
@@ -31,6 +33,7 @@ public partial class TransactionsViewModel(
     UseTransactionTemplateUseCase? useTransactionTemplateUseCase = null) : MonthNavigationViewModel, IAutoLoadViewModel
 {
     private readonly DeleteTransactionUseCase _deleteTransactionUseCase = deleteTransactionUseCase;
+    private readonly RestoreTransactionUseCase _restoreTransactionUseCase = restoreTransactionUseCase;
     private readonly LoadTransactionsMonthUseCase _loadTransactionsMonthUseCase = loadTransactionsMonthUseCase;
 
     public System.Windows.Input.ICommand AutoLoadCommand => LoadTransaktionenCommand;
@@ -38,6 +41,7 @@ public partial class TransactionsViewModel(
     private readonly INavigationService _navigationService = navigationService;
     private readonly ImportService _importService = importService;
     private readonly IDialogService _dialogService = dialogService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
     private readonly ILocalizationService _loc = localizationService;
     private readonly ICategoryRepository _categoryRepository = categoryRepository;
     private readonly IAccountRepository _accountRepository = accountRepository;
@@ -433,9 +437,12 @@ public partial class TransactionsViewModel(
             {
                 await _deleteTransactionUseCase.ExecuteTransferGroupAsync(transaktion.TransferGroupId);
                 await LoadTransaktionen();
+                _appEvents.NotifyDataChanged();
+                await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Geloescht));
                 return;
             }
 
+            var snapshot = CloneTransaction(transaktion);
             await _deleteTransactionUseCase.ExecuteAsync(transaktion.Id);
             var gruppe = TransaktionsGruppen.FirstOrDefault(g => g.Contains(transaktion));
             if (gruppe == null) return;
@@ -443,6 +450,17 @@ public partial class TransactionsViewModel(
             gruppe.Remove(transaktion);
             if (gruppe.Count == 0)
                 TransaktionsGruppen.Remove(gruppe);
+
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(
+                _loc.GetString(ResourceKeys.Msg_Geloescht),
+                _loc.GetString(ResourceKeys.Btn_Rueckgaengig),
+                async () =>
+                {
+                    await _restoreTransactionUseCase.ExecuteAsync(snapshot);
+                    await LoadTransaktionen();
+                    _appEvents.NotifyDataChanged();
+                });
         }
         catch (Exception ex)
         {
@@ -609,4 +627,20 @@ public partial class TransactionsViewModel(
             await _dialogService.ShowAlertAsync(errTitle, msg, okError);
         }
     }
+
+    private static Transaction CloneTransaction(Transaction source) => new()
+    {
+        Id = source.Id,
+        Betrag = source.Betrag,
+        Titel = source.Titel,
+        Datum = source.Datum,
+        KategorieId = source.KategorieId,
+        Typ = source.Typ,
+        DauerauftragId = source.DauerauftragId,
+        AccountId = source.AccountId,
+        IsTransfer = source.IsTransfer,
+        TransferGroupId = source.TransferGroupId,
+        Verwendungszweck = source.Verwendungszweck,
+        SparZielId = source.SparZielId
+    };
 }

--- a/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 using Microsoft.Extensions.Logging;
 
@@ -15,6 +16,8 @@ public partial class TransferDetailViewModel(
     INavigationService navigationService,
     IDialogService dialogService,
     ILocalizationService localizationService,
+    IFeedbackService feedbackService,
+    IAppEvents appEvents,
     ILogger<TransferDetailViewModel>? logger = null,
     Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel
 {
@@ -23,6 +26,8 @@ public partial class TransferDetailViewModel(
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILocalizationService _loc = localizationService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
+    private readonly IAppEvents _appEvents = appEvents;
     private readonly ILogger<TransferDetailViewModel>? _logger = logger;
     private readonly Finanzuebersicht.Core.Services.IClock _clock = clock ?? Finanzuebersicht.Core.Services.SystemClock.Instance;
 
@@ -100,7 +105,9 @@ public partial class TransferDetailViewModel(
                 title,
                 Note);
 
+            _appEvents.NotifyDataChanged();
             await _navigationService.GoBackAsync();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
         }
         catch (Exception ex)
         {

--- a/Finanzuebersicht.Tests/Application/UseCases/Accounts/ReconcileAccountBalanceUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/Accounts/ReconcileAccountBalanceUseCaseTests.cs
@@ -1,0 +1,46 @@
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Tests.Application.UseCases.Accounts;
+
+public class ReconcileAccountBalanceUseCaseTests
+{
+    [Fact]
+    public async Task ExecuteAsync_AdjustsOpeningBalanceToMatchActualBalance()
+    {
+        var account = new Account
+        {
+            Id = "acc-1",
+            Name = "Giro",
+            OpeningBalance = 100m
+        };
+
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(new List<Account> { account });
+        accountRepository.SaveAccountAsync(Arg.Any<Account>()).Returns(Task.CompletedTask);
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>
+            {
+                new()
+                {
+                    AccountId = "acc-1",
+                    Betrag = 50m,
+                    Typ = TransactionType.Einnahme
+                }
+            });
+
+        var getBalances = new GetAccountBalancesUseCase(accountRepository, transactionRepository);
+        var saveAccount = new SaveAccountDetailUseCase(accountRepository);
+        var sut = new ReconcileAccountBalanceUseCase(accountRepository, getBalances, saveAccount);
+
+        var result = await sut.ExecuteAsync("acc-1", 200m);
+
+        Assert.Equal(150m, result.CalculatedBalance);
+        Assert.Equal(200m, result.ActualBalance);
+        Assert.Equal(50m, result.Delta);
+        Assert.Equal(150m, result.NewOpeningBalance);
+        await accountRepository.Received(1).SaveAccountAsync(Arg.Is<Account>(a => a.OpeningBalance == 150m));
+    }
+}

--- a/Finanzuebersicht.Tests/Application/UseCases/Transactions/HasAnyTransactionsUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/Transactions/HasAnyTransactionsUseCaseTests.cs
@@ -1,0 +1,29 @@
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Tests.Application.UseCases.Transactions;
+
+public class HasAnyTransactionsUseCaseTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ReturnsFalse_WhenNoTransactions()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction>());
+
+        var sut = new HasAnyTransactionsUseCase(transactionRepository);
+        Assert.False(await sut.ExecuteAsync());
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsTrue_WhenTransactionsExist()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(new List<Transaction> { new() { Betrag = 10m } });
+
+        var sut = new HasAnyTransactionsUseCase(transactionRepository);
+        Assert.True(await sut.ExecuteAsync());
+    }
+}

--- a/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
@@ -3,6 +3,7 @@ using Finanzuebersicht.Application.UseCases.Categories;
 using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Tests.ViewModels;
@@ -210,7 +211,9 @@ public class CategoriesViewModelTests
             new DeleteAccountUseCase(accountRepository, transactionRepository, templateRepository),
             localizationService,
             navigationService,
-            dialogService);
+            dialogService,
+            Substitute.For<IFeedbackService>(),
+            Substitute.For<IAppEvents>());
     }
 
     private static CategoriesViewModel CreateSut(

--- a/Finanzuebersicht.Tests/ViewModels/ImportPreviewViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/ImportPreviewViewModelTests.cs
@@ -62,6 +62,7 @@ public class ImportPreviewViewModelTests
             dialog,
             localization,
             Substitute.For<IAppEvents>(),
+            Substitute.For<IFeedbackService>(),
             Substitute.For<ILogger<ImportPreviewViewModel>>());
 
         await vm.LoadPreviewCommand.ExecuteAsync(null);
@@ -105,6 +106,7 @@ public class ImportPreviewViewModelTests
             Substitute.For<IDialogService>(),
             localization,
             Substitute.For<IAppEvents>(),
+            Substitute.For<IFeedbackService>(),
             Substitute.For<ILogger<ImportPreviewViewModel>>());
 
         vm.HandlePageDisappearing();

--- a/Finanzuebersicht.Tests/ViewModels/RecurringTransactionsViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/RecurringTransactionsViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Tests.ViewModels;
@@ -104,6 +105,8 @@ public class RecurringTransactionsViewModelTests
             new ToggleRecurringTransactionActiveUseCase(recurringTransactionRepository),
             localizationService,
             navigationService,
-            dialogService);
+            dialogService,
+            Substitute.For<IFeedbackService>(),
+            Substitute.For<IAppEvents>());
     }
 }

--- a/Finanzuebersicht.Tests/ViewModels/SparZieleViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/SparZieleViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Finanzuebersicht.Application.UseCases.SparZiele;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Tests.ViewModels;
@@ -85,6 +86,8 @@ public class SparZieleViewModelTests
             new SaveSparZielUseCase(repository),
             new DeleteSparZielUseCase(repository),
             dialogService,
-            localizationService);
+            localizationService,
+            Substitute.For<IFeedbackService>(),
+            Substitute.For<IAppEvents>());
     }
 }

--- a/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
@@ -317,14 +317,21 @@ public class TransactionsViewModelTests
 
         deleteTransactionRepository ??= Substitute.For<ITransactionRepository>();
         deleteTransactionRepository.DeleteTransactionAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+        deleteTransactionRepository.SaveTransactionAsync(Arg.Any<Transaction>()).Returns(Task.CompletedTask);
+
+        var feedbackService = Substitute.For<IFeedbackService>();
+        feedbackService.ShowSnackbarAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<Func<Task>>())
+            .Returns(Task.CompletedTask);
 
         return new TransactionsViewModel(
             new DeleteTransactionUseCase(deleteTransactionRepository),
+            new RestoreTransactionUseCase(deleteTransactionRepository),
             new LoadTransactionsMonthUseCase(loadTransactionRepository, loadCategoryRepository, loadAccountRepository),
             new SearchTransactionsUseCase(searchTransactionRepository, searchCategoryRepository, searchAccountRepository),
             navigationService,
             importService,
             dialogService,
+            feedbackService,
             localizationService,
             loadCategoryRepository,
             loadAccountRepository,

--- a/Finanzuebersicht/AppShell.xaml.cs
+++ b/Finanzuebersicht/AppShell.xaml.cs
@@ -19,6 +19,7 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute(Routes.BackupList, typeof(BackupListPage));
 		Routing.RegisterRoute(Routes.ImportPreview, typeof(ImportPreviewPage));
 		Routing.RegisterRoute(Routes.Cashflow, typeof(CashflowPage));
+		Routing.RegisterRoute(Routes.Onboarding, typeof(OnboardingPage));
 	}
 
 	private async void OnSettingsClicked(object? sender, EventArgs e)

--- a/Finanzuebersicht/Controls/EmptyStateView.xaml
+++ b/Finanzuebersicht/Controls/EmptyStateView.xaml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Finanzuebersicht.Controls.EmptyStateView"
+             x:Name="Root">
+
+    <VerticalStackLayout Spacing="12"
+                         HorizontalOptions="Center"
+                         Margin="0,40,0,0"
+                         Padding="16,0">
+        <Label Text="{Binding Source={x:Reference Root}, Path=IconText}"
+               FontSize="48"
+               HorizontalTextAlignment="Center"
+               IsVisible="{Binding Source={x:Reference Root}, Path=HasIcon}"
+               AutomationProperties.IsInAccessibleTree="False" />
+        <Label Text="{Binding Source={x:Reference Root}, Path=Message}"
+               FontSize="17"
+               TextColor="Gray"
+               HorizontalTextAlignment="Center" />
+        <Label Text="{Binding Source={x:Reference Root}, Path=Hint}"
+               FontSize="14"
+               TextColor="Gray"
+               HorizontalTextAlignment="Center"
+               IsVisible="{Binding Source={x:Reference Root}, Path=HasHint}" />
+        <Button Text="{Binding Source={x:Reference Root}, Path=ActionText}"
+                Command="{Binding Source={x:Reference Root}, Path=ActionCommand}"
+                HorizontalOptions="Center"
+                BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                TextColor="White"
+                CornerRadius="10"
+                Padding="20,10"
+                IsVisible="{Binding Source={x:Reference Root}, Path=HasAction}" />
+    </VerticalStackLayout>
+</ContentView>

--- a/Finanzuebersicht/Controls/EmptyStateView.xaml.cs
+++ b/Finanzuebersicht/Controls/EmptyStateView.xaml.cs
@@ -1,0 +1,57 @@
+using System.Windows.Input;
+
+namespace Finanzuebersicht.Controls;
+
+public partial class EmptyStateView : ContentView
+{
+    public static readonly BindableProperty MessageProperty =
+        BindableProperty.Create(nameof(Message), typeof(string), typeof(EmptyStateView), string.Empty);
+
+    public static readonly BindableProperty HintProperty =
+        BindableProperty.Create(nameof(Hint), typeof(string), typeof(EmptyStateView), string.Empty);
+
+    public static readonly BindableProperty IconTextProperty =
+        BindableProperty.Create(nameof(IconText), typeof(string), typeof(EmptyStateView), string.Empty);
+
+    public static readonly BindableProperty ActionTextProperty =
+        BindableProperty.Create(nameof(ActionText), typeof(string), typeof(EmptyStateView), string.Empty);
+
+    public static readonly BindableProperty ActionCommandProperty =
+        BindableProperty.Create(nameof(ActionCommand), typeof(ICommand), typeof(EmptyStateView));
+
+    public EmptyStateView() => InitializeComponent();
+
+    public string Message
+    {
+        get => (string)GetValue(MessageProperty);
+        set => SetValue(MessageProperty, value);
+    }
+
+    public string Hint
+    {
+        get => (string)GetValue(HintProperty);
+        set => SetValue(HintProperty, value);
+    }
+
+    public string IconText
+    {
+        get => (string)GetValue(IconTextProperty);
+        set => SetValue(IconTextProperty, value);
+    }
+
+    public string ActionText
+    {
+        get => (string)GetValue(ActionTextProperty);
+        set => SetValue(ActionTextProperty, value);
+    }
+
+    public ICommand? ActionCommand
+    {
+        get => (ICommand?)GetValue(ActionCommandProperty);
+        set => SetValue(ActionCommandProperty, value);
+    }
+
+    public bool HasHint => !string.IsNullOrWhiteSpace(Hint);
+    public bool HasIcon => !string.IsNullOrWhiteSpace(IconText);
+    public bool HasAction => !string.IsNullOrWhiteSpace(ActionText) && ActionCommand != null;
+}

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -83,7 +83,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.70" />
-		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.9" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="14.2.0" />
 	</ItemGroup>

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -82,7 +82,7 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.70" />
+		<PackageReference Include="Microsoft.Maui.Controls" Version="10.0.71" />
 		<PackageReference Include="Microsoft.Extensions.Logging.Debug" Version="10.0.8" />
 		<PackageReference Include="CommunityToolkit.Mvvm" Version="8.4.2" />
 		<PackageReference Include="CommunityToolkit.Maui" Version="14.2.0" />

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -83,6 +83,8 @@ public static class MauiProgram
 		builder.Services.AddSingleton<ILocalizationService, LocalizationService>();
 		builder.Services.AddSingleton<INavigationService, ShellNavigationService>();
 		builder.Services.AddSingleton<IDialogService, ShellDialogService>();
+		builder.Services.AddSingleton<IFeedbackService, MauiFeedbackService>();
+		builder.Services.AddSingleton<IOnboardingCoordinator, OnboardingCoordinator>();
 		builder.Services.AddSingleton<IMainThreadDispatcher, MauiMainThreadDispatcher>();
 		builder.Services.AddSingleton<Finanzuebersicht.Presentation.Services.IFilePicker, MauiFilePicker>();
 		builder.Services.AddSingleton<IAppEvents, MauiAppEvents>();
@@ -109,6 +111,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<BackupListPage>();
 		builder.Services.AddTransient<ImportPreviewPage>();
 		builder.Services.AddTransient<CashflowPage>();
+		builder.Services.AddTransient<OnboardingPage>();
 
 #if DEBUG
 		builder.Logging.AddDebug();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -372,7 +372,10 @@ Bitte starte die App neu.</value></data>
   <data name="Onboarding_DescAccount" xml:space="preserve"><value>Lege optional einen Anfangssaldo fest, damit der Kontostand zur Bank passt.</value></data>
   <data name="Onboarding_DescFirstTransaction" xml:space="preserve"><value>Füge eine Einnahme oder Ausgabe hinzu, um dein Dashboard zu füllen.</value></data>
   <data name="Onboarding_DescBackup" xml:space="preserve"><value>Richte den Speicherort ein und erstelle regelmäßige Backups in den Einstellungen.</value></data>
+  <data name="Onboarding_TitleDone" xml:space="preserve"><value>Alles bereit!</value></data>
+  <data name="Onboarding_DescDone" xml:space="preserve"><value>Du kannst die Einrichtung jederzeit unter Einstellungen wiederholen. Viel Erfolg mit Finanzübersicht!</value></data>
   <data name="Onboarding_Btn_Anfangssaldo" xml:space="preserve"><value>Konto bearbeiten</value></data>
   <data name="Onboarding_Btn_ErsteTransaktion" xml:space="preserve"><value>Transaktion hinzufügen</value></data>
   <data name="Onboarding_Btn_Einstellungen" xml:space="preserve"><value>Einstellungen öffnen</value></data>
+  <data name="Onboarding_Btn_ZumDashboard" xml:space="preserve"><value>Zum Dashboard</value></data>
 </root>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -340,4 +340,34 @@ Bitte starte die App neu.</value></data>
   <data name="AccountType_Bargeld" xml:space="preserve"><value>Bargeld</value></data>
   <data name="AccountType_Depot" xml:space="preserve"><value>Wertpapierdepot</value></data>
   <data name="AccountType_Sonstiges" xml:space="preserve"><value>Sonstiges</value></data>
+  <data name="Btn_Weiter" xml:space="preserve"><value>Weiter</value></data>
+  <data name="Btn_Fertig" xml:space="preserve"><value>Fertig</value></data>
+  <data name="Btn_Ueberspringen" xml:space="preserve"><value>Überspringen</value></data>
+  <data name="Btn_Zurueck" xml:space="preserve"><value>Zurück</value></data>
+  <data name="Btn_Abgleichen" xml:space="preserve"><value>Abgleichen</value></data>
+  <data name="Btn_ErsteTransaktion" xml:space="preserve"><value>Erste Transaktion</value></data>
+  <data name="Btn_ErsterDauerauftrag" xml:space="preserve"><value>Ersten Dauerauftrag anlegen</value></data>
+  <data name="Empty_HintTransaktionen" xml:space="preserve"><value>Erfasse Einnahmen und Ausgaben, um dein Dashboard zu füllen.</value></data>
+  <data name="Empty_HintDauerauftraege" xml:space="preserve"><value>Lege Miete, Abos und andere wiederkehrende Buchungen an.</value></data>
+  <data name="Empty_HintSparZiele" xml:space="preserve"><value>Definiere ein Sparziel und verfolge deinen Fortschritt.</value></data>
+  <data name="Empty_HintCashflow" xml:space="preserve"><value>Prognosen erscheinen, sobald Transaktionen oder Daueraufträge vorhanden sind.</value></data>
+  <data name="Msg_Gespeichert" xml:space="preserve"><value>Gespeichert</value></data>
+  <data name="Msg_Geloescht" xml:space="preserve"><value>Gelöscht</value></data>
+  <data name="Btn_Rueckgaengig" xml:space="preserve"><value>Rückgängig</value></data>
+  <data name="Lbl_BerechneterSaldo" xml:space="preserve"><value>Berechneter Saldo</value></data>
+  <data name="Lbl_IstSaldo" xml:space="preserve"><value>Ist-Saldo (Bank)</value></data>
+  <data name="Hint_SaldoAbgleich" xml:space="preserve"><value>Trage den Saldo laut Kontoauszug ein. Der Anfangssaldo wird automatisch angepasst.</value></data>
+  <data name="Msg_SaldoAbgeglichen" xml:space="preserve"><value>Saldo abgeglichen</value></data>
+  <data name="Onboarding_PageTitle" xml:space="preserve"><value>Willkommen</value></data>
+  <data name="Onboarding_TitleWelcome" xml:space="preserve"><value>Willkommen bei Finanzübersicht</value></data>
+  <data name="Onboarding_TitleAccount" xml:space="preserve"><value>Anfangssaldo festlegen</value></data>
+  <data name="Onboarding_TitleFirstTransaction" xml:space="preserve"><value>Erste Transaktion erfassen</value></data>
+  <data name="Onboarding_TitleBackup" xml:space="preserve"><value>Daten schützen</value></data>
+  <data name="Onboarding_DescWelcome" xml:space="preserve"><value>Verwalte Konten, Budgets und Sparziele — alles lokal auf deinem Gerät.</value></data>
+  <data name="Onboarding_DescAccount" xml:space="preserve"><value>Lege optional einen Anfangssaldo fest, damit der Kontostand zur Bank passt.</value></data>
+  <data name="Onboarding_DescFirstTransaction" xml:space="preserve"><value>Füge eine Einnahme oder Ausgabe hinzu, um dein Dashboard zu füllen.</value></data>
+  <data name="Onboarding_DescBackup" xml:space="preserve"><value>Richte den Speicherort ein und erstelle regelmäßige Backups in den Einstellungen.</value></data>
+  <data name="Onboarding_Btn_Anfangssaldo" xml:space="preserve"><value>Konto bearbeiten</value></data>
+  <data name="Onboarding_Btn_ErsteTransaktion" xml:space="preserve"><value>Transaktion hinzufügen</value></data>
+  <data name="Onboarding_Btn_Einstellungen" xml:space="preserve"><value>Einstellungen öffnen</value></data>
 </root>

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -351,6 +351,11 @@ Bitte starte die App neu.</value></data>
   <data name="Empty_HintDauerauftraege" xml:space="preserve"><value>Lege Miete, Abos und andere wiederkehrende Buchungen an.</value></data>
   <data name="Empty_HintSparZiele" xml:space="preserve"><value>Definiere ein Sparziel und verfolge deinen Fortschritt.</value></data>
   <data name="Empty_HintCashflow" xml:space="preserve"><value>Prognosen erscheinen, sobald Transaktionen oder Daueraufträge vorhanden sind.</value></data>
+  <data name="Empty_HintKategorien" xml:space="preserve"><value>Ordne Einnahmen und Ausgaben mit eigenen Kategorien.</value></data>
+  <data name="Empty_HintBackups" xml:space="preserve"><value>Erstelle ein Backup in den Einstellungen, um es hier zu sehen.</value></data>
+  <data name="Lbl_Hilfe" xml:space="preserve"><value>Hilfe</value></data>
+  <data name="Hint_EinrichtungWiederholen" xml:space="preserve"><value>Willkommenstour und erste Schritte jederzeit erneut ansehen.</value></data>
+  <data name="Btn_EinrichtungWiederholen" xml:space="preserve"><value>Einrichtung wiederholen</value></data>
   <data name="Msg_Gespeichert" xml:space="preserve"><value>Gespeichert</value></data>
   <data name="Msg_Geloescht" xml:space="preserve"><value>Gelöscht</value></data>
   <data name="Btn_Rueckgaengig" xml:space="preserve"><value>Rückgängig</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -351,6 +351,11 @@ Please restart the app.</value></data>
   <data name="Empty_HintDauerauftraege" xml:space="preserve"><value>Set up rent, subscriptions and other recurring items.</value></data>
   <data name="Empty_HintSparZiele" xml:space="preserve"><value>Define a savings goal and track your progress.</value></data>
   <data name="Empty_HintCashflow" xml:space="preserve"><value>Projections appear once you have transactions or recurring items.</value></data>
+  <data name="Empty_HintKategorien" xml:space="preserve"><value>Organize your income and expenses with custom categories.</value></data>
+  <data name="Empty_HintBackups" xml:space="preserve"><value>Create a backup in Settings to see it listed here.</value></data>
+  <data name="Lbl_Hilfe" xml:space="preserve"><value>Help</value></data>
+  <data name="Hint_EinrichtungWiederholen" xml:space="preserve"><value>Review the welcome tour and first steps at any time.</value></data>
+  <data name="Btn_EinrichtungWiederholen" xml:space="preserve"><value>Repeat setup tour</value></data>
   <data name="Msg_Gespeichert" xml:space="preserve"><value>Saved</value></data>
   <data name="Msg_Geloescht" xml:space="preserve"><value>Deleted</value></data>
   <data name="Btn_Rueckgaengig" xml:space="preserve"><value>Undo</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -372,7 +372,10 @@ Please restart the app.</value></data>
   <data name="Onboarding_DescAccount" xml:space="preserve"><value>Optionally set an opening balance so your account balance matches your bank.</value></data>
   <data name="Onboarding_DescFirstTransaction" xml:space="preserve"><value>Add an income or expense to populate your dashboard.</value></data>
   <data name="Onboarding_DescBackup" xml:space="preserve"><value>Configure backup location and create regular backups in Settings.</value></data>
+  <data name="Onboarding_TitleDone" xml:space="preserve"><value>You're all set!</value></data>
+  <data name="Onboarding_DescDone" xml:space="preserve"><value>You can repeat this setup anytime in Settings. Enjoy using Finanzübersicht!</value></data>
   <data name="Onboarding_Btn_Anfangssaldo" xml:space="preserve"><value>Edit account balance</value></data>
   <data name="Onboarding_Btn_ErsteTransaktion" xml:space="preserve"><value>Add transaction</value></data>
   <data name="Onboarding_Btn_Einstellungen" xml:space="preserve"><value>Open settings</value></data>
+  <data name="Onboarding_Btn_ZumDashboard" xml:space="preserve"><value>Go to dashboard</value></data>
 </root>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -340,4 +340,34 @@ Please restart the app.</value></data>
   <data name="AccountType_Bargeld" xml:space="preserve"><value>Cash</value></data>
   <data name="AccountType_Depot" xml:space="preserve"><value>Securities account</value></data>
   <data name="AccountType_Sonstiges" xml:space="preserve"><value>Other</value></data>
+  <data name="Btn_Weiter" xml:space="preserve"><value>Continue</value></data>
+  <data name="Btn_Fertig" xml:space="preserve"><value>Done</value></data>
+  <data name="Btn_Ueberspringen" xml:space="preserve"><value>Skip</value></data>
+  <data name="Btn_Zurueck" xml:space="preserve"><value>Back</value></data>
+  <data name="Btn_Abgleichen" xml:space="preserve"><value>Reconcile</value></data>
+  <data name="Btn_ErsteTransaktion" xml:space="preserve"><value>Add first transaction</value></data>
+  <data name="Btn_ErsterDauerauftrag" xml:space="preserve"><value>Add recurring transaction</value></data>
+  <data name="Empty_HintTransaktionen" xml:space="preserve"><value>Record income and expenses to see your dashboard.</value></data>
+  <data name="Empty_HintDauerauftraege" xml:space="preserve"><value>Set up rent, subscriptions and other recurring items.</value></data>
+  <data name="Empty_HintSparZiele" xml:space="preserve"><value>Define a savings goal and track your progress.</value></data>
+  <data name="Empty_HintCashflow" xml:space="preserve"><value>Projections appear once you have transactions or recurring items.</value></data>
+  <data name="Msg_Gespeichert" xml:space="preserve"><value>Saved</value></data>
+  <data name="Msg_Geloescht" xml:space="preserve"><value>Deleted</value></data>
+  <data name="Btn_Rueckgaengig" xml:space="preserve"><value>Undo</value></data>
+  <data name="Lbl_BerechneterSaldo" xml:space="preserve"><value>Calculated balance</value></data>
+  <data name="Lbl_IstSaldo" xml:space="preserve"><value>Actual balance (bank)</value></data>
+  <data name="Hint_SaldoAbgleich" xml:space="preserve"><value>Enter the balance from your bank statement. The opening balance will be adjusted automatically.</value></data>
+  <data name="Msg_SaldoAbgeglichen" xml:space="preserve"><value>Balance reconciled</value></data>
+  <data name="Onboarding_PageTitle" xml:space="preserve"><value>Welcome</value></data>
+  <data name="Onboarding_TitleWelcome" xml:space="preserve"><value>Welcome to Finanzübersicht</value></data>
+  <data name="Onboarding_TitleAccount" xml:space="preserve"><value>Set your opening balance</value></data>
+  <data name="Onboarding_TitleFirstTransaction" xml:space="preserve"><value>Record your first transaction</value></data>
+  <data name="Onboarding_TitleBackup" xml:space="preserve"><value>Protect your data</value></data>
+  <data name="Onboarding_DescWelcome" xml:space="preserve"><value>Track accounts, budgets and savings — all stored locally on your device.</value></data>
+  <data name="Onboarding_DescAccount" xml:space="preserve"><value>Optionally set an opening balance so your account balance matches your bank.</value></data>
+  <data name="Onboarding_DescFirstTransaction" xml:space="preserve"><value>Add an income or expense to populate your dashboard.</value></data>
+  <data name="Onboarding_DescBackup" xml:space="preserve"><value>Configure backup location and create regular backups in Settings.</value></data>
+  <data name="Onboarding_Btn_Anfangssaldo" xml:space="preserve"><value>Edit account balance</value></data>
+  <data name="Onboarding_Btn_ErsteTransaktion" xml:space="preserve"><value>Add transaction</value></data>
+  <data name="Onboarding_Btn_Einstellungen" xml:space="preserve"><value>Open settings</value></data>
 </root>

--- a/Finanzuebersicht/Services/MauiFeedbackService.cs
+++ b/Finanzuebersicht/Services/MauiFeedbackService.cs
@@ -1,0 +1,21 @@
+using CommunityToolkit.Maui.Alerts;
+using CommunityToolkit.Maui.Core;
+using Finanzuebersicht.Presentation.Services;
+
+namespace Finanzuebersicht.Services;
+
+public class MauiFeedbackService(IMainThreadDispatcher dispatcher) : IFeedbackService
+{
+    private readonly IMainThreadDispatcher _dispatcher = dispatcher;
+    private static readonly TimeSpan SnackbarDuration = TimeSpan.FromSeconds(5);
+
+    public Task ShowSnackbarAsync(string message, string? actionText = null, Func<Task>? onActionAsync = null)
+        => _dispatcher.InvokeAsync(async () =>
+        {
+            var snackbar = string.IsNullOrWhiteSpace(actionText) || onActionAsync is null
+                ? Snackbar.Make(message, duration: SnackbarDuration)
+                : Snackbar.Make(message, async () => await onActionAsync(), actionText, duration: SnackbarDuration);
+
+            await snackbar.Show();
+        });
+}

--- a/Finanzuebersicht/Services/OnboardingCoordinator.cs
+++ b/Finanzuebersicht/Services/OnboardingCoordinator.cs
@@ -1,0 +1,21 @@
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Presentation.Services;
+
+namespace Finanzuebersicht.Services;
+
+public class OnboardingCoordinator(
+    ISettingsService settingsService,
+    HasAnyTransactionsUseCase hasAnyTransactionsUseCase) : IOnboardingCoordinator
+{
+    public async Task<bool> ShouldShowOnboardingAsync(CancellationToken cancellationToken = default)
+    {
+        if (settingsService.Get(SettingsKeys.OnboardingCompleted, "false") == "true")
+            return false;
+
+        return !await hasAnyTransactionsUseCase.ExecuteAsync(cancellationToken);
+    }
+
+    public void MarkCompleted()
+        => settingsService.Set(SettingsKeys.OnboardingCompleted, "true");
+}

--- a/Finanzuebersicht/Views/AccountDetailPage.xaml
+++ b/Finanzuebersicht/Views/AccountDetailPage.xaml
@@ -67,6 +67,26 @@
                    TextColor="Gray"
                    IsVisible="{Binding IsSystemAccount}" />
 
+            <VerticalStackLayout Spacing="8"
+                                 IsVisible="{Binding CanReconcile}">
+                <Label Text="{loc:Translate Lbl_BerechneterSaldo}" FontSize="13" TextColor="Gray" />
+                <Label Text="{Binding CalculatedBalanceText}" FontSize="16" FontAttributes="Bold" />
+                <Label Text="{loc:Translate Lbl_IstSaldo}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding ActualBalanceText}"
+                       Placeholder="{loc:Translate Hint_Betrag}"
+                       Keyboard="Numeric"
+                       FontSize="16" />
+                <Label Text="{loc:Translate Hint_SaldoAbgleich}"
+                       FontSize="12"
+                       TextColor="Gray" />
+                <Button Text="{loc:Translate Btn_Abgleichen}"
+                        Command="{Binding ReconcileCommand}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                        TextColor="White"
+                        CornerRadius="12"
+                        HeightRequest="44" />
+            </VerticalStackLayout>
+
             <Button Text="{loc:Translate Btn_Speichern}"
                     Command="{Binding SaveCommand}"
                     BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"

--- a/Finanzuebersicht/Views/BackupListPage.xaml
+++ b/Finanzuebersicht/Views/BackupListPage.xaml
@@ -6,6 +6,7 @@
              xmlns:coreServices="clr-namespace:Finanzuebersicht.Core.Services;assembly=Finanzuebersicht.Core"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
+             xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.BackupListPage"
              x:DataType="vm:BackupListViewModel"
              Title="{loc:Translate Ttl_BackupAuswaehlen}">
@@ -20,11 +21,10 @@
             <VerticalStackLayout Spacing="12" Padding="16">
 
                 <!-- Leerer Zustand -->
-                <Label Text="{loc:Translate Empty_KeineBackupsVorhanden}"
-                       FontSize="15" TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
-                       HorizontalTextAlignment="Center"
-                       Margin="0,40,0,0"
-                       IsVisible="{Binding IsEmpty}" />
+                <controls:EmptyStateView IconText="💾"
+                                         Message="{loc:Translate Empty_KeineBackupsVorhanden}"
+                                         Hint="{loc:Translate Empty_HintBackups}"
+                                         IsVisible="{Binding IsEmpty}" />
 
                 <!-- Backup-Liste -->
                 <VerticalStackLayout BindableLayout.ItemsSource="{Binding Backups}" Spacing="12"

--- a/Finanzuebersicht/Views/CashflowPage.xaml
+++ b/Finanzuebersicht/Views/CashflowPage.xaml
@@ -41,9 +41,10 @@
                     </VerticalStackLayout>
                 </Grid>
 
-                <Label Text="{loc:Translate Empty_KeinCashflow}"
-                       IsVisible="{Binding HasDays, Converter={StaticResource InvertBool}}"
-                       FontSize="15" TextColor="Gray" HorizontalTextAlignment="Center" Margin="0,40,0,0" />
+                <controls:EmptyStateView IconText="📅"
+                                         Message="{loc:Translate Empty_KeinCashflow}"
+                                         Hint="{loc:Translate Empty_HintCashflow}"
+                                         IsVisible="{Binding HasDays, Converter={StaticResource InvertBool}}" />
 
                 <VerticalStackLayout Spacing="12" BindableLayout.ItemsSource="{Binding Days}">
                     <BindableLayout.ItemTemplate>

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -6,6 +6,7 @@
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.CategoriesPage"
              x:DataType="vm:CategoriesViewModel"
              Title="{loc:Translate Nav_Verwaltung}">
@@ -34,10 +35,11 @@
                     <CollectionView ItemsSource="{Binding Kategorien}"
                                     SelectionMode="None">
                         <CollectionView.EmptyView>
-                            <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
-                                <Label Text="{loc:Translate Empty_KeineKategorien}" FontSize="16"
-                                       HorizontalTextAlignment="Center" TextColor="Gray" />
-                            </VerticalStackLayout>
+                            <controls:EmptyStateView IconText="🏷️"
+                                                     Message="{loc:Translate Empty_KeineKategorien}"
+                                                     Hint="{loc:Translate Empty_HintKategorien}"
+                                                     ActionText="{loc:Translate Btn_Hinzufuegen}"
+                                                     ActionCommand="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=GoToDetailCommand}" />
                         </CollectionView.EmptyView>
 
                         <CollectionView.ItemTemplate>
@@ -105,15 +107,11 @@
                             </Border>
                         </CollectionView.Header>
                         <CollectionView.EmptyView>
-                            <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
-                               <Label Text="{loc:Translate Empty_KeineKonten}" FontSize="16"
-                                       HorizontalTextAlignment="Center" TextColor="Gray" />
-                               <Label Text="{loc:Translate Empty_KontenHinweis}"
-                                      Margin="0,6,0,0"
-                                      FontSize="13"
-                                      HorizontalTextAlignment="Center"
-                                      TextColor="Gray" />
-                            </VerticalStackLayout>
+                            <controls:EmptyStateView IconText="🏦"
+                                                     Message="{loc:Translate Empty_KeineKonten}"
+                                                     Hint="{loc:Translate Empty_KontenHinweis}"
+                                                     ActionText="{loc:Translate Btn_Hinzufuegen}"
+                                                     ActionCommand="{Binding Source={RelativeSource AncestorType={x:Type vm:CategoriesViewModel}}, Path=GoToDetailCommand}" />
                         </CollectionView.EmptyView>
 
                         <CollectionView.ItemTemplate>

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -174,20 +174,11 @@
                         Padding="0" />
 
                 <!-- Global Empty State – keine Transaktionen vorhanden -->
-                <VerticalStackLayout Spacing="16" HorizontalOptions="Center" Margin="0,40,0,0"
-                                     IsVisible="{Binding HasAnyData, Converter={StaticResource InvertBool}}">
-                    <Label Text="📊" FontSize="56" HorizontalTextAlignment="Center"
-                           AutomationProperties.IsInAccessibleTree="False" />
-                    <Label Text="{loc:Translate Empty_NochKeineTransaktionen}"
-                           FontSize="17" TextColor="Gray"
-                           HorizontalTextAlignment="Center" />
-                    <Button Text="{loc:Translate Btn_ZuTransaktionen}"
-                            Command="{Binding NavigateToTransaktionenCommand}"
-                            HorizontalOptions="Center"
-                            BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                            TextColor="White"
-                            CornerRadius="10" Padding="20,10" />
-                </VerticalStackLayout>
+                <controls:EmptyStateView IconText="📊"
+                                         Message="{loc:Translate Empty_NochKeineTransaktionen}"
+                                         ActionText="{loc:Translate Btn_ZuTransaktionen}"
+                                         ActionCommand="{Binding NavigateToTransaktionenCommand}"
+                                         IsVisible="{Binding HasAnyData, Converter={StaticResource InvertBool}}" />
 
                 <!-- Dateninhalt (Toggle + Monats-/Jahresansicht) – nur wenn Daten vorhanden -->
                 <VerticalStackLayout Spacing="16" IsVisible="{Binding HasAnyData}">

--- a/Finanzuebersicht/Views/DashboardPage.xaml.cs
+++ b/Finanzuebersicht/Views/DashboardPage.xaml.cs
@@ -1,4 +1,6 @@
 using Finanzuebersicht.Charts;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.ViewModels;
 using System.ComponentModel;
 
@@ -7,21 +9,28 @@ namespace Finanzuebersicht.Views;
 public partial class DashboardPage : ContentPage
 {
     private readonly DashboardViewModel _vm;
+    private readonly IOnboardingCoordinator _onboardingCoordinator;
+    private readonly INavigationService _navigationService;
     private readonly DonutChartDrawable _monthDonut = new();
     private readonly BarChartDrawable _yearBar = new();
     private readonly DonutChartDrawable _yearDonut = new();
+    private bool _onboardingChecked;
 
-    public DashboardPage(DashboardViewModel viewModel)
+    public DashboardPage(
+        DashboardViewModel viewModel,
+        IOnboardingCoordinator onboardingCoordinator,
+        INavigationService navigationService)
     {
         InitializeComponent();
         BindingContext = viewModel;
         _vm = viewModel;
+        _onboardingCoordinator = onboardingCoordinator;
+        _navigationService = navigationService;
 
         MonthDonutChart.Drawable = _monthDonut;
         YearBarChart.Drawable = _yearBar;
         YearDonutChart.Drawable = _yearDonut;
 
-        // Initialize drawables with current VM data so charts render immediately
         _monthDonut.Items = _vm.KategorieAusgaben;
         _yearBar.Months = _vm.JahrMonate;
         _yearBar.CurrentMonth = _vm.IsYearView ? 0 : _vm.AktuellerMonat.Month;
@@ -33,15 +42,19 @@ public partial class DashboardPage : ContentPage
         _vm.PropertyChanged += OnViewModelPropertyChanged;
     }
 
-    protected override void OnAppearing()
+    protected override async void OnAppearing()
     {
         base.OnAppearing();
         if (BindingContext is DashboardViewModel vm)
-        {
             vm.LoadDashboardCommand.Execute(null);
+
+        if (!_onboardingChecked)
+        {
+            _onboardingChecked = true;
+            if (await _onboardingCoordinator.ShouldShowOnboardingAsync())
+                await _navigationService.GoToAsync(Routes.Onboarding);
         }
 
-        // Ensure charts are invalidated after loading so drawables render current data
         MainThread.BeginInvokeOnMainThread(() =>
         {
             MonthDonutChart.Invalidate();
@@ -49,7 +62,6 @@ public partial class DashboardPage : ContentPage
             YearBarChart.Invalidate();
         });
 
-        // subscribe to app-wide data change notifications
         App.DataChanged += OnAppDataChanged;
     }
 

--- a/Finanzuebersicht/Views/ImportPreviewPage.xaml
+++ b/Finanzuebersicht/Views/ImportPreviewPage.xaml
@@ -6,6 +6,7 @@
               xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
               xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
               xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
+              xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
               x:Class="Finanzuebersicht.Views.ImportPreviewPage"
               x:DataType="vm:ImportPreviewViewModel"
               Title="{loc:Translate Ttl_ImportVorschau}">
@@ -32,12 +33,10 @@
             </VerticalStackLayout>
         </Border>
 
-        <Label Grid.Row="1"
-               Text="{loc:Translate Empty_ImportVorschauLeer}"
-               IsVisible="{Binding HasRows, Converter={StaticResource InvertBool}}"
-               HorizontalTextAlignment="Center"
-               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
-               Margin="0,24,0,0" />
+        <controls:EmptyStateView Grid.Row="1"
+                                 IconText="📄"
+                                 Message="{loc:Translate Empty_ImportVorschauLeer}"
+                                 IsVisible="{Binding HasRows, Converter={StaticResource InvertBool}}" />
 
         <CollectionView Grid.Row="2"
                         IsVisible="{Binding HasRows}"

--- a/Finanzuebersicht/Views/ImportPreviewPage.xaml
+++ b/Finanzuebersicht/Views/ImportPreviewPage.xaml
@@ -6,7 +6,6 @@
               xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
               xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
               xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
-              xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
               x:Class="Finanzuebersicht.Views.ImportPreviewPage"
               x:DataType="vm:ImportPreviewViewModel"
               Title="{loc:Translate Ttl_ImportVorschau}">

--- a/Finanzuebersicht/Views/OnboardingPage.xaml
+++ b/Finanzuebersicht/Views/OnboardingPage.xaml
@@ -14,7 +14,10 @@
     </ContentPage.Resources>
 
     <ScrollView Padding="24">
-        <VerticalStackLayout Spacing="24" VerticalOptions="Center">
+        <VerticalStackLayout Spacing="24"
+                             VerticalOptions="Center"
+                             MaximumWidthRequest="400"
+                             HorizontalOptions="Center">
 
             <Label Text="{Binding StepTitle}"
                    FontSize="28"

--- a/Finanzuebersicht/Views/OnboardingPage.xaml
+++ b/Finanzuebersicht/Views/OnboardingPage.xaml
@@ -1,0 +1,85 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
+             xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             x:Class="Finanzuebersicht.Views.OnboardingPage"
+             x:DataType="vm:OnboardingViewModel"
+             Title="{loc:Translate Onboarding_PageTitle}"
+             Shell.NavBarIsVisible="False">
+
+    <ContentPage.Resources>
+        <conv:InvertBoolConverter x:Key="InvertBool" />
+    </ContentPage.Resources>
+
+    <ScrollView Padding="24">
+        <VerticalStackLayout Spacing="24" VerticalOptions="Center">
+
+            <Label Text="{Binding StepTitle}"
+                   FontSize="28"
+                   FontAttributes="Bold"
+                   HorizontalTextAlignment="Center" />
+
+            <Label Text="{Binding StepDescription}"
+                   FontSize="16"
+                   TextColor="Gray"
+                   HorizontalTextAlignment="Center"
+                   LineBreakMode="WordWrap" />
+
+            <Label Text="{Binding StepIndicator}"
+                   FontSize="13"
+                   TextColor="Gray"
+                   HorizontalTextAlignment="Center" />
+
+            <VerticalStackLayout Spacing="12" IsVisible="{Binding ShowAccountActions}">
+                <Button Text="{loc:Translate Onboarding_Btn_Anfangssaldo}"
+                        Command="{Binding OpenDefaultAccountCommand}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                        TextColor="White"
+                        CornerRadius="12"
+                        HeightRequest="48" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="12" IsVisible="{Binding ShowTransactionActions}">
+                <Button Text="{loc:Translate Onboarding_Btn_ErsteTransaktion}"
+                        Command="{Binding OpenNewTransactionCommand}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                        TextColor="White"
+                        CornerRadius="12"
+                        HeightRequest="48" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="12" IsVisible="{Binding ShowBackupActions}">
+                <Button Text="{loc:Translate Onboarding_Btn_Einstellungen}"
+                        Command="{Binding OpenSettingsCommand}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}"
+                        TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
+                        CornerRadius="12"
+                        HeightRequest="48" />
+            </VerticalStackLayout>
+
+            <Grid ColumnDefinitions="*,*" ColumnSpacing="12" Margin="0,16,0,0">
+                <Button Grid.Column="0"
+                        Text="{loc:Translate Btn_Ueberspringen}"
+                        Command="{Binding SkipCommand}"
+                        BackgroundColor="Transparent"
+                        TextColor="Gray" />
+                <Button Grid.Column="1"
+                        Text="{Binding PrimaryButtonText}"
+                        Command="{Binding NextCommand}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                        TextColor="White"
+                        CornerRadius="12"
+                        HeightRequest="48" />
+            </Grid>
+
+            <Button Text="{loc:Translate Btn_Zurueck}"
+                    Command="{Binding BackCommand}"
+                    IsVisible="{Binding IsFirstStep, Converter={StaticResource InvertBool}}"
+                    BackgroundColor="Transparent"
+                    TextColor="Gray" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Finanzuebersicht/Views/OnboardingPage.xaml
+++ b/Finanzuebersicht/Views/OnboardingPage.xaml
@@ -66,8 +66,10 @@
                 <Button Grid.Column="0"
                         Text="{loc:Translate Btn_Ueberspringen}"
                         Command="{Binding SkipCommand}"
-                        BackgroundColor="Transparent"
-                        TextColor="Gray" />
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}"
+                        TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource TextPrimaryDark}}"
+                        CornerRadius="12"
+                        HeightRequest="48" />
                 <Button Grid.Column="1"
                         Text="{Binding PrimaryButtonText}"
                         Command="{Binding NextCommand}"

--- a/Finanzuebersicht/Views/OnboardingPage.xaml
+++ b/Finanzuebersicht/Views/OnboardingPage.xaml
@@ -56,8 +56,8 @@
             <VerticalStackLayout Spacing="12" IsVisible="{Binding ShowBackupActions}">
                 <Button Text="{loc:Translate Onboarding_Btn_Einstellungen}"
                         Command="{Binding OpenSettingsCommand}"
-                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray600}}"
-                        TextColor="{AppThemeBinding Light={StaticResource Black}, Dark={StaticResource White}}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                        TextColor="White"
                         CornerRadius="12"
                         HeightRequest="48" />
             </VerticalStackLayout>

--- a/Finanzuebersicht/Views/OnboardingPage.xaml.cs
+++ b/Finanzuebersicht/Views/OnboardingPage.xaml.cs
@@ -1,0 +1,10 @@
+namespace Finanzuebersicht.Views;
+
+public partial class OnboardingPage : ContentPage
+{
+    public OnboardingPage(OnboardingViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+}

--- a/Finanzuebersicht/Views/OnboardingPage.xaml.cs
+++ b/Finanzuebersicht/Views/OnboardingPage.xaml.cs
@@ -1,3 +1,5 @@
+using Finanzuebersicht.ViewModels;
+
 namespace Finanzuebersicht.Views;
 
 public partial class OnboardingPage : ContentPage

--- a/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
@@ -6,6 +6,7 @@
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.RecurringTransactionsPage"
              x:DataType="vm:RecurringTransactionsViewModel"
              Title="Daueraufträge">
@@ -24,10 +25,11 @@
                         SelectionMode="None">
 
             <CollectionView.EmptyView>
-                <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
-                    <Label Text="{loc:Translate Empty_KeineDauerauftraege}"
-                           FontSize="16" HorizontalTextAlignment="Center" TextColor="Gray" />
-                </VerticalStackLayout>
+                <controls:EmptyStateView IconText="🔄"
+                                         Message="{loc:Translate Empty_KeineDauerauftraege}"
+                                         Hint="{loc:Translate Empty_HintDauerauftraege}"
+                                         ActionText="{loc:Translate Btn_ErsterDauerauftrag}"
+                                         ActionCommand="{Binding GoToDetailCommand}" />
             </CollectionView.EmptyView>
 
             <CollectionView.ItemTemplate>

--- a/Finanzuebersicht/Views/SettingsPage.xaml
+++ b/Finanzuebersicht/Views/SettingsPage.xaml
@@ -170,8 +170,6 @@
                 </VerticalStackLayout>
             </Border>
 
-            </Border>
-
             <!-- Hilfe / Einrichtung -->
             <Border StrokeShape="RoundRectangle 12"
                     Stroke="{AppThemeBinding Light={StaticResource Separator}, Dark={StaticResource SeparatorDark}}"

--- a/Finanzuebersicht/Views/SettingsPage.xaml
+++ b/Finanzuebersicht/Views/SettingsPage.xaml
@@ -170,6 +170,30 @@
                 </VerticalStackLayout>
             </Border>
 
+            </Border>
+
+            <!-- Hilfe / Einrichtung -->
+            <Border StrokeShape="RoundRectangle 12"
+                    Stroke="{AppThemeBinding Light={StaticResource Separator}, Dark={StaticResource SeparatorDark}}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                    Padding="16">
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="{loc:Translate Lbl_Hilfe}"
+                           FontSize="18"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource TextPrimaryDark}}" />
+                    <Label Text="{loc:Translate Hint_EinrichtungWiederholen}"
+                           FontSize="14"
+                           TextColor="{AppThemeBinding Light={StaticResource TextSecondary}, Dark={StaticResource TextSecondaryDark}}" />
+                    <Button Text="{loc:Translate Btn_EinrichtungWiederholen}"
+                            Command="{Binding ShowOnboardingAgainCommand}"
+                            FontSize="14"
+                            Padding="12,8"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                            TextColor="White" />
+                </VerticalStackLayout>
+            </Border>
+
             <!-- Über -->
             <Border StrokeShape="RoundRectangle 12"
                     Stroke="{AppThemeBinding Light={StaticResource Separator}, Dark={StaticResource SeparatorDark}}"

--- a/Finanzuebersicht/Views/SparZielePage.xaml
+++ b/Finanzuebersicht/Views/SparZielePage.xaml
@@ -6,6 +6,7 @@
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.SparZielePage"
              x:DataType="vm:SparZieleViewModel"
              Title="{loc:Translate Title_SparZiele}">
@@ -20,12 +21,12 @@
             <ScrollView>
                 <VerticalStackLayout Spacing="16" Padding="16">
 
-                    <!-- Leeres Label wenn keine Ziele -->
-                    <Label Text="{loc:Translate Empty_KeineSparZiele}"
-                           FontSize="16" HorizontalTextAlignment="Center"
-                           TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}"
-                           IsVisible="{Binding IsEmpty}"
-                           Margin="0,40,0,0" />
+                    <controls:EmptyStateView IconText="🎯"
+                                             Message="{loc:Translate Empty_KeineSparZiele}"
+                                             Hint="{loc:Translate Empty_HintSparZiele}"
+                                             ActionText="{loc:Translate Btn_NeuesZiel}"
+                                             ActionCommand="{Binding ToggleAddFormCommand}"
+                                             IsVisible="{Binding IsEmpty}" />
 
                     <!-- Ziele-Liste -->
                     <VerticalStackLayout BindableLayout.ItemsSource="{Binding SparZiele}" Spacing="12">

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -263,10 +263,11 @@
                                 IsGrouped="True"
                                 SelectionMode="None">
                     <CollectionView.EmptyView>
-                        <VerticalStackLayout VerticalOptions="Center" HorizontalOptions="Center" Padding="20">
-                            <Label Text="{loc:Translate Empty_KeineTransaktionen}"
-                                   FontSize="16" HorizontalTextAlignment="Center" TextColor="Gray" />
-                        </VerticalStackLayout>
+                        <controls:EmptyStateView IconText="💳"
+                                                 Message="{loc:Translate Empty_KeineTransaktionen}"
+                                                 Hint="{loc:Translate Empty_HintTransaktionen}"
+                                                 ActionText="{loc:Translate Btn_ErsteTransaktion}"
+                                                 ActionCommand="{Binding GoToDetailCommand}" />
                     </CollectionView.EmptyView>
                     <CollectionView.GroupHeaderTemplate>
                         <DataTemplate x:DataType="models:TransactionGroup">

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,7 +2,9 @@
 
 Übersicht über geplante Releases und Features. Die Roadmap wird fortlaufend aktualisiert.
 
-> **Hinweis:** Die Milestone-Bezeichnungen (v1.1, v1.2, v2.0) sind thematische GitHub-Planungslabels, keine sequenziellen Release-Versionen. Tatsächliche Releases (v1.0, v1.6, v1.6.1 …) werden durch Git-Commit-Höhe via Nerdbank.GitVersioning bestimmt.
+> **Hinweis:** Die Milestone-Bezeichnungen (v1.14, v1.2, v2.0) sind thematische GitHub-Planungslabels, keine sequenziellen Release-Versionen. Tatsächliche Releases (v1.0, v1.6, v1.12 …) werden durch Git-Commit-Höhe via Nerdbank.GitVersioning bestimmt.
+
+**Aktueller Stand:** Release **v1.13** (Latest). Nächste geplante UX-Releases: **v1.14–v1.17** (vor v2.0).
 
 ---
 
@@ -14,7 +16,6 @@
 - Backup / Restore mit Schema-Migrations-Framework
 - Accessibility (VoiceOver / Tastaturnavigation)
 - CI/CD: Build-Artifacts für macOS & Windows
-- Vollständige Fehlerbehandlung in allen ViewModels
 
 ---
 
@@ -24,83 +25,133 @@ Fokus: Layering bereinigen, Persistenz robuster machen und DI modularisieren.
 
 | Issue | Thema | Status |
 |-------|-------|--------|
-| [#152](https://github.com/tom4711/finanzuebersicht/issues/152) | JSON-Persistenz: Korruption nicht stillschweigend als leere Daten behandeln | ✅ Closed |
-| [#153](https://github.com/tom4711/finanzuebersicht/issues/153) | Restore-Prozess transaktional absichern | ✅ Closed |
-| [#154](https://github.com/tom4711/finanzuebersicht/issues/154) | Refactor Core: I/O-, Logging- und Persistenz-Services aus Core auslagern | ✅ Closed |
-| [#155](https://github.com/tom4711/finanzuebersicht/issues/155) | CSV-Import: Teilimporte und globale Side-Effects vermeiden | ✅ Closed |
-| [#159](https://github.com/tom4711/finanzuebersicht/issues/159) | Recurring-Berechnung zentralisieren und CancellationToken unterstützen | ✅ Closed |
-| [#160](https://github.com/tom4711/finanzuebersicht/issues/160) | DataServiceFacade in fachlich getrennte Interfaces aufteilen | ✅ Closed |
-| [#161](https://github.com/tom4711/finanzuebersicht/issues/161) | DI-Registrierung in modulare Extensions aufteilen | ✅ Closed |
-| [#162](https://github.com/tom4711/finanzuebersicht/issues/162) | Namespaces nach Layern trennen und vereinheitlichen | ✅ Closed |
-| [#163](https://github.com/tom4711/finanzuebersicht/issues/163) | SettingsService: I/O abstrahieren und async/testbar machen | ✅ Closed |
-| [#168](https://github.com/tom4711/finanzuebersicht/issues/168) | UseCases um CancellationToken und klare Application-Verantwortung erweitern | ✅ Closed |
-
-Alle 10 Issues des Milestones sind geschlossen.
+| [#152](https://github.com/tom4711/finanzuebersicht/issues/152)–[#168](https://github.com/tom4711/finanzuebersicht/issues/168) | Persistenz, Restore, Layering, DI, UseCases | ✅ Closed |
 
 ---
 
-## ✅ v1.11 — Konten & Salden *(abgeschlossen)*
+## ✅ v1.9 — UX-Schnellgewinne *(abgeschlossen)*
 
-Fokus: Mehrkonten-Verwaltung, Saldo-Berechnung und Dashboard-Übersicht.
-
-| Issue | Thema | Status |
-|-------|-------|--------|
-| [#212](https://github.com/tom4711/finanzuebersicht/issues/212) | Anfangssaldo pro Konto (ohne Fake-Transaktionen) | ✅ Closed |
-| [#213](https://github.com/tom4711/finanzuebersicht/issues/213) | Dashboard-Kontenübersicht mit Gesamtsaldo | ✅ Closed |
-
-**Weitere Umsetzungen in diesem Release-Zyklus:**
-- 30-Tage-Cashflow-Vorschau (`CashflowPage`, `LoadCashflowOutlookUseCase`)
-- Umbuchungen zwischen Konten (`TransferDetailPage`)
-- Transaktionen: Suche, Filter, Swipe-Aktionen (Löschen/Duplizieren)
-
-**Offener Follow-up:** [#214](https://github.com/tom4711/finanzuebersicht/issues/214) — manueller Saldo-Abgleich (ohne Bank-API)
+- Import-Vorschau mit Dubletten-Erkennung ([#192](https://github.com/tom4711/finanzuebersicht/issues/192))
+- Transaktionsvorlagen / Schnellbuchungen ([#191](https://github.com/tom4711/finanzuebersicht/issues/191))
+- Budget-Hinweise mit Tagesbudget ([#193](https://github.com/tom4711/finanzuebersicht/issues/193))
 
 ---
 
-## 🔧 v1.1 — Qualität & Performance *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/5)
+## ✅ v1.10 — Multi-Account-Grundlage *(abgeschlossen)*
 
-Fokus: Code-Qualität, technische Schulden abbauen, Performance verbessern.
+- Kontenmodell, Verwaltung, Filter, Umbuchungen ([#49](https://github.com/tom4711/finanzuebersicht/issues/49))
+
+---
+
+## ✅ v1.11 — Planung & Sparziele *(abgeschlossen)*
+
+| Issue | Thema |
+|-------|-------|
+| [#194](https://github.com/tom4711/finanzuebersicht/issues/194) | Daueraufträge vom Dashboard buchen / überspringen / verschieben |
+| [#195](https://github.com/tom4711/finanzuebersicht/issues/195) | Sparziele mit Transaktionen verknüpfen |
+| [#196](https://github.com/tom4711/finanzuebersicht/issues/196) | Cashflow-Kalender (30 Tage) |
+| [#206](https://github.com/tom4711/finanzuebersicht/issues/206)–[#208](https://github.com/tom4711/finanzuebersicht/issues/208) | Kontosaldo, Konto-Filter Prognose/Budget |
+
+---
+
+## ✅ v1.12 — Konten & Salden *(abgeschlossen)*
+
+| Issue | Thema |
+|-------|-------|
+| [#212](https://github.com/tom4711/finanzuebersicht/issues/212) | Anfangssaldo pro Konto |
+| [#213](https://github.com/tom4711/finanzuebersicht/issues/213) | Dashboard-Kontenübersicht mit Gesamtsaldo |
+
+Weitere Umsetzungen: Umbuchungen, Transaktions-Suche/Filter/Swipe, Cashflow-Navigation, Docs & Screenshots.
+
+---
+
+## ✅ v1.13 — Mac Catalyst Picker *(abgeschlossen)*
+
+Kleines Update: Mitigation für Mac-Catalyst-Picker-Freeze (`UpdateMode=WhenFinished`, `RecurrenceIntervalOption`, Handoff-Dokumentation). Branch: `fix/recurring-interval-picker`.
+
+---
+
+## 🎯 v1.14 — Erste Schritte & Vertrauen *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/18)
+
+Fokus: Onboarding, einheitliche Empty States, Aktion-Feedback, Saldo-Vertrauen.
+
+| Issue | Thema | Priorität |
+|-------|-------|-----------|
+| [#227](https://github.com/tom4711/finanzuebersicht/issues/227) | Onboarding für neue Nutzer | A |
+| [#228](https://github.com/tom4711/finanzuebersicht/issues/228) | Leere Zustände vereinheitlichen | A |
+| [#229](https://github.com/tom4711/finanzuebersicht/issues/229) | Feedback nach Speichern/Löschen (optional Rückgängig) | A |
+| [#214](https://github.com/tom4711/finanzuebersicht/issues/214) | Manueller Saldo-Abgleich (Ist vs. berechnet) | A |
+
+---
+
+## 🎯 v1.15 — Sparziele & Planung *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/19)
+
+| Issue | Thema | Priorität |
+|-------|-------|-----------|
+| [#230](https://github.com/tom4711/finanzuebersicht/issues/230) | Sparziele bearbeiten, sicher löschen, Beitrag buchen | A |
+| [#231](https://github.com/tom4711/finanzuebersicht/issues/231) | Cashflow besser auffindbar | B |
+| [#232](https://github.com/tom4711/finanzuebersicht/issues/232) | Fällige Daueraufträge — kompaktere Dashboard-Aktionen | B |
+| [#233](https://github.com/tom4711/finanzuebersicht/issues/233) | Dashboard Informationshierarchie entschlacken | C |
+
+---
+
+## 🎯 v1.16 — UI-Konsistenz & Lokalisierung *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/20)
+
+| Issue | Thema | Priorität |
+|-------|-------|-----------|
+| [#234](https://github.com/tom4711/finanzuebersicht/issues/234) | Seitentitel und Enum-Labels lokalisieren | B |
+| [#236](https://github.com/tom4711/finanzuebersicht/issues/236) | Verwaltung Kategorien/Konten — Segment klarer | B |
+| [#238](https://github.com/tom4711/finanzuebersicht/issues/238) | Filter und Umbuchung mit Text statt Emoji | B |
+| [#240](https://github.com/tom4711/finanzuebersicht/issues/240) | Einheitliches Icon-Set statt Emoji | C |
+
+---
+
+## 🎯 v1.17 — Barrierefreiheit & Mac-Formulare *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/21)
+
+| Issue | Thema | Priorität |
+|-------|-------|-----------|
+| [#235](https://github.com/tom4711/finanzuebersicht/issues/235) | Charts mit Text-Zusammenfassung (Screenreader) | B |
+| [#237](https://github.com/tom4711/finanzuebersicht/issues/237) | Listenzeilen für VoiceOver beschriften | B |
+| [#239](https://github.com/tom4711/finanzuebersicht/issues/239) | Mac Catalyst: SelectionField in Scroll-Formularen | B |
+
+---
+
+## 💡 v1.18 — Ideen & Langfrist *(Backlog, vor v2)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/22)
+
+Größere Features — Priorisierung nach Abschluss von v1.14–v1.17.
 
 | Issue | Thema | Aufwand |
 |-------|-------|---------|
-| [#101](https://github.com/tom4711/finanzuebersicht/issues/101) | Store-Basisklasse (`JsonStore<T>`) – DRY für alle 5 Stores | M |
-| [#102](https://github.com/tom4711/finanzuebersicht/issues/102) | `YearOverviewViewModel`: `List<>` → `ObservableCollection` | S |
-| [#103](https://github.com/tom4711/finanzuebersicht/issues/103) | Namespace-Bereinigung (ASCII-Konvention) | M |
-| [#100](https://github.com/tom4711/finanzuebersicht/issues/100) | Bulk-Replace API für Restore (O(n²) → O(n) I/O) | M |
+| [#241](https://github.com/tom4711/finanzuebersicht/issues/241) | Kategorien-Hierarchie (Ober-/Unterkategorien) | L |
+| [#242](https://github.com/tom4711/finanzuebersicht/issues/242) | Home-Screen-Widget (iOS / macOS) | L |
+| [#244](https://github.com/tom4711/finanzuebersicht/issues/244) | Daueraufträge mit variablem Betrag | M |
+| [#243](https://github.com/tom4711/finanzuebersicht/issues/243) | CloudKit-Sync zwischen Geräten | XL |
+| [#245](https://github.com/tom4711/finanzuebersicht/issues/245) | Open Banking / automatischer Bank-Import | XL |
 
 ---
 
-## 📊 v1.2 — Export & Auswertungen *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/6)
+## 🔧 v1.1 — Qualität & Performance *(Backlog)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/5)
 
-Fokus: Erweiterte Exportmöglichkeiten für Steuern und Analysen.
+Technische Schulden — parallel zu UX-Releases möglich.
 
 | Issue | Thema | Aufwand |
 |-------|-------|---------|
+| [#101](https://github.com/tom4711/finanzuebersicht/issues/101) | Store-Basisklasse (`JsonStore<T>`) | M |
+| [#102](https://github.com/tom4711/finanzuebersicht/issues/102) | `YearOverviewViewModel`: ObservableCollection | S |
+| [#103](https://github.com/tom4711/finanzuebersicht/issues/103) | Namespace-Bereinigung | M |
+| [#100](https://github.com/tom4711/finanzuebersicht/issues/100) | Bulk-Replace API für Restore | M |
+
+---
+
+## 🔐 v2.0 — Sicherheit & erweiterte Finanzen *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/17)
+
+Größere Architekturänderungen — nach v1.14–v1.18.
+
+| Issue | Thema | Aufwand |
+|-------|-------|---------|
+| [#53](https://github.com/tom4711/finanzuebersicht/issues/53) | Optionale lokale Verschlüsselung (passwortbasiert) | L |
+| [#197](https://github.com/tom4711/finanzuebersicht/issues/197) | Mehrwährung mit historischen Wechselkursen | XL |
 | [#64](https://github.com/tom4711/finanzuebersicht/issues/64) | CSV/PDF-Export für Steuerzwecke | M |
-
----
-
-## 🔐 v2.0 — Sicherheit & Multi-Account *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/7)
-
-Fokus: Größere Architekturänderungen – eigener Release-Zyklus.
-
-| Issue | Thema | Aufwand |
-|-------|-------|---------|
-| [#53](https://github.com/tom4711/finanzuebersicht/issues/53) | Optionale lokale Verschlüsselung (PBKDF2/Argon2) | L |
-| [#49](https://github.com/tom4711/finanzuebersicht/issues/49) | Multi-Account & Währungsunterstützung | XL |
-
----
-
-## 💡 Ideen / Nicht eingeplant
-
-Features, die diskutiert wurden aber noch keinen Milestone haben:
-
-- [#214](https://github.com/tom4711/finanzuebersicht/issues/214) Manueller Saldo-Abgleich (Ist-Saldo vs. berechneter Saldo)
-- CloudKit-Sync (erfordert Apple Developer Membership)
-- Widget für iOS/macOS
-- Wiederkehrende Transaktionen mit variablem Betrag
-- Kategorien-Hierarchie (Ober-/Unterkategorien)
-- Open Banking / automatischer Bank-Import (aktuell nur CSV)
 
 ---
 


### PR DESCRIPTION
## Summary
- **Onboarding:** 4-step wizard on first launch (no transactions yet)
- **Empty states:** unified `EmptyStateView` on main list screens
- **Feedback:** Snackbar on save; delete with undo for transactions
- **Saldo-Abgleich:** reconcile actual vs calculated balance via opening balance (#214)

## Milestone
v1.14 — Erste Schritte & Vertrauen

## Issues
Closes #214
Closes #227
Closes #228
Closes #229

## Test plan
- [x] 284 unit tests locally
- [x] Manual: first launch onboarding
- [x] Manual: account reconcile
- [x] Manual: transaction delete undo snackbar
- [ ] CI

## Note
Draft — Feinschliff (settings onboarding replay, remaining empty states, broader feedback) follows in this PR.

Made with [Cursor](https://cursor.com)