### PR TITLE
feat(v1.15): Sparziele, Dashboard-Planung und i18n/Währungs-Fixes

### DIFF
--- a/Finanzuebersicht.Core/Models/KategorieFilterItem.cs
+++ b/Finanzuebersicht.Core/Models/KategorieFilterItem.cs
@@ -1,3 +1,3 @@
 namespace Finanzuebersicht.Models;
 
-public record KategorieFilterItem(string? Id, string DisplayName);
+public record KategorieFilterItem(string? Id, string DisplayName, string? LocalizationResourceKey = null);

--- a/Finanzuebersicht.Core/Services/CurrencyCulture.cs
+++ b/Finanzuebersicht.Core/Services/CurrencyCulture.cs
@@ -1,0 +1,11 @@
+using System.Globalization;
+
+namespace Finanzuebersicht.Core.Services;
+
+/// <summary>
+/// Fixed EUR formatting for monetary amounts regardless of UI language.
+/// </summary>
+public static class CurrencyCulture
+{
+    public static CultureInfo Instance { get; } = CultureInfo.GetCultureInfo("de-DE");
+}

--- a/Finanzuebersicht.Core/Services/SettingsKeys.cs
+++ b/Finanzuebersicht.Core/Services/SettingsKeys.cs
@@ -41,5 +41,15 @@ namespace Finanzuebersicht.Core.Services
         /// Whether the first-run onboarding wizard was completed (true/false).
         /// </summary>
         public const string OnboardingCompleted = "OnboardingCompleted";
+
+        /// <summary>
+        /// Whether the dashboard budget section is expanded (true/false).
+        /// </summary>
+        public const string DashboardBudgetExpanded = "DashboardBudgetExpanded";
+
+        /// <summary>
+        /// Whether the dashboard year details section is expanded (true/false).
+        /// </summary>
+        public const string DashboardYearDetailsExpanded = "DashboardYearDetailsExpanded";
     }
 }

--- a/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Presentation/DependencyInjection/PresentationServiceCollectionExtensions.cs
@@ -42,6 +42,7 @@ public static class PresentationServiceCollectionExtensions
                 sp.GetRequiredService<AboutViewModel>(),
                 sp.GetRequiredService<INavigationService>()));
         services.AddTransient<SparZieleViewModel>();
+        services.AddTransient<SparZielDetailViewModel>();
         services.AddTransient<BackupListViewModel>();
         services.AddTransient<ImportPreviewViewModel>();
         services.AddTransient<CashflowViewModel>();

--- a/Finanzuebersicht.Presentation/Navigation/Routes.cs
+++ b/Finanzuebersicht.Presentation/Navigation/Routes.cs
@@ -16,5 +16,6 @@ public static class Routes
     public static readonly string BackupList = "BackupListPage";
     public static readonly string ImportPreview = "ImportPreviewPage";
     public static readonly string Cashflow = "CashflowPage";
+    public static readonly string SparZielDetail = "SparZielDetailPage";
     public static readonly string Onboarding = "OnboardingPage";
 }

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -233,6 +233,14 @@ public static class ResourceKeys
     // Budgeting & Forecasting
     public const string Nav_SparZiele = nameof(Nav_SparZiele);
     public const string Title_SparZiele = nameof(Title_SparZiele);
+    public const string Title_SparZielBearbeiten = nameof(Title_SparZielBearbeiten);
+    public const string Btn_BeitragBuchen = nameof(Btn_BeitragBuchen);
+    public const string Btn_Buchen = nameof(Btn_Buchen);
+    public const string Lbl_Cashflow30Tage = nameof(Lbl_Cashflow30Tage);
+    public const string Lbl_CashflowNetto = nameof(Lbl_CashflowNetto);
+    public const string Fmt_CashflowSummary = nameof(Fmt_CashflowSummary);
+    public const string Fmt_SparZielFortschritt = nameof(Fmt_SparZielFortschritt);
+    public const string Lbl_Jahresdetails = nameof(Lbl_Jahresdetails);
     public const string Lbl_MonatlichesBudget = nameof(Lbl_MonatlichesBudget);
     public const string Lbl_ZielBetrag = nameof(Lbl_ZielBetrag);
     public const string Lbl_AktuellerBetrag = nameof(Lbl_AktuellerBetrag);
@@ -278,6 +286,9 @@ public static class ResourceKeys
     public const string A11y_FilterUmschalten = nameof(A11y_FilterUmschalten);
     public const string Lbl_DauerauftraegeFaellig = nameof(Lbl_DauerauftraegeFaellig);
     public const string Lbl_DauerauftraegeFaellig_Singular = nameof(Lbl_DauerauftraegeFaellig_Singular);
+    public const string Hint_HeuteFaellig = nameof(Hint_HeuteFaellig);
+    public const string Hint_UeberfaelligSeitTagen = nameof(Hint_UeberfaelligSeitTagen);
+    public const string Hint_FaelligInTagen = nameof(Hint_FaelligInTagen);
     public const string Lbl_OhneKategorie = nameof(Lbl_OhneKategorie);
     public const string Lbl_BudgetVon = nameof(Lbl_BudgetVon);
     public const string Lbl_Von = nameof(Lbl_Von);

--- a/Finanzuebersicht.Presentation/Services/ILocalizationService.cs
+++ b/Finanzuebersicht.Presentation/Services/ILocalizationService.cs
@@ -4,6 +4,9 @@ namespace Finanzuebersicht.Presentation.Services;
 
 public interface ILocalizationService
 {
+    /// <summary>Raised after UI culture and resources were updated.</summary>
+    event Action? LanguageChanged;
+
     /// <summary>Initialisiert ResourceManager und setzt gespeicherte oder Gerätesprache.</summary>
     void Initialize();
 

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -2,6 +2,7 @@ using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Presentation.Services;
@@ -195,7 +196,7 @@ public partial class AccountDetailViewModel(
 
         var summaries = await _getAccountBalancesUseCase.ExecuteAsync();
         var summary = summaries.FirstOrDefault(s => s.AccountId == _existingAccount.Id);
-        CalculatedBalanceText = summary?.Saldo.ToString("C", CultureInfo.CurrentCulture) ?? string.Empty;
+        CalculatedBalanceText = summary?.Saldo.ToString("C", CurrencyCulture.Instance) ?? string.Empty;
     }
 
     private bool TryParseOpeningBalance(out decimal openingBalance)

--- a/Finanzuebersicht.Presentation/ViewModels/CashflowViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CashflowViewModel.cs
@@ -91,7 +91,7 @@ public partial class CashflowViewModel(
         var accounts = await _accountRepository.GetAccountsAsync();
         var items = new ObservableCollection<KategorieFilterItem>
         {
-            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten))
+            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten), ResourceKeys.Lbl_AlleKonten)
         };
 
         foreach (var account in accounts.Where(a => !a.IsArchived).OrderBy(a => a.Name))

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -4,6 +4,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Categories;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Presentation.Services;
@@ -96,8 +97,8 @@ public partial class CategoriesViewModel(
                             BalanceBreakdownText = summary is { OpeningBalance: not 0 }
                                 ? _loc.GetString(
                                     ResourceKeys.Fmt_KontoSaldoAufschluesselung,
-                                    summary.OpeningBalance.ToString("C", CultureInfo.CurrentCulture),
-                                    summary.TransactionBalance.ToString("C", CultureInfo.CurrentCulture))
+                                    summary.OpeningBalance.ToString("C", CurrencyCulture.Instance),
+                                    summary.TransactionBalance.ToString("C", CurrencyCulture.Instance))
                                 : null
                         };
                     }));

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Resources.Strings;
@@ -19,6 +20,8 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private readonly GetDueRecurringWithHintsUseCase _getDueRecurringUseCase;
     private readonly BookDueRecurringInstanceUseCase _bookDueRecurringUseCase;
     private readonly SkipDueRecurringInstanceUseCase _skipDueRecurringUseCase;
+    private readonly LoadCashflowOutlookUseCase _loadCashflowOutlookUseCase;
+    private readonly ISettingsService _settingsService;
     private readonly IDialogService _dialogService;
     private readonly IBudgetRepository _budgetRepository;
     private readonly IAccountRepository _accountRepository;
@@ -176,6 +179,47 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     public bool HasDueItems => DueRecurringCount > 0;
 
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCashflowPreview))]
+    private decimal cashflowNetAmount;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCashflowPreview))]
+    private decimal cashflowProjectedIncome;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCashflowPreview))]
+    private decimal cashflowProjectedExpenses;
+
+    [ObservableProperty]
+    private string cashflowSummaryText = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasCashflowPreview))]
+    private int cashflowNotableDays;
+
+    public bool HasCashflowPreview => CashflowProjectedIncome > 0 || CashflowProjectedExpenses > 0 || CashflowNotableDays > 0;
+
+    [ObservableProperty]
+    private bool isBudgetSectionExpanded = true;
+
+    [ObservableProperty]
+    private bool isYearDetailsExpanded = true;
+
+    public bool ShowDashboardSummary => HasKontenUebersicht || HasSelectedAccountSaldo || (IsMonthView && HasMonthData);
+
+    public decimal SummarySaldo => HasSelectedAccountSaldo ? SelectedAccountSaldo : GesamtSaldo;
+
+    public string SummarySaldoLabel => HasSelectedAccountSaldo
+        ? _loc.GetString(ResourceKeys.Lbl_Kontosaldo)
+        : _loc.GetString(ResourceKeys.Lbl_Gesamtsaldo);
+
+    public bool ShowSummaryBilanz => IsMonthView && HasMonthData;
+
+    public string BudgetSectionChevron => IsBudgetSectionExpanded ? "▼" : "▶";
+
+    public string YearDetailsChevron => IsYearDetailsExpanded ? "▼" : "▶";
+
     public string DueRecurringText => DueRecurringCount == 1
         ? _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig_Singular, DueRecurringCount)
         : _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig, DueRecurringCount);
@@ -197,10 +241,29 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _ = LoadDashboard();
     }
 
