### PR TITLE
🔧 chore(config): set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,24 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+This repo is a **.NET 10 + .NET MAUI** personal finance app. Cloud Agents run on **Linux**, which constrains what can be built/run here.
+
+### What runs on Linux (Cloud Agent)
+The `net10.0` class libraries and the test project build and run on Linux. This is exactly the CI "quick path" (`.github/workflows/ci-split.yml` → `quick-checks`):
+
+- `Finanzuebersicht.Core`, `Finanzuebersicht.Application`, `Finanzuebersicht.Infrastructure`, `Finanzuebersicht.Presentation` (all `net10.0`)
+- `Finanzuebersicht.Tests` (xUnit, `net10.0`) — exercises use cases, repositories, JSON stores, DKB CSV import, etc.
+
+Standard commands (see `README.md` / `.github/copilot-instructions.md`):
+- Restore: `dotnet restore Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj`
+- Build + test: `dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj -c Release`
+
+There is no separate lint step: `TreatWarningsAsErrors=true` + `AnalysisLevel=latest` (`Directory.Build.props`) make the build itself the analyzer/lint gate.
+
+### What does NOT run on Linux
+The MAUI app project `Finanzuebersicht/Finanzuebersicht.csproj` targets `net10.0-ios`, `net10.0-maccatalyst`, and Windows only. **Do not** try to `dotnet build`/`dotnet run` the MAUI app or the full solution (`Finanzuebersicht.slnx`) on Linux — it requires macOS (Xcode) or Windows plus the `maui` workloads. The GUI app cannot be launched in this environment; the full Mac Catalyst build runs only on macOS CI for PRs to `main`.
+
+### Environment notes
+- The .NET 10 SDK is installed at `~/.dotnet` and added to `PATH` via `~/.bashrc`. The update script self-heals by reinstalling it if missing.
+- `Nerdbank.GitVersioning` computes the version from git history; the full clone is present, so no extra steps are needed.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up and verifies the Cloud Agent (Linux) development environment for this .NET 10 + MAUI repo, and documents durable cloud-specific guidance in `AGENTS.md`.

Cloud Agents run on Linux, so the achievable scope is the CI "quick path": build the `net10.0` libraries and run the xUnit test suite. The MAUI GUI app (`Finanzuebersicht.csproj` → iOS/Mac Catalyst/Windows) cannot be built or run on Linux — that requires macOS/Windows + `maui` workloads.

## What was done
- Installed the .NET 10 SDK (`10.0.301`) and put it on `PATH`.
- Restored, built (Release), and ran the full test suite.
- Added `AGENTS.md` `## Cursor Cloud specific instructions` describing what runs on Linux vs. what doesn't, and the lint gate (`TreatWarningsAsErrors`).

## Verification
- `dotnet restore Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj` ✅
- `dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj -c Release` ✅ — **284 passed, 0 failed**

Test log:
[dotnet_test_output.log](https://cursor.com/agents/bc-69b55bbd-73c8-4a5c-a1b8-f55fbb67af2b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdotnet_test_output.log)

## Update script (runs on VM startup)
Self-heals the SDK if missing, then restores:
```
if [ ! -x "$HOME/.dotnet/dotnet" ]; then
  curl -fsSL https://dot.net/v1/dotnet-install.sh -o /tmp/dotnet-install.sh
  bash /tmp/dotnet-install.sh --channel 10.0 --install-dir "$HOME/.dotnet"
fi
"$HOME/.dotnet/dotnet" restore Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj
```

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-69b55bbd-73c8-4a5c-a1b8-f55fbb67af2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-69b55bbd-73c8-4a5c-a1b8-f55fbb67af2b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