+    partial void OnIsBudgetSectionExpandedChanged(bool value) => OnPropertyChanged(nameof(BudgetSectionChevron));
+
+    partial void OnIsYearDetailsExpandedChanged(bool value) => OnPropertyChanged(nameof(YearDetailsChevron));
+
+    partial void OnGesamtSaldoChanged(decimal value)
+    {
+        OnPropertyChanged(nameof(SummarySaldo));
+        OnPropertyChanged(nameof(ShowDashboardSummary));
+    }
+
+    partial void OnSelectedAccountSaldoChanged(decimal value)
+    {
+        OnPropertyChanged(nameof(SummarySaldo));
+        OnPropertyChanged(nameof(ShowDashboardSummary));
+    }
+
+    partial void OnBilanzChanged(decimal value) => OnPropertyChanged(nameof(ShowSummaryBilanz));
+
     public DashboardViewModel(
         LoadDashboardMonthUseCase loadDashboardMonthUseCase,
         LoadDashboardYearUseCase loadDashboardYearUseCase,
         LoadForecastUseCase loadForecastUseCase,
+        LoadCashflowOutlookUseCase loadCashflowOutlookUseCase,
         GetDueRecurringWithHintsUseCase getDueRecurringUseCase,
         BookDueRecurringInstanceUseCase bookDueRecurringUseCase,
         SkipDueRecurringInstanceUseCase skipDueRecurringUseCase,
@@ -211,6 +274,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         ITransactionRepository transactionRepository,
         IAccountRepository accountRepository,
         GetAccountBalancesUseCase getAccountBalancesUseCase,
+        ISettingsService settingsService,
         IClock? clock = null,
         ILogger<DashboardViewModel>? logger = null) : base(clock)
     {
@@ -220,6 +284,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _loadDashboardMonthUseCase = loadDashboardMonthUseCase;
         _loadDashboardYearUseCase = loadDashboardYearUseCase;
         _loadForecastUseCase = loadForecastUseCase;
+        _loadCashflowOutlookUseCase = loadCashflowOutlookUseCase;
         _getDueRecurringUseCase = getDueRecurringUseCase;
         _bookDueRecurringUseCase = bookDueRecurringUseCase;
         _skipDueRecurringUseCase = skipDueRecurringUseCase;
@@ -230,8 +295,25 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _transactionRepository = transactionRepository;
         _accountRepository = accountRepository;
         _getAccountBalancesUseCase = getAccountBalancesUseCase;
+        _settingsService = settingsService;
         _logger = logger;
+        IsBudgetSectionExpanded = settingsService.Get(SettingsKeys.DashboardBudgetExpanded, "true") == "true";
+        IsYearDetailsExpanded = settingsService.Get(SettingsKeys.DashboardYearDetailsExpanded, "true") == "true";
         UpdateJahrAnzeige();
+        _loc.LanguageChanged += OnLanguageChanged;
+    }
+
+    private async void OnLanguageChanged()
+    {
+        try
+        {
+            await LadeFaelligeDauerauftraegeAsync();
+            await LoadCashflowPreviewAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogWarning(ex, "Dashboard refresh after language change failed");
+        }
     }
 
     protected override async Task OnMonthChangedAsync() => await LoadDashboard();
@@ -256,11 +338,15 @@ public partial class DashboardViewModel : MonthNavigationViewModel
                 await LadeJahrAsync();
             }
             await LadeFaelligeDauerauftraegeAsync();
+            await LoadCashflowPreviewAsync();
             HasAnyDataLoaded = HasMonthData || HasYearData;
         }
         finally
         {
             IsLoading = false;
+            OnPropertyChanged(nameof(ShowDashboardSummary));
+            OnPropertyChanged(nameof(ShowSummaryBilanz));
+            OnPropertyChanged(nameof(SummarySaldoLabel));
         }
     }
 
@@ -334,7 +420,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         var accounts = await _accountRepository.GetAccountsAsync();
         var items = new ObservableCollection<KategorieFilterItem>
         {
-            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten))
+            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten), ResourceKeys.Lbl_AlleKonten)
         };
 
         foreach (var account in accounts.Where(a => !a.IsArchived).OrderBy(a => a.Name))
@@ -481,12 +567,81 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         PreviousYearCommand.NotifyCanExecuteChanged();
     }
 
+    private async Task LoadCashflowPreviewAsync()
+    {
+        try
+        {
+            var data = await _loadCashflowOutlookUseCase.ExecuteAsync(accountId: SelectedAccountId);
+            CashflowNetAmount = data.ProjectedIncome - data.ProjectedExpenses;
+            CashflowProjectedIncome = data.ProjectedIncome;
+            CashflowProjectedExpenses = data.ProjectedExpenses;
+            CashflowNotableDays = data.Days.Count(d => d.IsNotable);
+            CashflowSummaryText = string.Format(
+                System.Globalization.CultureInfo.CurrentCulture,
+                _loc.GetString(ResourceKeys.Fmt_CashflowSummary),
+                data.ProjectedIncome.ToString("C", CurrencyCulture.Instance),
+                data.ProjectedExpenses.ToString("C", CurrencyCulture.Instance));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "DashboardViewModel: LoadCashflowPreviewAsync failed");
+            CashflowNetAmount = 0;
+            CashflowProjectedIncome = 0;
+            CashflowProjectedExpenses = 0;
+            CashflowNotableDays = 0;
+            CashflowSummaryText = string.Empty;
+        }
+    }
+
+    [RelayCommand]
+    private void ToggleBudgetSection()
+    {
+        IsBudgetSectionExpanded = !IsBudgetSectionExpanded;
+        _settingsService.Set(SettingsKeys.DashboardBudgetExpanded, IsBudgetSectionExpanded.ToString().ToLowerInvariant());
+    }
+
+    [RelayCommand]
+    private void ToggleYearDetails()
+    {
+        IsYearDetailsExpanded = !IsYearDetailsExpanded;
+        _settingsService.Set(SettingsKeys.DashboardYearDetailsExpanded, IsYearDetailsExpanded.ToString().ToLowerInvariant());
+    }
+
     private async Task LadeFaelligeDauerauftraegeAsync()
     {
+        const int dashboardPreviewDays = 7;
         var items = await _getDueRecurringUseCase.ExecuteAsync(_clock.Today);
-        var actionable = items.Where(i => i.Hint != null).ToList();
+        var actionable = items
+            .Select(item =>
+            {
+                var hint = BuildDueRecurringHint(item, dashboardPreviewDays);
+                if (hint is null)
+                    return null;
+
+                item.Hint = hint;
+                return item;
+            })
+            .Where(item => item is not null)
+            .Cast<DueRecurringItem>()
+            .ToList();
+
         DueRecurringCount = actionable.Count;
         DueRecurringItems = new ObservableCollection<DueRecurringItem>(actionable);
+        OnPropertyChanged(nameof(DueRecurringText));
+    }
+
+    private string? BuildDueRecurringHint(DueRecurringItem item, int dashboardPreviewDays)
+    {
+        var daysUntil = (item.DueDate.Date - _clock.Today.Date).Days;
+        return daysUntil switch
+        {
+            0 => _loc.GetString(ResourceKeys.Hint_HeuteFaellig),
+            < 0 => _loc.GetString(ResourceKeys.Hint_UeberfaelligSeitTagen, -daysUntil),
+            > 0 when daysUntil <= dashboardPreviewDays => _loc.GetString(ResourceKeys.Hint_FaelligInTagen, daysUntil),
+            > 0 when item.Recurring.ReminderDaysBefore > 0 && daysUntil <= item.Recurring.ReminderDaysBefore
+                => _loc.GetString(ResourceKeys.Hint_FaelligInTagen, daysUntil),
+            _ => null
+        };
     }
 
     [RelayCommand]

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -151,6 +151,8 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     [NotifyPropertyChangedFor(nameof(IsYearView))]
     [NotifyPropertyChangedFor(nameof(ShowMonthView))]
     [NotifyPropertyChangedFor(nameof(ShowYearView))]
+    [NotifyPropertyChangedFor(nameof(ShowDashboardSummary))]
+    [NotifyPropertyChangedFor(nameof(ShowSummaryBilanz))]
     private bool isMonthView = true;
 
     public bool IsYearView => !IsMonthView;
@@ -300,20 +302,6 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         IsBudgetSectionExpanded = settingsService.Get(SettingsKeys.DashboardBudgetExpanded, "true") == "true";
         IsYearDetailsExpanded = settingsService.Get(SettingsKeys.DashboardYearDetailsExpanded, "true") == "true";
         UpdateJahrAnzeige();
-        _loc.LanguageChanged += OnLanguageChanged;
-    }
-
-    private async void OnLanguageChanged()
-    {
-        try
-        {
-            await LadeFaelligeDauerauftraegeAsync();
-            await LoadCashflowPreviewAsync();
-        }
-        catch (Exception ex)
-        {
-            _logger?.LogWarning(ex, "Dashboard refresh after language change failed");
-        }
     }
 
     protected override async Task OnMonthChangedAsync() => await LoadDashboard();

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -2,6 +2,7 @@ using System.Collections.ObjectModel;
 using System.Globalization;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Presentation.Services;
@@ -265,7 +266,7 @@ public partial class ImportPreviewRowItemViewModel : ObservableObject
         {
             var tx = _row.Transaction;
             if (tx == null) return "—";
-            var ci = CultureInfo.CurrentCulture;
+            var ci = CurrencyCulture.Instance;
             var abs = Math.Abs(tx.Betrag);
             var formatted = abs.ToString("C", ci);
             var sign = tx.Typ == TransactionType.Einnahme ? "+" : "-";

--- a/Finanzuebersicht.Presentation/ViewModels/SparZielDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SparZielDetailViewModel.cs
@@ -20,7 +20,7 @@ public partial class SparZielDetailViewModel(
     IDialogService dialogService,
     IFeedbackService feedbackService,
     IAppEvents appEvents,
-    ILogger<SparZielDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
+    ILogger<SparZielDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes, IAutoLoadViewModel
 {
     private readonly SaveSparZielUseCase _saveSparZielUseCase = saveSparZielUseCase;
     private readonly DeleteSparZielUseCase _deleteSparZielUseCase = deleteSparZielUseCase;
@@ -63,6 +63,8 @@ public partial class SparZielDetailViewModel(
     private string fortschrittText = string.Empty;
 
     public bool HasFaelligkeit => UseFaelligkeit;
+
+    public System.Windows.Input.ICommand AutoLoadCommand => LoadProgressCommand;
 
     public string PageTitle => _loc.GetString(ResourceKeys.Title_SparZielBearbeiten);
 

--- a/Finanzuebersicht.Presentation/ViewModels/SparZielDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SparZielDetailViewModel.cs
@@ -1,0 +1,232 @@
+using System.Globalization;
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Application.UseCases.SparZiele;
+using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.Resources.Strings;
+using Microsoft.Extensions.Logging;
+
+namespace Finanzuebersicht.ViewModels;
+
+public partial class SparZielDetailViewModel(
+    SaveSparZielUseCase saveSparZielUseCase,
+    DeleteSparZielUseCase deleteSparZielUseCase,
+    LoadSparZieleUseCase loadSparZieleUseCase,
+    INavigationService navigationService,
+    ILocalizationService localizationService,
+    IDialogService dialogService,
+    IFeedbackService feedbackService,
+    IAppEvents appEvents,
+    ILogger<SparZielDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
+{
+    private readonly SaveSparZielUseCase _saveSparZielUseCase = saveSparZielUseCase;
+    private readonly DeleteSparZielUseCase _deleteSparZielUseCase = deleteSparZielUseCase;
+    private readonly LoadSparZieleUseCase _loadSparZieleUseCase = loadSparZieleUseCase;
+    private readonly INavigationService _navigationService = navigationService;
+    private readonly ILocalizationService _loc = localizationService;
+    private readonly IDialogService _dialogService = dialogService;
+    private readonly IFeedbackService _feedbackService = feedbackService;
+    private readonly IAppEvents _appEvents = appEvents;
+    private readonly ILogger<SparZielDetailViewModel>? _logger = logger;
+
+    private SparZiel? _sparZiel;
+
+    [ObservableProperty]
+    private string titel = string.Empty;
+
+    [ObservableProperty]
+    private string icon = "🎯";
+
+    [ObservableProperty]
+    private string zielBetragText = string.Empty;
+
+    [ObservableProperty]
+    private string aktuellerBetragText = string.Empty;
+
+    [ObservableProperty]
+    private string monatlicheSparrateText = string.Empty;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(HasFaelligkeit))]
+    private bool useFaelligkeit;
+
+    [ObservableProperty]
+    private DateTime faelligkeitsdatum = DateTime.Today;
+
+    [ObservableProperty]
+    private decimal fortschrittProzent;
+
+    [ObservableProperty]
+    private string fortschrittText = string.Empty;
+
+    public bool HasFaelligkeit => UseFaelligkeit;
+
+    public string PageTitle => _loc.GetString(ResourceKeys.Title_SparZielBearbeiten);
+
+    public SparZiel? SparZiel
+    {
+        set
+        {
+            if (value == null) return;
+            _sparZiel = value;
+            Titel = value.Titel;
+            Icon = string.IsNullOrWhiteSpace(value.Icon) ? "🎯" : value.Icon;
+            ZielBetragText = value.ZielBetrag.ToString("F2", CultureInfo.CurrentCulture);
+            AktuellerBetragText = value.AktuellerBetrag.ToString("F2", CultureInfo.CurrentCulture);
+            MonatlicheSparrateText = value.MonatlicheSparrate?.ToString("F2", CultureInfo.CurrentCulture) ?? string.Empty;
+            UseFaelligkeit = value.Faelligkeitsdatum.HasValue;
+            Faelligkeitsdatum = value.Faelligkeitsdatum ?? DateTime.Today;
+            _ = LoadProgressAsync();
+        }
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (query.TryGetValue("SparZiel", out var val) && val is SparZiel sz)
+            SparZiel = sz;
+    }
+
+    [RelayCommand]
+    private async Task LoadProgressAsync()
+    {
+        if (_sparZiel == null) return;
+
+        var summaries = await _loadSparZieleUseCase.ExecuteAsync();
+        var summary = summaries.FirstOrDefault(s => s.SparZiel.Id == _sparZiel.Id);
+        if (summary == null) return;
+
+        FortschrittProzent = summary.FortschrittProzent;
+        FortschrittText = string.Format(
+            CultureInfo.CurrentCulture,
+            _loc.GetString(ResourceKeys.Fmt_SparZielFortschritt),
+            summary.GesamtFortschritt.ToString("C", CurrencyCulture.Instance),
+            summary.SparZiel.ZielBetrag.ToString("C", CurrencyCulture.Instance));
+    }
+
+    [RelayCommand]
+    private async Task Save()
+    {
+        if (_sparZiel == null) return;
+
+        if (string.IsNullOrWhiteSpace(Titel))
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_TitelErforderlich),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        if (!TryParseAmount(ZielBetragText, out var zielBetrag) || zielBetrag <= 0)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_BetragGroesserNull),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        if (!TryParseAmount(AktuellerBetragText, out var aktuellerBetrag) || aktuellerBetrag < 0)
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        decimal? monatlicheSparrate = null;
+        if (!string.IsNullOrWhiteSpace(MonatlicheSparrateText))
+        {
+            if (!TryParseAmount(MonatlicheSparrateText, out var rate) || rate < 0)
+            {
+                await _dialogService.ShowAlertAsync(
+                    _loc.GetString(ResourceKeys.Err_Titel),
+                    _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                    _loc.GetString(ResourceKeys.Btn_OK));
+                return;
+            }
+
+            if (rate > 0)
+                monatlicheSparrate = rate;
+        }
+
+        try
+        {
+            _sparZiel.Titel = Titel.Trim();
+            _sparZiel.Icon = string.IsNullOrWhiteSpace(Icon) ? "🎯" : Icon;
+            _sparZiel.ZielBetrag = zielBetrag;
+            _sparZiel.AktuellerBetrag = aktuellerBetrag;
+            _sparZiel.MonatlicheSparrate = monatlicheSparrate;
+            _sparZiel.Faelligkeitsdatum = UseFaelligkeit ? Faelligkeitsdatum : null;
+
+            await _saveSparZielUseCase.ExecuteAsync(_sparZiel);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
+            await LoadProgressAsync();
+            await _navigationService.GoBackAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "SparZielDetailViewModel: Save failed");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    [RelayCommand]
+    private async Task Delete()
+    {
+        if (_sparZiel == null) return;
+
+        var confirm = await _dialogService.ShowConfirmationAsync(
+            _loc.GetString(ResourceKeys.Dlg_SparZielLoeschen),
+            _loc.GetString(ResourceKeys.Dlg_SparZielLoeschenFrage, _sparZiel.Titel),
+            _loc.GetString(ResourceKeys.Btn_Ja),
+            _loc.GetString(ResourceKeys.Btn_Nein));
+        if (!confirm) return;
+
+        try
+        {
+            await _deleteSparZielUseCase.ExecuteAsync(_sparZiel.Id);
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Geloescht));
+            await _navigationService.GoBackAsync();
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "SparZielDetailViewModel: Delete failed");
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_LoeschenFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    [RelayCommand]
+    private async Task BookContribution()
+    {
+        if (_sparZiel == null) return;
+
+        await _navigationService.GoToAsync(Routes.TransactionDetail, new Dictionary<string, object>
+        {
+            ["SparZielContribution"] = _sparZiel
+        });
+    }
+
+    private static bool TryParseAmount(string text, out decimal amount)
+    {
+        if (string.IsNullOrWhiteSpace(text))
+        {
+            amount = 0m;
+            return true;
+        }
+
+        return decimal.TryParse(text, NumberStyles.Number, CultureInfo.CurrentCulture, out amount);
+    }
+}

--- a/Finanzuebersicht.Presentation/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SparZieleViewModel.cs
@@ -3,6 +3,7 @@ using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.SparZiele;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.Resources.Strings;
 using Microsoft.Extensions.Logging;
@@ -14,6 +15,7 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
     private readonly LoadSparZieleUseCase _loadUseCase;
     private readonly SaveSparZielUseCase _saveUseCase;
     private readonly DeleteSparZielUseCase _deleteUseCase;
+    private readonly INavigationService _navigationService;
     private readonly IDialogService _dialogService;
     private readonly ILocalizationService _loc;
     private readonly IFeedbackService _feedbackService;
@@ -56,6 +58,7 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
         LoadSparZieleUseCase loadUseCase,
         SaveSparZielUseCase saveUseCase,
         DeleteSparZielUseCase deleteUseCase,
+        INavigationService navigationService,
         IDialogService dialogService,
         ILocalizationService localizationService,
         IFeedbackService feedbackService,
@@ -65,6 +68,7 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
         _loadUseCase = loadUseCase;
         _saveUseCase = saveUseCase;
         _deleteUseCase = deleteUseCase;
+        _navigationService = navigationService;
         _dialogService = dialogService;
         _loc = localizationService;
         _feedbackService = feedbackService;
@@ -176,6 +180,15 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel
                 _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
                 _loc.GetString(ResourceKeys.Btn_OK));
         }
+    }
+
+    [RelayCommand]
+    private async Task OpenSparZiel(SparZielSummary summary)
+    {
+        await _navigationService.GoToAsync(Routes.SparZielDetail, new Dictionary<string, object>
+        {
+            ["SparZiel"] = summary.SparZiel
+        });
     }
 
     [RelayCommand]

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
@@ -115,6 +115,10 @@ public partial class TransactionDetailViewModel(
         {
             ApplyTemplateDraft(template);
         }
+        else if (query.TryGetValue("SparZielContribution", out var contributionVal) && contributionVal is SparZiel sparZiel)
+        {
+            ApplySparZielContribution(sparZiel);
+        }
     }
 
     [RelayCommand]
@@ -295,6 +299,17 @@ public partial class TransactionDetailViewModel(
         _selectedAccountId = source.AccountId;
         _ = SetKategorieAsync(source.KategorieId);
         _ = SetAccountAsync(source.AccountId);
+    }
+
+    private void ApplySparZielContribution(SparZiel sparZiel)
+    {
+        _existingTransaction = null;
+        _selectedSparZielId = sparZiel.Id;
+        Titel = sparZiel.Titel;
+        Typ = TransactionType.Einnahme;
+        Datum = _clock.Today;
+        if (sparZiel.MonatlicheSparrate is > 0)
+            BetragText = sparZiel.MonatlicheSparrate.Value.ToString("F2", System.Globalization.CultureInfo.CurrentCulture);
     }
 
     private void ApplyTemplateDraft(TransactionTemplate template)

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -352,7 +352,7 @@ public partial class TransactionsViewModel(
         var kategorien = await _categoryRepository.GetCategoriesAsync();
         var items = new ObservableCollection<KategorieFilterItem>
         {
-            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKategorien))
+            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKategorien), ResourceKeys.Lbl_AlleKategorien)
         };
         foreach (var k in kategorien.OrderBy(k => k.Name))
             items.Add(new KategorieFilterItem(k.Id, $"{k.Icon} {k.Name}"));
@@ -366,7 +366,7 @@ public partial class TransactionsViewModel(
         var konten = await _accountRepository.GetAccountsAsync();
         var items = new ObservableCollection<KategorieFilterItem>
         {
-            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten))
+            new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten), ResourceKeys.Lbl_AlleKonten)
         };
         foreach (var konto in konten.OrderBy(k => k.Name))
             items.Add(new KategorieFilterItem(konto.Id, konto.Name));

--- a/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
@@ -1,6 +1,7 @@
 using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Tests.TestHelpers;
@@ -108,6 +109,48 @@ public class DashboardViewModelTests
         Assert.True(notified);
     }
 
+    [Fact]
+    public async Task LoadDashboard_PopulatesCashflowPreview()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>()));
+
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>
+            {
+                new()
+                {
+                    Typ = TransactionType.Einnahme,
+                    Betrag = 500m,
+                    Datum = new DateTime(2026, 3, 20),
+                    KategorieId = "cat-1",
+                    Titel = "Gehalt"
+                }
+            }));
+
+        var viewModel = CreateSut(accountRepository, transactionRepository);
+        await viewModel.LoadDashboardCommand.ExecuteAsync(null);
+
+        Assert.True(viewModel.HasCashflowPreview);
+        Assert.Equal(500m, viewModel.CashflowProjectedIncome);
+    }
+
+    [Fact]
+    public void ToggleBudgetSection_PersistsExpandedState()
+    {
+        var settings = Substitute.For<ISettingsService>();
+        settings.Get(SettingsKeys.DashboardBudgetExpanded, "true").Returns("true");
+
+        var viewModel = CreateSut(settings);
+        Assert.True(viewModel.IsBudgetSectionExpanded);
+
+        viewModel.ToggleBudgetSectionCommand.Execute(null);
+
+        Assert.False(viewModel.IsBudgetSectionExpanded);
+        settings.Received(1).Set(SettingsKeys.DashboardBudgetExpanded, "false");
+    }
+
     private static DashboardViewModel CreateSut()
     {
         var accountRepository = Substitute.For<IAccountRepository>();
@@ -121,6 +164,22 @@ public class DashboardViewModelTests
     private static DashboardViewModel CreateSut(
         IAccountRepository accountRepository,
         ITransactionRepository transactionRepository)
+        => CreateSut(accountRepository, transactionRepository, Substitute.For<ISettingsService>());
+
+    private static DashboardViewModel CreateSut(ISettingsService settingsService)
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>()));
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>()));
+        return CreateSut(accountRepository, transactionRepository, settingsService);
+    }
+
+    private static DashboardViewModel CreateSut(
+        IAccountRepository accountRepository,
+        ITransactionRepository transactionRepository,
+        ISettingsService settingsService)
     {
         var categoryRepository = Substitute.For<ICategoryRepository>();
         categoryRepository.GetCategoriesAsync().Returns(Task.FromResult(new List<Category>
@@ -146,6 +205,7 @@ public class DashboardViewModelTests
             new LoadDashboardMonthUseCase(categoryRepository, transactionRepository, recurringTransactionRepository, budgetRepository),
             new LoadDashboardYearUseCase(transactionRepository, categoryRepository),
             new LoadForecastUseCase(forecastService),
+            new LoadCashflowOutlookUseCase(transactionRepository, recurringTransactionRepository, clock),
             new GetDueRecurringWithHintsUseCase(recurringTransactionRepository),
             new BookDueRecurringInstanceUseCase(recurringTransactionRepository, transactionRepository, accountRepository),
             new SkipDueRecurringInstanceUseCase(new AddRecurringExceptionUseCase(recurringTransactionRepository)),
@@ -156,6 +216,7 @@ public class DashboardViewModelTests
             transactionRepository,
             accountRepository,
             new GetAccountBalancesUseCase(accountRepository, transactionRepository),
+            settingsService,
             clock);
     }
 }

--- a/Finanzuebersicht.Tests/ViewModels/SparZielDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/SparZielDetailViewModelTests.cs
@@ -1,0 +1,115 @@
+using System.Globalization;
+using Finanzuebersicht.Application.UseCases.SparZiele;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Tests.ViewModels;
+
+public class SparZielDetailViewModelTests
+{
+    [Fact]
+    public void ApplyQueryAttributes_LoadsSparZielFields()
+    {
+        var viewModel = CreateSut(out _);
+        var sparZiel = new SparZiel
+        {
+            Id = "goal-1",
+            Titel = "Urlaub",
+            Icon = "🏖️",
+            ZielBetrag = 3000m,
+            AktuellerBetrag = 500m,
+            MonatlicheSparrate = 200m,
+            Faelligkeitsdatum = new DateTime(2027, 6, 1)
+        };
+
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { ["SparZiel"] = sparZiel });
+
+        Assert.Equal("Urlaub", viewModel.Titel);
+        Assert.Equal("🏖️", viewModel.Icon);
+        Assert.Equal(3000m.ToString("F2", CultureInfo.CurrentCulture), viewModel.ZielBetragText);
+        Assert.Equal(500m.ToString("F2", CultureInfo.CurrentCulture), viewModel.AktuellerBetragText);
+        Assert.Equal(200m.ToString("F2", CultureInfo.CurrentCulture), viewModel.MonatlicheSparrateText);
+        Assert.True(viewModel.UseFaelligkeit);
+    }
+
+    [Fact]
+    public async Task Save_WithValidData_PersistsAndNavigatesBack()
+    {
+        var repository = Substitute.For<ISparZielRepository>();
+        repository.SaveSparZielAsync(Arg.Any<SparZiel>()).Returns(Task.CompletedTask);
+        repository.GetSparZieleAsync().Returns(Task.FromResult(new List<SparZiel>()));
+
+        var viewModel = CreateSut(repository, out var navigationService);
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object>
+        {
+            ["SparZiel"] = new SparZiel { Id = "goal-1", Titel = "Alt", ZielBetrag = 1000m }
+        });
+        viewModel.Titel = "Neu";
+        viewModel.ZielBetragText = "1500";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        await repository.Received(1).SaveSparZielAsync(Arg.Is<SparZiel>(z => z.Titel == "Neu" && z.ZielBetrag == 1500m));
+        await navigationService.Received(1).GoBackAsync();
+    }
+
+    [Fact]
+    public async Task BookContribution_NavigatesToTransactionDetailWithSparZiel()
+    {
+        var viewModel = CreateSut(out var navigationService);
+        var sparZiel = new SparZiel { Id = "goal-1", Titel = "Urlaub", MonatlicheSparrate = 100m };
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { ["SparZiel"] = sparZiel });
+
+        await viewModel.BookContributionCommand.ExecuteAsync(null);
+
+        await navigationService.Received(1).GoToAsync(
+            Routes.TransactionDetail,
+            Arg.Any<IDictionary<string, object>>());
+        var call = navigationService.ReceivedCalls()
+            .Last(c => c.GetMethodInfo().Name == nameof(INavigationService.GoToAsync));
+        var args = (IDictionary<string, object>)call.GetArguments()[1]!;
+        Assert.True(args.TryGetValue("SparZielContribution", out var value));
+        Assert.IsType<SparZiel>(value);
+        Assert.Equal("goal-1", ((SparZiel)value).Id);
+    }
+
+    private static SparZielDetailViewModel CreateSut(out INavigationService navigationService)
+        => CreateSut(Substitute.For<ISparZielRepository>(), out navigationService);
+
+    private static SparZielDetailViewModel CreateSut(
+        ISparZielRepository repository,
+        out INavigationService navigationService)
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns(Task.FromResult(new List<Transaction>()));
+        repository.GetSparZieleAsync().Returns(Task.FromResult(new List<SparZiel>()));
+
+        navigationService = Substitute.For<INavigationService>();
+        navigationService.GoBackAsync().Returns(Task.CompletedTask);
+        navigationService.GoToAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object>>())
+            .Returns(Task.CompletedTask);
+
+        var localizationService = Substitute.For<ILocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(call => call.Arg<string>());
+        localizationService.GetString(Arg.Any<string>(), Arg.Any<object[]>()).Returns(call => call.Arg<string>());
+
+        var dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.CompletedTask);
+        dialogService.ShowConfirmationAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.FromResult(false));
+
+        return new SparZielDetailViewModel(
+            new SaveSparZielUseCase(repository),
+            new DeleteSparZielUseCase(repository),
+            new LoadSparZieleUseCase(repository, transactionRepository),
+            navigationService,
+            localizationService,
+            dialogService,
+            Substitute.For<IFeedbackService>(),
+            Substitute.For<IAppEvents>());
+    }
+}

--- a/Finanzuebersicht.Tests/ViewModels/SparZieleViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/SparZieleViewModelTests.cs
@@ -1,6 +1,7 @@
 using System.Collections.Generic;
 using Finanzuebersicht.Application.UseCases.SparZiele;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.ViewModels;
 
@@ -85,6 +86,7 @@ public class SparZieleViewModelTests
             new LoadSparZieleUseCase(repository, transactionRepository),
             new SaveSparZielUseCase(repository),
             new DeleteSparZielUseCase(repository),
+            Substitute.For<INavigationService>(),
             dialogService,
             localizationService,
             Substitute.For<IFeedbackService>(),

--- a/Finanzuebersicht/App.xaml.cs
+++ b/Finanzuebersicht/App.xaml.cs
@@ -7,6 +7,8 @@ public partial class App : global::Microsoft.Maui.Controls.Application
 	// App-wide event to notify UI of data changes (e.g., after import)
 	public static event Action? DataChanged;
 
+	public static event Action? LanguageChanged;
+
 		public static void NotifyDataChanged()
 		{
 			DataChanged?.Invoke();
@@ -22,6 +24,7 @@ public partial class App : global::Microsoft.Maui.Controls.Application
 	{
 		// Sprache vor InitializeComponent setzen, damit XAML-Bindings korrekt aufgelöst werden
 		localizationService.Initialize();
+		localizationService.LanguageChanged += () => LanguageChanged?.Invoke();
 
 		InitializeComponent();
 		_recurringGenerationService = recurringGenerationService;

--- a/Finanzuebersicht/AppShell.xaml.cs
+++ b/Finanzuebersicht/AppShell.xaml.cs
@@ -19,6 +19,7 @@ public partial class AppShell : Shell
 		Routing.RegisterRoute(Routes.BackupList, typeof(BackupListPage));
 		Routing.RegisterRoute(Routes.ImportPreview, typeof(ImportPreviewPage));
 		Routing.RegisterRoute(Routes.Cashflow, typeof(CashflowPage));
+		Routing.RegisterRoute(Routes.SparZielDetail, typeof(SparZielDetailPage));
 		Routing.RegisterRoute(Routes.Onboarding, typeof(OnboardingPage));
 	}
 

--- a/Finanzuebersicht/Controls/DatePickerProperties.cs
+++ b/Finanzuebersicht/Controls/DatePickerProperties.cs
@@ -1,0 +1,46 @@
+#if MACCATALYST || IOS
+using Microsoft.Maui.Controls.PlatformConfiguration;
+using Microsoft.Maui.Controls.PlatformConfiguration.iOSSpecific;
+#endif
+
+namespace Finanzuebersicht.Controls;
+
+/// <summary>
+/// Opt-in immediate date binding for form DatePickers that are saved via a button
+/// (instead of relying on the picker "Done" action with <see cref="UpdateMode.WhenFinished"/>).
+/// </summary>
+public static class DatePickerProperties
+{
+    public static readonly BindableProperty ImmediateUpdateProperty =
+        BindableProperty.CreateAttached(
+            "ImmediateUpdate",
+            typeof(bool),
+            typeof(DatePickerProperties),
+            false,
+            propertyChanged: OnImmediateUpdateChanged);
+
+    public static bool GetImmediateUpdate(BindableObject view)
+        => (bool)view.GetValue(ImmediateUpdateProperty);
+
+    public static void SetImmediateUpdate(BindableObject view, bool value)
+        => view.SetValue(ImmediateUpdateProperty, value);
+
+    private static void OnImmediateUpdateChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+#if MACCATALYST || IOS
+        if (bindable is Microsoft.Maui.Controls.DatePicker datePicker)
+            ApplyUpdateMode(datePicker, (bool)newValue);
+#endif
+    }
+
+#if MACCATALYST || IOS
+    internal static void ApplyUpdateMode(Microsoft.Maui.Controls.DatePicker datePicker)
+        => ApplyUpdateMode(datePicker, GetImmediateUpdate(datePicker));
+
+    private static void ApplyUpdateMode(Microsoft.Maui.Controls.DatePicker datePicker, bool immediate)
+    {
+        datePicker.On<iOS>().SetUpdateMode(
+            immediate ? UpdateMode.Immediately : UpdateMode.WhenFinished);
+    }
+#endif
+}

--- a/Finanzuebersicht/Controls/SelectionField.xaml
+++ b/Finanzuebersicht/Controls/SelectionField.xaml
@@ -15,7 +15,7 @@
         <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
             <Label Text="{Binding Source={x:Reference Root}, Path=ResolvedDisplayText}"
                    FontSize="16"
-                   TextColor="{Binding Source={x:Reference Root}, Path=ResolvedTextColor}"
+                   TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource TextPrimaryDark}}"
                    VerticalOptions="Center"
                    LineBreakMode="TailTruncation" />
             <Label Grid.Column="1"

--- a/Finanzuebersicht/Controls/SelectionField.xaml.cs
+++ b/Finanzuebersicht/Controls/SelectionField.xaml.cs
@@ -57,8 +57,18 @@ public partial class SelectionField : ContentView
     public SelectionField()
     {
         InitializeComponent();
-        LocalizationResourceManager.Current.PropertyChanged += OnLocalizationChanged;
         UpdateResolvedDisplay();
+    }
+
+    protected override void OnParentSet()
+    {
+        base.OnParentSet();
+        LocalizationResourceManager.Current.PropertyChanged -= OnLocalizationChanged;
+        if (Parent is not null)
+        {
+            LocalizationResourceManager.Current.PropertyChanged += OnLocalizationChanged;
+            UpdateResolvedDisplay();
+        }
     }
 
     private void OnLocalizationChanged(object? sender, PropertyChangedEventArgs e)

--- a/Finanzuebersicht/Controls/SelectionField.xaml.cs
+++ b/Finanzuebersicht/Controls/SelectionField.xaml.cs
@@ -1,7 +1,8 @@
+using System.ComponentModel;
 using System.Collections;
 using CommunityToolkit.Maui.Extensions;
-using Finanzuebersicht.Converters;
 using Finanzuebersicht.Selection;
+using Finanzuebersicht.Services;
 using Finanzuebersicht.Views.Popups;
 
 namespace Finanzuebersicht.Controls;
@@ -22,9 +23,6 @@ public partial class SelectionField : ContentView
 
     public static readonly BindableProperty ResolvedDisplayTextProperty =
         BindableProperty.Create(nameof(ResolvedDisplayText), typeof(string), typeof(SelectionField), string.Empty);
-
-    public static readonly BindableProperty ResolvedTextColorProperty =
-        BindableProperty.Create(nameof(ResolvedTextColor), typeof(Color), typeof(SelectionField), Colors.Gray);
 
     public IEnumerable? ItemsSource
     {
@@ -56,17 +54,15 @@ public partial class SelectionField : ContentView
         set => SetValue(ResolvedDisplayTextProperty, value);
     }
 
-    public Color ResolvedTextColor
-    {
-        get => (Color)GetValue(ResolvedTextColorProperty);
-        set => SetValue(ResolvedTextColorProperty, value);
-    }
-
     public SelectionField()
     {
         InitializeComponent();
+        LocalizationResourceManager.Current.PropertyChanged += OnLocalizationChanged;
         UpdateResolvedDisplay();
     }
+
+    private void OnLocalizationChanged(object? sender, PropertyChangedEventArgs e)
+        => UpdateResolvedDisplay();
 
     private static void OnSelectionChanged(BindableObject bindable, object oldValue, object newValue)
     {
@@ -74,10 +70,16 @@ public partial class SelectionField : ContentView
             field.UpdateResolvedDisplay();
     }
 
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+        UpdateResolvedDisplay();
+    }
+
     protected override void OnPropertyChanged(string? propertyName = null)
     {
         base.OnPropertyChanged(propertyName);
-        if (propertyName is nameof(SelectedItem) or nameof(Placeholder) or nameof(DisplayMemberPath))
+        if (propertyName is nameof(SelectedItem) or nameof(Placeholder) or nameof(DisplayMemberPath) or nameof(ItemsSource))
             UpdateResolvedDisplay();
     }
 
@@ -85,17 +87,11 @@ public partial class SelectionField : ContentView
     {
         if (SelectedItem is not null)
         {
-            ResolvedDisplayText = SelectionDisplayHelper.GetDisplayText(SelectedItem, DisplayMemberPath);
-            ResolvedTextColor = ColorResourceHelper.GetThemeColor(
-                "TextPrimary", "TextPrimaryDark",
-                Color.FromArgb("#000000"), Color.FromArgb("#FFFFFF"));
+            ResolvedDisplayText = LocalizedSelectionDisplay.GetDisplayText(SelectedItem, DisplayMemberPath);
             return;
         }
 
         ResolvedDisplayText = string.IsNullOrWhiteSpace(Placeholder) ? "—" : Placeholder;
-        ResolvedTextColor = ColorResourceHelper.GetThemeColor(
-            "Gray500", "Gray600",
-            Color.FromArgb("#AEAEB2"), Color.FromArgb("#8E8E93"));
     }
 
     private async void OnTapped(object? sender, TappedEventArgs e)

--- a/Finanzuebersicht/Converters/BetragDisplayConverter.cs
+++ b/Finanzuebersicht/Converters/BetragDisplayConverter.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Converters;
@@ -7,7 +8,7 @@ public class BetragDisplayConverter : IValueConverter
 {
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        var ci = culture ?? CultureInfo.CurrentCulture;
+        var ci = CurrencyCulture.Instance;
 
         if (value is Transaction t)
         {

--- a/Finanzuebersicht/Converters/ColorResourceHelper.cs
+++ b/Finanzuebersicht/Converters/ColorResourceHelper.cs
@@ -18,9 +18,23 @@ internal static class ColorResourceHelper
 
     public static Color GetThemeColor(string lightResourceKey, string darkResourceKey, Color lightFallback, Color darkFallback)
     {
-        var isDarkTheme = global::Microsoft.Maui.Controls.Application.Current?.RequestedTheme == AppTheme.Dark;
+        var isDarkTheme = IsDarkThemeActive();
         return isDarkTheme
             ? GetColor(darkResourceKey, darkFallback)
             : GetColor(lightResourceKey, lightFallback);
+    }
+
+    private static bool IsDarkThemeActive()
+    {
+        var app = global::Microsoft.Maui.Controls.Application.Current;
+        if (app is null)
+            return false;
+
+        return app.RequestedTheme switch
+        {
+            AppTheme.Dark => true,
+            AppTheme.Light => false,
+            _ => app.PlatformAppTheme == AppTheme.Dark
+        };
     }
 }

--- a/Finanzuebersicht/Converters/DashboardConverters.cs
+++ b/Finanzuebersicht/Converters/DashboardConverters.cs
@@ -1,4 +1,5 @@
 using System.Globalization;
+using Finanzuebersicht.Core.Services;
 
 namespace Finanzuebersicht.Converters;
 
@@ -42,12 +43,9 @@ public class DecimalCurrencyConverter : IValueConverter
     public object? Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
         if (value is decimal betrag)
-        {
-            var ci = culture ?? CultureInfo.CurrentCulture;
-            return betrag.ToString("C", ci);
-        }
+            return betrag.ToString("C", CurrencyCulture.Instance);
 
-        return 0m.ToString("C", culture ?? CultureInfo.CurrentCulture);
+        return 0m.ToString("C", CurrencyCulture.Instance);
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
@@ -60,13 +58,12 @@ public class BilanzDisplayConverter : IValueConverter
     {
         if (value is decimal bilanz)
         {
-            var ci = culture ?? CultureInfo.CurrentCulture;
             var abs = Math.Abs(bilanz);
             var sign = bilanz >= 0 ? "+" : "-";
-            return $"{sign}{abs.ToString("C", ci)}";
+            return $"{sign}{abs.ToString("C", CurrencyCulture.Instance)}";
         }
 
-        return 0m.ToString("C", culture ?? CultureInfo.CurrentCulture);
+        return 0m.ToString("C", CurrencyCulture.Instance);
     }
 
     public object? ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -46,7 +46,7 @@ public static class MauiProgram
 			Microsoft.Maui.Handlers.DatePickerHandler.Mapper.AppendToMapping("WhenFinishedSelection", (handler, view) =>
 			{
 				if (view is Microsoft.Maui.Controls.DatePicker datePicker)
-					datePicker.On<iOS>().SetUpdateMode(UpdateMode.WhenFinished);
+					Finanzuebersicht.Controls.DatePickerProperties.ApplyUpdateMode(datePicker);
 			});
 			Microsoft.Maui.Handlers.TimePickerHandler.Mapper.AppendToMapping("WhenFinishedSelection", (handler, view) =>
 			{
@@ -108,6 +108,7 @@ public static class MauiProgram
 		builder.Services.AddTransient<AccountDetailPage>();
 		builder.Services.AddTransient<SettingsPage>();
 		builder.Services.AddTransient<SparZielePage>();
+		builder.Services.AddTransient<SparZielDetailPage>();
 		builder.Services.AddTransient<BackupListPage>();
 		builder.Services.AddTransient<ImportPreviewPage>();
 		builder.Services.AddTransient<CashflowPage>();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -250,6 +250,14 @@ Bitte starte die App neu.</value></data>
   <!-- Budgeting & Forecasting -->
   <data name="Nav_SparZiele" xml:space="preserve"><value>Sparziele</value></data>
   <data name="Title_SparZiele" xml:space="preserve"><value>Sparziele</value></data>
+  <data name="Title_SparZielBearbeiten" xml:space="preserve"><value>Sparziel bearbeiten</value></data>
+  <data name="Btn_BeitragBuchen" xml:space="preserve"><value>Beitrag buchen</value></data>
+  <data name="Btn_Buchen" xml:space="preserve"><value>Buchen</value></data>
+  <data name="Lbl_Cashflow30Tage" xml:space="preserve"><value>Nächste 30 Tage</value></data>
+  <data name="Lbl_CashflowNetto" xml:space="preserve"><value>Netto-Prognose</value></data>
+  <data name="Fmt_CashflowSummary" xml:space="preserve"><value>Einnahmen {0} · Ausgaben {1}</value></data>
+  <data name="Fmt_SparZielFortschritt" xml:space="preserve"><value>{0} von {1}</value></data>
+  <data name="Lbl_Jahresdetails" xml:space="preserve"><value>Jahresdetails</value></data>
   <data name="Lbl_MonatlichesBudget" xml:space="preserve"><value>Monatliches Budget</value></data>
   <data name="Lbl_ZielBetrag" xml:space="preserve"><value>Zielbetrag</value></data>
   <data name="Lbl_AktuellerBetrag" xml:space="preserve"><value>Aktueller Betrag</value></data>
@@ -272,6 +280,9 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_FilterUmschalten" xml:space="preserve"><value>Filter umschalten</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} Daueraufträge bald fällig</value></data>
   <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} Dauerauftrag bald fällig</value></data>
+  <data name="Hint_HeuteFaellig" xml:space="preserve"><value>Heute fällig</value></data>
+  <data name="Hint_UeberfaelligSeitTagen" xml:space="preserve"><value>Seit {0} Tagen überfällig</value></data>
+  <data name="Hint_FaelligInTagen" xml:space="preserve"><value>Fällig in {0} Tagen</value></data>
   <data name="Lbl_OhneKategorie" xml:space="preserve"><value>Ohne Kategorie</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>von {0}</value></data>
   <data name="Lbl_Von" xml:space="preserve"><value>von</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -250,6 +250,14 @@ Please restart the app.</value></data>
   <!-- Budgeting & Forecasting -->
   <data name="Nav_SparZiele" xml:space="preserve"><value>Savings</value></data>
   <data name="Title_SparZiele" xml:space="preserve"><value>Savings Goals</value></data>
+  <data name="Title_SparZielBearbeiten" xml:space="preserve"><value>Edit Savings Goal</value></data>
+  <data name="Btn_BeitragBuchen" xml:space="preserve"><value>Book Contribution</value></data>
+  <data name="Btn_Buchen" xml:space="preserve"><value>Book</value></data>
+  <data name="Lbl_Cashflow30Tage" xml:space="preserve"><value>Next 30 Days</value></data>
+  <data name="Lbl_CashflowNetto" xml:space="preserve"><value>Net Projection</value></data>
+  <data name="Fmt_CashflowSummary" xml:space="preserve"><value>Income {0} · Expenses {1}</value></data>
+  <data name="Fmt_SparZielFortschritt" xml:space="preserve"><value>{0} of {1}</value></data>
+  <data name="Lbl_Jahresdetails" xml:space="preserve"><value>Year Details</value></data>
   <data name="Lbl_MonatlichesBudget" xml:space="preserve"><value>Monthly Budget</value></data>
   <data name="Lbl_ZielBetrag" xml:space="preserve"><value>Target Amount</value></data>
   <data name="Lbl_AktuellerBetrag" xml:space="preserve"><value>Current Amount</value></data>
@@ -272,6 +280,9 @@ Please restart the app.</value></data>
   <data name="A11y_FilterUmschalten" xml:space="preserve"><value>Toggle filters</value></data>
   <data name="Lbl_DauerauftraegeFaellig" xml:space="preserve"><value>🔔 {0} recurring transactions due soon</value></data>
   <data name="Lbl_DauerauftraegeFaellig_Singular" xml:space="preserve"><value>🔔 {0} recurring transaction due soon</value></data>
+  <data name="Hint_HeuteFaellig" xml:space="preserve"><value>Due today</value></data>
+  <data name="Hint_UeberfaelligSeitTagen" xml:space="preserve"><value>Overdue by {0} days</value></data>
+  <data name="Hint_FaelligInTagen" xml:space="preserve"><value>Due in {0} days</value></data>
   <data name="Lbl_OhneKategorie" xml:space="preserve"><value>No category</value></data>
   <data name="Lbl_BudgetVon" xml:space="preserve"><value>of {0}</value></data>
   <data name="Lbl_Von" xml:space="preserve"><value>of</value></data>

--- a/Finanzuebersicht/Selection/LocalizedSelectionDisplay.cs
+++ b/Finanzuebersicht/Selection/LocalizedSelectionDisplay.cs
@@ -1,0 +1,15 @@
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Services;
+
+namespace Finanzuebersicht.Selection;
+
+public static class LocalizedSelectionDisplay
+{
+    public static string GetDisplayText(object? item, string displayMemberPath)
+    {
+        if (item is KategorieFilterItem { LocalizationResourceKey: { } key })
+            return LocalizationResourceManager.Current[key];
+
+        return SelectionDisplayHelper.GetDisplayText(item, displayMemberPath);
+    }
+}

--- a/Finanzuebersicht/Selection/SelectionRowViewFactory.cs
+++ b/Finanzuebersicht/Selection/SelectionRowViewFactory.cs
@@ -23,7 +23,7 @@ internal static class SelectionRowViewFactory
             VerticalOptions = LayoutOptions.Center,
             TextColor = ColorResourceHelper.GetThemeColor(
                 "TextPrimary", "TextPrimaryDark",
-                Color.FromArgb("#000000"), Color.FromArgb("#FFFFFF"))
+                Color.FromArgb("#1C1C1E"), Color.FromArgb("#FFFFFF"))
         };
 
         var check = new Label
@@ -61,23 +61,12 @@ internal static class SelectionRowViewFactory
         };
         Grid.SetColumn(label, 0);
         Grid.SetColumn(check, 1);
-        Grid.SetRowSpan(separator, 1);
 
-        var button = new Button
-        {
-            BackgroundColor = Colors.Transparent,
-            BorderWidth = 0,
-            Padding = 0,
-            HorizontalOptions = LayoutOptions.Fill,
-            VerticalOptions = LayoutOptions.Fill
-        };
-        button.Clicked += async (_, _) => await onSelectedAsync(row);
+        var tap = new TapGestureRecognizer();
+        tap.Tapped += async (_, _) => await onSelectedAsync(row);
+        rowGrid.GestureRecognizers.Add(tap);
 
-        return new Grid
-        {
-            HeightRequest = RowHeight,
-            Children = { rowGrid, button }
-        };
+        return rowGrid;
     }
 
     public static double RowHeightRequest => RowHeight;

--- a/Finanzuebersicht/Services/LocalizationService.cs
+++ b/Finanzuebersicht/Services/LocalizationService.cs
@@ -15,6 +15,8 @@ public class LocalizationService(ISettingsService settings) : ILocalizationServi
     private readonly ISettingsService _settings = settings;
     private string _currentLanguageCode = string.Empty;
 
+    public event Action? LanguageChanged;
+
     public string CurrentLanguageCode => _currentLanguageCode;
 
     public void Initialize()
@@ -52,5 +54,6 @@ public class LocalizationService(ISettingsService settings) : ILocalizationServi
         CultureInfo.CurrentCulture = culture;
         CultureInfo.CurrentUICulture = culture;
         LocalizationResourceManager.Current.CurrentCulture = culture;
+        LanguageChanged?.Invoke();
     }
 }

--- a/Finanzuebersicht/Views/BaseContentPage.cs
+++ b/Finanzuebersicht/Views/BaseContentPage.cs
@@ -22,7 +22,20 @@ public abstract class BaseContentPage : ContentPage
     protected override void OnAppearing()
     {
         base.OnAppearing();
+        App.LanguageChanged += OnLanguageChanged;
         if (BindingContext is IAutoLoadViewModel vm && vm.ShouldAutoLoad)
+            vm.AutoLoadCommand.Execute(null);
+    }
+
+    protected override void OnDisappearing()
+    {
+        App.LanguageChanged -= OnLanguageChanged;
+        base.OnDisappearing();
+    }
+
+    private void OnLanguageChanged()
+    {
+        if (BindingContext is IAutoLoadViewModel vm)
             vm.AutoLoadCommand.Execute(null);
     }
 }

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -65,25 +65,59 @@
                                 <VerticalStackLayout Spacing="8">
                                     <Label Text="{Binding Recurring.Titel}" FontSize="15" FontAttributes="Bold" />
                                     <Label Text="{Binding Hint}" FontSize="13" TextColor="Gray" />
-                                    <HorizontalStackLayout Spacing="8">
-                                        <Button Text="{loc:Translate Btn_AlsAusgefuehrtBuchen}"
+                                    <Button Text="{loc:Translate Btn_Buchen}"
+                                            FontSize="14"
+                                            HeightRequest="44"
+                                            HorizontalOptions="Fill"
+                                            Command="{Binding Source={RelativeSource AncestorType={x:Type vm:DashboardViewModel}}, Path=BookDueRecurringCommand}"
+                                            CommandParameter="{Binding .}" />
+                                    <Grid ColumnDefinitions="*, *" ColumnSpacing="8">
+                                        <Button Grid.Column="0"
+                                                Text="{loc:Translate Btn_TerminUeberspringen}"
                                                 FontSize="12"
-                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:DashboardViewModel}}, Path=BookDueRecurringCommand}"
-                                                CommandParameter="{Binding .}" />
-                                        <Button Text="{loc:Translate Btn_TerminUeberspringen}"
-                                                FontSize="12"
+                                                HeightRequest="44"
                                                 Command="{Binding Source={RelativeSource AncestorType={x:Type vm:DashboardViewModel}}, Path=SkipDueRecurringCommand}"
                                                 CommandParameter="{Binding .}" />
-                                        <Button Text="{loc:Translate Btn_TerminVerschieben}"
+                                        <Button Grid.Column="1"
+                                                Text="{loc:Translate Btn_TerminVerschieben}"
                                                 FontSize="12"
+                                                HeightRequest="44"
                                                 Command="{Binding Source={RelativeSource AncestorType={x:Type vm:DashboardViewModel}}, Path=ShiftDueRecurringCommand}"
                                                 CommandParameter="{Binding .}" />
-                                    </HorizontalStackLayout>
+                                    </Grid>
                                 </VerticalStackLayout>
                             </Border>
                         </DataTemplate>
                     </BindableLayout.ItemTemplate>
                 </VerticalStackLayout>
+
+                <Border StrokeShape="RoundRectangle 12"
+                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                        Padding="14"
+                        IsVisible="{Binding ShowDashboardSummary}">
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="16">
+                        <VerticalStackLayout Spacing="4">
+                            <Label Text="{Binding SummarySaldoLabel}"
+                                   FontSize="12"
+                                   TextColor="Gray" />
+                            <Label Text="{Binding SummarySaldo, Converter={StaticResource Currency}}"
+                                   FontSize="20"
+                                   FontAttributes="Bold"
+                                   TextColor="{Binding SummarySaldo, Converter={StaticResource BilanzColor}}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1" Spacing="4"
+                                             IsVisible="{Binding ShowSummaryBilanz}">
+                            <Label Text="{loc:Translate Lbl_Bilanz}"
+                                   FontSize="12"
+                                   TextColor="Gray" />
+                            <Label Text="{Binding Bilanz, Converter={StaticResource BilanzDisplay}}"
+                                   TextColor="{Binding Bilanz, Converter={StaticResource BilanzColor}}"
+                                   FontSize="20"
+                                   FontAttributes="Bold" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </Border>
 
                 <Border StrokeShape="RoundRectangle 12"
                         Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
@@ -165,13 +199,68 @@
                            VerticalTextAlignment="Center" />
                 </Grid>
 
-                <Button Text="{loc:Translate Nav_Cashflow}"
-                        Command="{Binding NavigateToCashflowCommand}"
-                        BackgroundColor="Transparent"
-                        TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                        FontSize="14"
-                        HorizontalOptions="Start"
-                        Padding="0" />
+                <Border StrokeShape="RoundRectangle 12"
+                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                        Padding="14"
+                        IsVisible="{Binding HasCashflowPreview}">
+                    <Border.GestureRecognizers>
+                        <TapGestureRecognizer Command="{Binding NavigateToCashflowCommand}" />
+                    </Border.GestureRecognizers>
+                    <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto, Auto" RowSpacing="6">
+                        <Label Grid.Row="0" Grid.Column="0"
+                               Text="{loc:Translate Lbl_Cashflow30Tage}"
+                               FontSize="16"
+                               FontAttributes="Bold"
+                               VerticalTextAlignment="Center" />
+                        <Label Grid.Row="0" Grid.Column="1"
+                               Text="›"
+                               FontSize="20"
+                               FontAttributes="Bold"
+                               VerticalTextAlignment="Center"
+                               AutomationProperties.IsInAccessibleTree="False" />
+                        <Label Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                               Text="{loc:Translate Lbl_CashflowNetto}"
+                               FontSize="12"
+                               TextColor="Gray" />
+                        <Label Grid.Row="2" Grid.Column="0"
+                               Text="{Binding CashflowNetAmount, Converter={StaticResource Currency}}"
+                               FontSize="18"
+                               FontAttributes="Bold"
+                               TextColor="{Binding CashflowNetAmount, Converter={StaticResource BilanzColor}}" />
+                        <Label Grid.Row="2" Grid.Column="1"
+                               Text="{Binding CashflowSummaryText}"
+                               FontSize="12"
+                               TextColor="Gray"
+                               HorizontalTextAlignment="End"
+                               VerticalTextAlignment="Center" />
+                    </Grid>
+                </Border>
+
+                <Border StrokeShape="RoundRectangle 12"
+                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                        Padding="14"
+                        IsVisible="{Binding HasCashflowPreview, Converter={StaticResource InvertBool}}">
+                    <VerticalStackLayout Spacing="6">
+                        <Label Text="{loc:Translate Lbl_Cashflow30Tage}"
+                               FontSize="16"
+                               FontAttributes="Bold" />
+                        <Label Text="{loc:Translate Empty_KeinCashflow}"
+                               FontSize="14"
+                               TextColor="Gray" />
+                        <Label Text="{loc:Translate Empty_HintCashflow}"
+                               FontSize="12"
+                               TextColor="Gray" />
+                        <Button Text="{loc:Translate Nav_Cashflow}"
+                                Command="{Binding NavigateToCashflowCommand}"
+                                BackgroundColor="Transparent"
+                                TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                FontSize="14"
+                                HorizontalOptions="Start"
+                                Padding="0" />
+                    </VerticalStackLayout>
+                </Border>
 
                 <!-- Global Empty State – keine Transaktionen vorhanden -->
                 <controls:EmptyStateView IconText="📊"
@@ -265,7 +354,9 @@
 
                     <!-- Bilanz -->
                     <Border Grid.Column="2" StrokeShape="RoundRectangle 12"
-                            Stroke="Transparent" BackgroundColor="#F2F2F7" Padding="12">
+                            Stroke="Transparent"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                            Padding="12">
                         <VerticalStackLayout Spacing="4">
                             <Label Text="{loc:Translate Lbl_Bilanz}" FontSize="11" TextColor="Gray" />
                             <Label Text="{Binding Bilanz, Converter={StaticResource BilanzDisplay}}"
@@ -276,18 +367,30 @@
                 </Grid>
 
                 <!-- Budget-Hinweise -->
+                <VerticalStackLayout IsVisible="{Binding HasBudgetHinweise}">
+                    <Grid ColumnDefinitions="*, Auto" Padding="0,0,0,4">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ToggleBudgetSectionCommand}" />
+                        </Grid.GestureRecognizers>
+                        <Label Grid.Column="0"
+                               Text="{loc:Translate Lbl_BudgetHinweise}"
+                               FontSize="18"
+                               FontAttributes="Bold"
+                               SemanticProperties.HeadingLevel="Level2"
+                               VerticalTextAlignment="Center" />
+                        <Label Grid.Column="1"
+                               Text="{Binding BudgetSectionChevron}"
+                               FontSize="14"
+                               TextColor="Gray"
+                               VerticalTextAlignment="Center" />
+                    </Grid>
                 <Border StrokeShape="RoundRectangle 12"
                         Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
                         BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
                         Padding="12"
-                        IsVisible="{Binding HasBudgetHinweise}">
+                        IsVisible="{Binding IsBudgetSectionExpanded}">
                     <VerticalStackLayout Spacing="10">
                         <Grid ColumnDefinitions="*, Auto">
-                            <Label Grid.Column="0"
-                                   Text="{loc:Translate Lbl_BudgetHinweise}"
-                                   FontSize="18"
-                                   FontAttributes="Bold"
-                                   SemanticProperties.HeadingLevel="Level2" />
                             <Label Grid.Column="1"
                                    Text="{Binding BudgetRest, Converter={StaticResource Currency}}"
                                    FontSize="15"
@@ -380,6 +483,7 @@
                         </VerticalStackLayout>
                     </VerticalStackLayout>
                 </Border>
+                </VerticalStackLayout>
 
                 <!-- Ausgaben nach Kategorie -->
                   <Label Text="{loc:Translate Lbl_AusgabenNachKategorie}" FontSize="18" FontAttributes="Bold"
@@ -538,14 +642,31 @@
                 </Border>
 
                 <!-- Balkendiagramm Monatsvergleich -->
+                <VerticalStackLayout IsVisible="{Binding HasYearData}">
+                    <Grid ColumnDefinitions="*, Auto" Padding="0,8,0,4">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ToggleYearDetailsCommand}" />
+                        </Grid.GestureRecognizers>
+                        <Label Grid.Column="0"
+                               Text="{loc:Translate Lbl_Jahresdetails}"
+                               FontSize="18"
+                               FontAttributes="Bold"
+                               SemanticProperties.HeadingLevel="Level2"
+                               VerticalTextAlignment="Center" />
+                        <Label Grid.Column="1"
+                               Text="{Binding YearDetailsChevron}"
+                               FontSize="14"
+                               TextColor="Gray"
+                               VerticalTextAlignment="Center" />
+                    </Grid>
+
+                <VerticalStackLayout IsVisible="{Binding IsYearDetailsExpanded}" Spacing="0">
                   <Label Text="{loc:Translate Lbl_AusgabenProMonat}" FontSize="18" FontAttributes="Bold"
-                      Margin="0,8,0,0"
-                      SemanticProperties.HeadingLevel="Level2"
-                      IsVisible="{Binding HasYearData}" />
+                      Margin="0,0,0,0"
+                      SemanticProperties.HeadingLevel="Level2" />
 
                 <GraphicsView x:Name="YearBarChart"
                               HeightRequest="150"
-                              IsVisible="{Binding HasYearData}"
                               Margin="0,4,0,8" />
 
                 <!-- Kategorien im Jahr -->
@@ -584,6 +705,8 @@
                             </VerticalStackLayout>
                         </DataTemplate>
                     </BindableLayout.ItemTemplate>
+                </VerticalStackLayout>
+                </VerticalStackLayout>
                 </VerticalStackLayout>
 
                 <!-- Empty State Jahresansicht -->

--- a/Finanzuebersicht/Views/DashboardPage.xaml.cs
+++ b/Finanzuebersicht/Views/DashboardPage.xaml.cs
@@ -63,12 +63,19 @@ public partial class DashboardPage : ContentPage
         });
 
         App.DataChanged += OnAppDataChanged;
+        App.LanguageChanged += OnLanguageChanged;
     }
 
     protected override void OnDisappearing()
     {
         base.OnDisappearing();
         App.DataChanged -= OnAppDataChanged;
+        App.LanguageChanged -= OnLanguageChanged;
+    }
+
+    private void OnLanguageChanged()
+    {
+        _vm.LoadDashboardCommand.Execute(null);
     }
 
     private void OnAppDataChanged()

--- a/Finanzuebersicht/Views/Popups/SelectionPopup.cs
+++ b/Finanzuebersicht/Views/Popups/SelectionPopup.cs
@@ -27,7 +27,7 @@ public class SelectionPopup : Popup<object>
             .Cast<object>()
             .Select(item => new SelectionRow(
                 item,
-                SelectionDisplayHelper.GetDisplayText(item, displayMemberPath),
+                LocalizedSelectionDisplay.GetDisplayText(item, displayMemberPath),
                 ReferenceEquals(item, selectedItem) || Equals(item, selectedItem)))
             .ToList();
 

--- a/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
@@ -67,8 +67,9 @@
             <!-- Startdatum -->
             <VerticalStackLayout Spacing="4">
                 <Label Text="{loc:Translate Lbl_Startdatum}" FontSize="13" TextColor="Gray" />
-                <DatePicker Date="{Binding Startdatum}" FontSize="16"
-                            Format="dd. MMMM yyyy" />
+                <DatePicker Date="{Binding Startdatum, Mode=TwoWay}" FontSize="16"
+                            Format="dd. MMMM yyyy"
+                            controls:DatePickerProperties.ImmediateUpdate="True" />
             </VerticalStackLayout>
 
             <!-- Enddatum (optional) -->
@@ -78,9 +79,10 @@
                 <Switch Grid.Column="1" IsToggled="{Binding HatEnddatum}" />
             </Grid>
 
-            <DatePicker Date="{Binding EnddatumWert}" FontSize="16"
+            <DatePicker Date="{Binding EnddatumWert, Mode=TwoWay}" FontSize="16"
                         Format="dd. MMMM yyyy"
-                        IsVisible="{Binding HatEnddatum}" />
+                        IsVisible="{Binding HatEnddatum}"
+                        controls:DatePickerProperties.ImmediateUpdate="True" />
 
             <!-- Aktiv -->
             <Grid ColumnDefinitions="*, Auto" Padding="0">

--- a/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
@@ -14,7 +14,7 @@
     <views:BaseContentPage.Resources>
         <conv:TransactionTypToColorConverter x:Key="TypToColor" />
         <conv:BoolToOpacityConverter x:Key="BoolToOpacity" />
-        <conv:VorzeichenConverter x:Key="VorzeichenConv" />
+        <conv:BetragDisplayConverter x:Key="BetragDisplay" />
         <conv:AktivTextConverter x:Key="AktivText" />
     </views:BaseContentPage.Resources>
 
@@ -84,16 +84,10 @@
                             </VerticalStackLayout>
 
                             <Label Grid.Column="2"
+                                   Text="{Binding ., Converter={StaticResource BetragDisplay}}"
                                    TextColor="{Binding Typ, Converter={StaticResource TypToColor}}"
                                    FontSize="16" FontAttributes="Bold"
-                                   VerticalTextAlignment="Center">
-                                <Label.Text>
-                                    <MultiBinding StringFormat="{}{0}{1:C}">
-                                        <Binding Path="Typ" Converter="{StaticResource VorzeichenConv}" />
-                                        <Binding Path="Betrag" />
-                                    </MultiBinding>
-                                </Label.Text>
-                            </Label>
+                                   VerticalTextAlignment="Center" />
                         </Grid>
                     </SwipeView>
                 </DataTemplate>

--- a/Finanzuebersicht/Views/SparZielDetailPage.xaml
+++ b/Finanzuebersicht/Views/SparZielDetailPage.xaml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
+             x:Class="Finanzuebersicht.Views.SparZielDetailPage"
+             x:DataType="vm:SparZielDetailViewModel"
+             Title="{Binding PageTitle}">
+
+    <ContentPage.Resources>
+        <conv:DecimalCurrencyConverter x:Key="Currency" />
+        <conv:ProzentToWidthConverter x:Key="ProzentToWidth" />
+    </ContentPage.Resources>
+
+    <ScrollView Padding="16">
+        <VerticalStackLayout Spacing="20">
+
+            <VerticalStackLayout Spacing="8">
+                <Label Text="{Binding FortschrittText}" FontSize="14" TextColor="Gray" />
+                <ProgressBar Progress="{Binding FortschrittProzent, Converter={StaticResource ProzentToWidth}}"
+                             ProgressColor="{AppThemeBinding Light={StaticResource Einnahme}, Dark={StaticResource EinnahmeDark}}"
+                             BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                             SemanticProperties.Description="{loc:Translate A11y_SparZielBalken}" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding Titel}" Placeholder="{loc:Translate Hint_ZielTitel}" FontSize="16" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_Icon}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding Icon}" FontSize="24" MaxLength="2" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_ZielBetrag}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding ZielBetragText}" Keyboard="Numeric" FontSize="16" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_AktuellerBetrag}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding AktuellerBetragText}" Keyboard="Numeric" FontSize="16" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Label Text="{loc:Translate Lbl_MonatlicheSparrate}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding MonatlicheSparrateText}" Keyboard="Numeric" FontSize="16" />
+            </VerticalStackLayout>
+
+            <VerticalStackLayout Spacing="4">
+                <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
+                    <Label Text="{loc:Translate Lbl_Faelligkeit}"
+                           FontSize="13"
+                           TextColor="Gray"
+                           VerticalTextAlignment="Center" />
+                    <Switch Grid.Column="1" IsToggled="{Binding UseFaelligkeit}" />
+                </Grid>
+                <DatePicker Date="{Binding Faelligkeitsdatum}"
+                            IsVisible="{Binding HasFaelligkeit}"
+                            FontSize="16" />
+            </VerticalStackLayout>
+
+            <Button Text="{loc:Translate Btn_BeitragBuchen}"
+                    Command="{Binding BookContributionCommand}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                    TextColor="White"
+                    CornerRadius="12"
+                    HeightRequest="44" />
+
+            <Button Text="{loc:Translate Btn_Speichern}"
+                    Command="{Binding SaveCommand}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                    TextColor="White"
+                    CornerRadius="12"
+                    HeightRequest="50"
+                    FontSize="16"
+                    FontAttributes="Bold"
+                    Margin="0,8,0,0" />
+
+            <Button Text="{loc:Translate Btn_Loeschen}"
+                    Command="{Binding DeleteCommand}"
+                    BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                    TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
+                    CornerRadius="12"
+                    HeightRequest="44" />
+
+        </VerticalStackLayout>
+    </ScrollView>
+</ContentPage>

--- a/Finanzuebersicht/Views/SparZielDetailPage.xaml
+++ b/Finanzuebersicht/Views/SparZielDetailPage.xaml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="utf-8" ?>
-<ContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+<views:BaseContentPage xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
              xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
+             xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.SparZielDetailPage"
              x:DataType="vm:SparZielDetailViewModel"
              Title="{Binding PageTitle}">
 
-    <ContentPage.Resources>
+    <views:BaseContentPage.Resources>
         <conv:DecimalCurrencyConverter x:Key="Currency" />
         <conv:ProzentToWidthConverter x:Key="ProzentToWidth" />
-    </ContentPage.Resources>
+    </views:BaseContentPage.Resources>
 
     <ScrollView Padding="16">
         <VerticalStackLayout Spacing="20">
@@ -59,6 +61,7 @@
                 </Grid>
                 <DatePicker Date="{Binding Faelligkeitsdatum}"
                             IsVisible="{Binding HasFaelligkeit}"
+                            controls:DatePickerProperties.ImmediateUpdate="True"
                             FontSize="16" />
             </VerticalStackLayout>
 
@@ -88,4 +91,4 @@
 
         </VerticalStackLayout>
     </ScrollView>
-</ContentPage>
+</views:BaseContentPage>

--- a/Finanzuebersicht/Views/SparZielDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/SparZielDetailPage.xaml.cs
@@ -3,7 +3,7 @@ using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
-public partial class SparZielDetailPage : ContentPage, IQueryAttributable
+public partial class SparZielDetailPage : BaseContentPage, IQueryAttributable
 {
     public SparZielDetailPage(SparZielDetailViewModel viewModel)
     {

--- a/Finanzuebersicht/Views/SparZielDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/SparZielDetailPage.xaml.cs
@@ -1,0 +1,19 @@
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Views;
+
+public partial class SparZielDetailPage : ContentPage, IQueryAttributable
+{
+    public SparZielDetailPage(SparZielDetailViewModel viewModel)
+    {
+        InitializeComponent();
+        BindingContext = viewModel;
+    }
+
+    public void ApplyQueryAttributes(IDictionary<string, object> query)
+    {
+        if (BindingContext is IApplyQueryAttributes vm)
+            vm.ApplyQueryAttributes(query);
+    }
+}

--- a/Finanzuebersicht/Views/SparZielePage.xaml
+++ b/Finanzuebersicht/Views/SparZielePage.xaml
@@ -32,10 +32,24 @@
                     <VerticalStackLayout BindableLayout.ItemsSource="{Binding SparZiele}" Spacing="12">
                         <BindableLayout.ItemTemplate>
                             <DataTemplate x:DataType="models:SparZielSummary">
-                                <Border StrokeShape="RoundRectangle 12"
-                                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
-                                        Padding="16">
+                                <SwipeView>
+                                    <SwipeView.RightItems>
+                                        <SwipeItems>
+                                            <SwipeItem Text="{loc:Translate Btn_Loeschen}"
+                                                       BackgroundColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
+                                                       Command="{Binding Source={RelativeSource AncestorType={x:Type vm:SparZieleViewModel}}, Path=DeleteSparZielCommand}"
+                                                       CommandParameter="{Binding SparZiel.Id}" />
+                                        </SwipeItems>
+                                    </SwipeView.RightItems>
+                                    <Border StrokeShape="RoundRectangle 12"
+                                            Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                                            Padding="16">
+                                        <Border.GestureRecognizers>
+                                            <TapGestureRecognizer
+                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:SparZieleViewModel}}, Path=OpenSparZielCommand}"
+                                                CommandParameter="{Binding .}" />
+                                        </Border.GestureRecognizers>
                                     <VerticalStackLayout Spacing="10">
 
                                         <!-- Header: Icon, Titel, Beträge -->
@@ -85,19 +99,9 @@
                                                    Text="{Binding PrognostiziertesDatum, StringFormat='{0:dd.MM.yyyy}'}" />
                                         </HorizontalStackLayout>
 
-                                        <!-- Löschen-Button -->
-                                        <Button Text="{loc:Translate Btn_Loeschen}"
-                                                FontSize="13"
-                                                BackgroundColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
-                                                TextColor="White"
-                                                CornerRadius="8"
-                                                HeightRequest="36"
-                                                HorizontalOptions="End"
-                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:SparZieleViewModel}}, Path=DeleteSparZielCommand}"
-                                                CommandParameter="{Binding SparZiel.Id}" />
-
                                     </VerticalStackLayout>
-                                </Border>
+                                    </Border>
+                                </SwipeView>
                             </DataTemplate>
                         </BindableLayout.ItemTemplate>
                     </VerticalStackLayout>


### PR DESCRIPTION
## Summary
- **#230** Sparziel-Detailseite: bearbeiten, Swipe-Löschen, Beitrag buchen (Einnahme mit Verknüpfung)
- **#231** Dashboard-Karte „Nächste 30 Tage“ für bessere Cashflow-Auffindbarkeit
- **#232** Kompaktere Dauerauftrag-Aktionen auf dem Dashboard (Buchen / Überspringen / Verschieben)
- **#233** Dashboard-Hierarchie: Summary-Karte oben, einklappbare Budget-/Jahresabschnitte (persistiert)
- Bugfixes: Dauerauftrag-Startdatum-Persistenz, Dropdown-Lesbarkeit (Light Mode), lokalisiertes „Alle Konten“, sofortige Sprach-/EUR-Aktualisierung beim Wechsel, Review-Follow-ups (Sparziel-DatePicker, Fortschritt nach Buchung, SelectionField-Leak, Summary-Sichtbarkeit)

## Test plan
- [ ] Sparziel antippen → Detail bearbeiten, speichern, löschen (Swipe)
- [ ] „Beitrag buchen“ → Transaktion anlegen → zurück: Fortschritt aktualisiert
- [ ] Sparziel-Fälligkeitsdatum ändern und speichern ohne DatePicker „Fertig“
- [ ] Dashboard: fällige Daueraufträge, Cashflow-Karte, Summary-Karte, Monat/Jahr-Umschaltung
- [ ] Sprache DE ↔ EN: Dauerauftrag-Hinweise und Kontofilter sofort korrekt; € überall sichtbar
- [ ] Kontoauswahl-Dropdown in Light/Dark Mode lesbar
- [ ] `dotnet test` — 289 Tests grün


Made with [Cursor](https://cursor.com)