### PR TITLE
🚀 release: v1.16 — UI-Konsistenz & Lokalisierung

### DIFF
--- a/.cursor/rules/app-domain.mdc
+++ b/.cursor/rules/app-domain.mdc
@@ -13,7 +13,7 @@ alwaysApply: true
 - **Tabs:** Dashboard · Transaktionen · Daueraufträge · Verwaltung (Kategorien/Konten) · Sparziele · Einstellungen (Toolbar)
 - **Neuer Code:** ViewModel → Use Case → `I*Repository` (nicht `IDataService`)
 - **ViewModels:** `Finanzuebersicht.Presentation/ViewModels/` — in `PresentationServiceCollectionExtensions` registrieren
-- **Build macOS:** `dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst` → `maccatalyst-arm64/Finanzübersicht.app`
+- **Build macOS:** `dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst` → kopiert nach `~/Applications/Finanzübersicht.app`
 
 ## Mac Catalyst UI
 

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Personal finance app built with **.NET 10** and **.NET MAUI**, targeting **macOS
 Data is persisted locally as JSON. Architecture: **Clean Architecture + MVVM**.
 Languages: **German and English** (`AppResources.resx` / `AppResources.de.resx`).
 
-Current version baseline: `version.json` → `1.15` (patch = git height via Nerdbank.GitVersioning).
+Current version baseline: `version.json` → `1.16` (patch = git height via Nerdbank.GitVersioning).
 
 ## Build & Run
 
@@ -150,7 +150,7 @@ Native `Picker` controls freeze on **macOS 27 Beta** when scrolling inside picke
 
 Automatic **SemVer** via **Nerdbank.GitVersioning** (`version.json`):
 
-- Version = `<major>.<minor>.<git-height>` (e.g. `1.15.5`)
+- Version = `<major>.<minor>.<git-height>` (e.g. `1.16.5`)
 - Bump: edit `version.json` or `nbgv set-version <version>`
 - Current: `nbgv get-version`
 - Stable releases: `main` and `release/v*` branches

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -32,23 +32,27 @@ dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-ios
 
 ### Running on macOS (Mac Catalyst)
 
-`dotnet run` and `-t:Run` fail due to macOS sandboxing. Copy the `.app` to `/Applications` first:
+`dotnet run` and `-t:Run` fail due to macOS sandboxing. Debug builds copy the `.app` to `~/Applications` automatically; start it with:
 
 ```bash
-# Apple Silicon (arm64) — typical on modern Macs
-cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/
-open /Applications/Finanzübersicht.app
+dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst -c Debug
+open ~/Applications/Finanzübersicht.app
+```
 
-# Intel (x64)
-cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-x64/Finanzübersicht.app /Applications/
+> Dev-signed builds may fail to launch from system `/Applications` on macOS 26+ (Launch Constraint). Use `~/Applications` or open directly from the build output (`maccatalyst-arm64/Finanzübersicht.app`).
+
+Manual copy (if needed — Apple Silicon `arm64`, Intel `x64`):
+
+```bash
+cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app ~/Applications/
+open ~/Applications/Finanzübersicht.app
 ```
 
 One-liner after build (adjust `arm64` / `x64` as needed):
 
 ```bash
 dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst -c Debug \
-  && cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/ \
-  && open /Applications/Finanzübersicht.app
+  && open ~/Applications/Finanzübersicht.app
 ```
 
 ## Architecture

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,27 @@
 # Änderungsverlauf
 
+## [1.16] - 2026-06-20
+
+### Hinzugefügt
+
+- Anzeige-Währung (EUR/USD/GBP/CHF) in Einstellungen und Onboarding, getrennt von UI-Sprache (#253)
+- `IDisplayCurrencyService` und `App.CurrencyChanged` für sofortige Betrags-Aktualisierung
+- Lokalisierung von Seitentiteln und Enum-Labels (Kontotyp, Transaktionstyp) (#234)
+- Verwaltung: Dashboard-Segment Kategorien/Konten mit klarerem Tab-Titel (#236)
+- Dashboard Runde 2: Summary oben, einklappbare Sekundärbereiche (#252)
+- Einheitliche Tab-Icons in Empty States statt Emoji (#240)
+
+### Geändert
+
+- Hardcoded XAML-Farben durch zentrale `Colors.xaml`-Tokens ersetzt (#254)
+- Transaktionen: beschriftete Buttons „Filter“ / „Umbuchen“ statt Emoji (#238)
+- Debug-Build installiert nach `~/Applications` (macOS 26+ Dev-Signatur)
+
+### Behoben
+
+- Fällige Daueraufträge im Dashboard standardmäßig aufgeklappt
+- Währungswechsel aktualisiert Salden (Konto-Detail) und Import-Beträge ohne Seitenwechsel
+
 ## [1.15] - 2026-06-20
 
 ### Hinzugefügt

--- a/Finanzuebersicht.Core/Services/CurrencyCulture.cs
+++ b/Finanzuebersicht.Core/Services/CurrencyCulture.cs
@@ -3,9 +3,14 @@ using System.Globalization;
 namespace Finanzuebersicht.Core.Services;
 
 /// <summary>
-/// Fixed EUR formatting for monetary amounts regardless of UI language.
+/// Monetary formatting culture derived from the configured display currency.
 /// </summary>
 public static class CurrencyCulture
 {
-    public static CultureInfo Instance { get; } = CultureInfo.GetCultureInfo("de-DE");
+    private static IDisplayCurrencyService? _service;
+
+    public static CultureInfo Instance =>
+        _service?.FormatCulture ?? CultureInfo.GetCultureInfo("de-DE");
+
+    public static void Initialize(IDisplayCurrencyService service) => _service = service;
 }

--- a/Finanzuebersicht.Core/Services/IDisplayCurrencyService.cs
+++ b/Finanzuebersicht.Core/Services/IDisplayCurrencyService.cs
@@ -1,0 +1,19 @@
+using System.Globalization;
+
+namespace Finanzuebersicht.Core.Services;
+
+/// <summary>
+/// Display currency for monetary formatting (single currency app-wide, independent of UI language).
+/// </summary>
+public interface IDisplayCurrencyService
+{
+    IReadOnlyList<string> SupportedCodes { get; }
+
+    string CurrencyCode { get; }
+
+    CultureInfo FormatCulture { get; }
+
+    int SelectedIndex { get; set; }
+
+    event Action? Changed;
+}

--- a/Finanzuebersicht.Core/Services/SettingsKeys.cs
+++ b/Finanzuebersicht.Core/Services/SettingsKeys.cs
@@ -51,5 +51,30 @@ namespace Finanzuebersicht.Core.Services
         /// Whether the dashboard year details section is expanded (true/false).
         /// </summary>
         public const string DashboardYearDetailsExpanded = "DashboardYearDetailsExpanded";
+
+        /// <summary>
+        /// Whether due recurring action cards are expanded on the dashboard (true/false).
+        /// </summary>
+        public const string DashboardDueDetailsExpanded = "DashboardDueDetailsExpanded";
+
+        /// <summary>
+        /// Whether the accounts overview section is expanded on the dashboard (true/false).
+        /// </summary>
+        public const string DashboardAccountsExpanded = "DashboardAccountsExpanded";
+
+        /// <summary>
+        /// Whether the cashflow preview section is expanded on the dashboard (true/false).
+        /// </summary>
+        public const string DashboardCashflowExpanded = "DashboardCashflowExpanded";
+
+        /// <summary>
+        /// Whether the account filter section is expanded on the dashboard (true/false).
+        /// </summary>
+        public const string DashboardFilterExpanded = "DashboardFilterExpanded";
+
+        /// <summary>
+        /// ISO currency code for amount display formatting (EUR, CHF, USD, GBP).
+        /// </summary>
+        public const string DisplayCurrency = "DisplayCurrency";
     }
 }

--- a/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -9,6 +9,7 @@ public static class InfrastructureServiceCollectionExtensions
     {
         // Settings (file-based JSON persistence)
         services.AddSingleton<ISettingsService, SettingsService>();
+        services.AddSingleton<IDisplayCurrencyService, DisplayCurrencyService>();
 
         // Backup
         services.AddSingleton<IDataMigrator, Finanzuebersicht.Core.Services.Migrations.V1ToV2Migrator>();

--- a/Finanzuebersicht.Infrastructure/Services/DisplayCurrencyService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/DisplayCurrencyService.cs
@@ -67,6 +67,7 @@ public sealed class DisplayCurrencyService : IDisplayCurrencyService
         if (string.IsNullOrEmpty(code))
             code = _settings.Get("Currency", "EUR");
 
+        code = code.Trim().ToUpperInvariant();
         return CultureByCode.ContainsKey(code) ? code : "EUR";
     }
 

--- a/Finanzuebersicht.Infrastructure/Services/DisplayCurrencyService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/DisplayCurrencyService.cs
@@ -1,0 +1,80 @@
+using System.Globalization;
+
+namespace Finanzuebersicht.Infrastructure.Services;
+
+public sealed class DisplayCurrencyService : IDisplayCurrencyService
+{
+    private static readonly string[] Codes = ["EUR", "CHF", "USD", "GBP"];
+
+    private static readonly Dictionary<string, string> CultureByCode = new(StringComparer.Ordinal)
+    {
+        ["EUR"] = "de-DE",
+        ["CHF"] = "de-CH",
+        ["USD"] = "en-US",
+        ["GBP"] = "en-GB",
+    };
+
+    private readonly ISettingsService _settings;
+    private string _currencyCode;
+
+    public DisplayCurrencyService(ISettingsService settings)
+    {
+        _settings = settings;
+        _currencyCode = LoadCurrencyCode();
+        CurrencyCulture.Initialize(this);
+    }
+
+    public IReadOnlyList<string> SupportedCodes => Codes;
+
+    public string CurrencyCode => _currencyCode;
+
+    public CultureInfo FormatCulture => ResolveCulture(_currencyCode);
+
+    public event Action? Changed;
+
+    public int SelectedIndex
+    {
+        get
+        {
+            var index = Array.IndexOf(Codes, _currencyCode);
+            return index >= 0 ? index : 0;
+        }
+        set
+        {
+            if (value < 0 || value >= Codes.Length)
+                return;
+
+            SetCurrencyCode(Codes[value]);
+        }
+    }
+
+    private void SetCurrencyCode(string code)
+    {
+        if (!CultureByCode.ContainsKey(code))
+            code = "EUR";
+
+        if (string.Equals(_currencyCode, code, StringComparison.Ordinal))
+            return;
+
+        _currencyCode = code;
+        _settings.Set(SettingsKeys.DisplayCurrency, code);
+        Changed?.Invoke();
+    }
+
+    private string LoadCurrencyCode()
+    {
+        var code = _settings.Get(SettingsKeys.DisplayCurrency, "");
+        if (string.IsNullOrEmpty(code))
+            code = _settings.Get("Currency", "EUR");
+
+        return CultureByCode.ContainsKey(code) ? code : "EUR";
+    }
+
+    private static CultureInfo ResolveCulture(string code)
+    {
+        if (!CultureByCode.TryGetValue(code, out var cultureName))
+            cultureName = "de-DE";
+
+        return CultureInfo.GetCultureInfo(cultureName);
+    }
+}

--- a/Finanzuebersicht.Presentation/Resources/Strings/EnumResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/EnumResourceKeys.cs
@@ -1,0 +1,37 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Resources.Strings;
+
+/// <summary>
+/// Resource key names for enum display labels.
+/// </summary>
+public static class EnumResourceKeys
+{
+    public static string GetAccountType(AccountType type) => type switch
+    {
+        AccountType.Girokonto => ResourceKeys.AccountType_Girokonto,
+        AccountType.Tagesgeld => ResourceKeys.AccountType_Tagesgeld,
+        AccountType.Kreditkarte => ResourceKeys.AccountType_Kreditkarte,
+        AccountType.Bargeld => ResourceKeys.AccountType_Bargeld,
+        AccountType.Depot => ResourceKeys.AccountType_Depot,
+        AccountType.Sonstiges => ResourceKeys.AccountType_Sonstiges,
+        _ => ResourceKeys.AccountType_Sonstiges
+    };
+
+    public static string GetTransactionType(TransactionType type) => type switch
+    {
+        TransactionType.Einnahme => ResourceKeys.Lbl_Einnahme,
+        TransactionType.Ausgabe => ResourceKeys.Lbl_Ausgabe,
+        _ => ResourceKeys.Lbl_Ausgabe
+    };
+
+    public static string GetRecurrenceInterval(RecurrenceInterval interval) => interval switch
+    {
+        RecurrenceInterval.Daily => ResourceKeys.RecurrenceInterval_Daily,
+        RecurrenceInterval.Weekly => ResourceKeys.RecurrenceInterval_Weekly,
+        RecurrenceInterval.Monthly => ResourceKeys.RecurrenceInterval_Monthly,
+        RecurrenceInterval.Quarterly => ResourceKeys.RecurrenceInterval_Quarterly,
+        RecurrenceInterval.Yearly => ResourceKeys.RecurrenceInterval_Yearly,
+        _ => ResourceKeys.RecurrenceInterval_Monthly
+    };
+}

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -57,6 +57,7 @@ public static class ResourceKeys
     public const string Lbl_Verwendungszweck = nameof(Lbl_Verwendungszweck);
     public const string Lbl_DatenWerdenGespeichert = nameof(Lbl_DatenWerdenGespeichert);
     public const string Lbl_Sprache = nameof(Lbl_Sprache);
+    public const string Lbl_Anzeigewaehrung = nameof(Lbl_Anzeigewaehrung);
     public const string Lbl_KategorienColon = nameof(Lbl_KategorienColon);
 
     // Buttons
@@ -120,6 +121,12 @@ public static class ResourceKeys
     // Confirmation Dialogs
     public const string Dlg_KategorieLoeschen = nameof(Dlg_KategorieLoeschen);
     public const string Dlg_KategorieLoeschenFrage = nameof(Dlg_KategorieLoeschenFrage);
+    public const string Dlg_KontoLoeschen = nameof(Dlg_KontoLoeschen);
+    public const string Dlg_KontoLoeschenFrage = nameof(Dlg_KontoLoeschenFrage);
+    public const string Dlg_KontoArchivieren = nameof(Dlg_KontoArchivieren);
+    public const string Dlg_KontoArchivierenFrage = nameof(Dlg_KontoArchivierenFrage);
+    public const string Dlg_KontoReaktivieren = nameof(Dlg_KontoReaktivieren);
+    public const string Dlg_KontoReaktivierenFrage = nameof(Dlg_KontoReaktivierenFrage);
     public const string Dlg_DauerauftragLoeschen = nameof(Dlg_DauerauftragLoeschen);
     public const string Dlg_DauerauftragLoeschenFrage = nameof(Dlg_DauerauftragLoeschenFrage);
     public const string Dlg_DauerauftragBuchen = nameof(Dlg_DauerauftragBuchen);
@@ -148,6 +155,10 @@ public static class ResourceKeys
     public const string Stn_SpracheDeutsch = nameof(Stn_SpracheDeutsch);
     public const string Stn_SpracheEnglisch = nameof(Stn_SpracheEnglisch);
     public const string Stn_SpracheSystem = nameof(Stn_SpracheSystem);
+    public const string Stn_CurrencyEur = nameof(Stn_CurrencyEur);
+    public const string Stn_CurrencyChf = nameof(Stn_CurrencyChf);
+    public const string Stn_CurrencyUsd = nameof(Stn_CurrencyUsd);
+    public const string Stn_CurrencyGbp = nameof(Stn_CurrencyGbp);
 
     // Status
     public const string Status_Aktiv = nameof(Status_Aktiv);
@@ -219,6 +230,8 @@ public static class ResourceKeys
     public const string Msg_BackupRestoreTitle = nameof(Msg_BackupRestoreTitle);
     public const string Msg_BackupRestoreDesc = nameof(Msg_BackupRestoreDesc);
     public const string Btn_Import = nameof(Btn_Import);
+    public const string Btn_Filter = nameof(Btn_Filter);
+    public const string Btn_Umbuchen = nameof(Btn_Umbuchen);
     public const string Btn_FilterZuruecksetzen = nameof(Btn_FilterZuruecksetzen);
     public const string Title_ShiftInstance = nameof(Title_ShiftInstance);
 
@@ -261,6 +274,7 @@ public static class ResourceKeys
     public const string Lbl_AnfangssaldoStichtag = nameof(Lbl_AnfangssaldoStichtag);
     public const string Hint_Anfangssaldo = nameof(Hint_Anfangssaldo);
     public const string Fmt_KontoSaldoAufschluesselung = nameof(Fmt_KontoSaldoAufschluesselung);
+    public const string Lbl_Konten = nameof(Lbl_Konten);
     public const string Lbl_KontenUebersicht = nameof(Lbl_KontenUebersicht);
     public const string Lbl_Gesamtsaldo = nameof(Lbl_Gesamtsaldo);
     public const string Lbl_GesamtsaldoAktiv = nameof(Lbl_GesamtsaldoAktiv);
@@ -278,6 +292,13 @@ public static class ResourceKeys
     public const string RecurrenceInterval_Monthly = nameof(RecurrenceInterval_Monthly);
     public const string RecurrenceInterval_Quarterly = nameof(RecurrenceInterval_Quarterly);
     public const string RecurrenceInterval_Yearly = nameof(RecurrenceInterval_Yearly);
+
+    public const string AccountType_Girokonto = nameof(AccountType_Girokonto);
+    public const string AccountType_Tagesgeld = nameof(AccountType_Tagesgeld);
+    public const string AccountType_Kreditkarte = nameof(AccountType_Kreditkarte);
+    public const string AccountType_Bargeld = nameof(AccountType_Bargeld);
+    public const string AccountType_Depot = nameof(AccountType_Depot);
+    public const string AccountType_Sonstiges = nameof(AccountType_Sonstiges);
     public const string Lbl_AlleTypen = nameof(Lbl_AlleTypen);
     public const string Lbl_VonDatum = nameof(Lbl_VonDatum);
     public const string Lbl_BisDatum = nameof(Lbl_BisDatum);
@@ -309,6 +330,7 @@ public static class ResourceKeys
     public const string Lbl_ImportStatusUngueltig = nameof(Lbl_ImportStatusUngueltig);
     public const string Lbl_ImportStatusUnkategorisiert = nameof(Lbl_ImportStatusUnkategorisiert);
     public const string Lbl_ImportStatusSpeicherfehler = nameof(Lbl_ImportStatusSpeicherfehler);
+    public const string Lbl_ImportStatusUnbekannt = nameof(Lbl_ImportStatusUnbekannt);
     public const string Lbl_ImportBereitCount = nameof(Lbl_ImportBereitCount);
     public const string Lbl_ImportDuplikateCount = nameof(Lbl_ImportDuplikateCount);
     public const string Lbl_ImportProblemeCount = nameof(Lbl_ImportProblemeCount);
@@ -376,6 +398,7 @@ public static class ResourceKeys
     public const string A11y_TransaktionHinzufuegen = nameof(A11y_TransaktionHinzufuegen);
     public const string A11y_UmbuchungHinzufuegen = nameof(A11y_UmbuchungHinzufuegen);
     public const string A11y_KategorieHinzufuegen = nameof(A11y_KategorieHinzufuegen);
+    public const string A11y_KontoHinzufuegen = nameof(A11y_KontoHinzufuegen);
     public const string A11y_SparZielHinzufuegen = nameof(A11y_SparZielHinzufuegen);
     public const string A11y_DauerauftragHinzufuegen = nameof(A11y_DauerauftragHinzufuegen);
     public const string A11y_BudgetBalken = nameof(A11y_BudgetBalken);

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -96,6 +96,8 @@ public partial class AccountDetailViewModel(
         OnPropertyChanged(nameof(ArchiveStatusText));
         OnPropertyChanged(nameof(SystemAccountHint));
         SelectedTypeOption = VerfuegbareTypen.FirstOrDefault(t => t.Value == Type);
+        if (_existingAccount != null)
+            _ = LoadCalculatedBalanceAsync();
     }
 
     public Account? Account

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -20,7 +20,7 @@ public partial class AccountDetailViewModel(
     IDialogService dialogService,
     IFeedbackService feedbackService,
     IAppEvents appEvents,
-    ILogger<AccountDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
+    ILogger<AccountDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes, ILocalizableViewModel
 {
     private readonly SaveAccountDetailUseCase _saveAccountDetailUseCase = saveAccountDetailUseCase;
     private readonly GetAccountBalancesUseCase _getAccountBalancesUseCase = getAccountBalancesUseCase;
@@ -81,13 +81,22 @@ public partial class AccountDetailViewModel(
 
     public List<AccountTypeOption> VerfuegbareTypen =>
     [
-        new(AccountType.Girokonto, _loc.GetString("AccountType_Girokonto")),
-        new(AccountType.Tagesgeld, _loc.GetString("AccountType_Tagesgeld")),
-        new(AccountType.Kreditkarte, _loc.GetString("AccountType_Kreditkarte")),
-        new(AccountType.Bargeld, _loc.GetString("AccountType_Bargeld")),
-        new(AccountType.Depot, _loc.GetString("AccountType_Depot")),
-        new(AccountType.Sonstiges, _loc.GetString("AccountType_Sonstiges"))
+        new(AccountType.Girokonto, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Girokonto))),
+        new(AccountType.Tagesgeld, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Tagesgeld))),
+        new(AccountType.Kreditkarte, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Kreditkarte))),
+        new(AccountType.Bargeld, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Bargeld))),
+        new(AccountType.Depot, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Depot))),
+        new(AccountType.Sonstiges, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Sonstiges)))
     ];
+
+    public void RefreshLocalizedStrings()
+    {
+        OnPropertyChanged(nameof(VerfuegbareTypen));
+        OnPropertyChanged(nameof(PageTitle));
+        OnPropertyChanged(nameof(ArchiveStatusText));
+        OnPropertyChanged(nameof(SystemAccountHint));
+        SelectedTypeOption = VerfuegbareTypen.FirstOrDefault(t => t.Value == Type);
+    }
 
     public Account? Account
     {

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -25,7 +25,7 @@ public partial class CategoriesViewModel(
     IDialogService dialogService,
     IFeedbackService feedbackService,
     IAppEvents appEvents,
-    ILogger<CategoriesViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel
+    ILogger<CategoriesViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel, ILocalizableViewModel
 {
     private readonly DeleteCategoryUseCase _deleteCategoryUseCase = deleteCategoryUseCase;
     private readonly LoadCategoriesUseCase _loadCategoriesUseCase = loadCategoriesUseCase;
@@ -62,6 +62,21 @@ public partial class CategoriesViewModel(
 
     public bool IsKategorienVisible => SelectedSectionIndex == 0;
     public bool IsKontenVisible => SelectedSectionIndex == 1;
+
+    public string FabAccessibilityDescription => IsKontenVisible
+        ? _loc.GetString(ResourceKeys.A11y_KontoHinzufuegen)
+        : _loc.GetString(ResourceKeys.A11y_KategorieHinzufuegen);
+
+    partial void OnSelectedSectionIndexChanged(int value)
+    {
+        OnPropertyChanged(nameof(FabAccessibilityDescription));
+    }
+
+    public void RefreshLocalizedStrings()
+    {
+        OnPropertyChanged(nameof(FabAccessibilityDescription));
+        _ = LoadKategorien();
+    }
 
     [ObservableProperty]
     private bool isLoading;
@@ -150,8 +165,8 @@ public partial class CategoriesViewModel(
         if (!konto.CanDelete) return;
 
         var confirm = await _dialogService.ShowConfirmationAsync(
-            "Konto löschen",
-            $"\"{konto.Name}\" wirklich löschen?",
+            _loc.GetString(ResourceKeys.Dlg_KontoLoeschen),
+            _loc.GetString(ResourceKeys.Dlg_KontoLoeschenFrage, konto.Name),
             _loc.GetString(ResourceKeys.Btn_Ja), _loc.GetString(ResourceKeys.Btn_Nein));
         if (!confirm) return;
 
@@ -178,10 +193,12 @@ public partial class CategoriesViewModel(
         if (!konto.CanArchive) return;
 
         var setArchived = !konto.IsArchived;
-        var confirmTitle = setArchived ? "Konto archivieren" : "Konto reaktivieren";
+        var confirmTitle = setArchived
+            ? _loc.GetString(ResourceKeys.Dlg_KontoArchivieren)
+            : _loc.GetString(ResourceKeys.Dlg_KontoReaktivieren);
         var confirmBody = setArchived
-            ? $"\"{konto.Name}\" archivieren? Konto steht dann nicht mehr für neue Buchungen zur Auswahl."
-            : $"\"{konto.Name}\" wieder aktivieren?";
+            ? _loc.GetString(ResourceKeys.Dlg_KontoArchivierenFrage, konto.Name)
+            : _loc.GetString(ResourceKeys.Dlg_KontoReaktivierenFrage, konto.Name);
         var confirm = await _dialogService.ShowConfirmationAsync(
             confirmTitle,
             confirmBody,

--- a/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
@@ -18,7 +18,7 @@ public partial class CategoryDetailViewModel(
     IAppEvents appEvents,
     SaveCategoryBudgetUseCase? saveCategoryBudgetUseCase = null,
     IBudgetRepository? budgetRepository = null,
-    ILogger<CategoryDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes
+    ILogger<CategoryDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes, ILocalizableViewModel
 {
     private readonly SaveCategoryDetailUseCase _saveCategoryDetailUseCase = saveCategoryDetailUseCase;
     private readonly INavigationService _navigationService = navigationService;
@@ -48,11 +48,21 @@ public partial class CategoryDetailViewModel(
     private List<TransactionTypeOption>? _verfuegbareTypen;
 
     public IReadOnlyList<TransactionTypeOption> VerfuegbareTypen =>
-        _verfuegbareTypen ??=
-        [
-            new(TransactionType.Einnahme, _loc.GetString(ResourceKeys.Lbl_Einnahme)),
-            new(TransactionType.Ausgabe, _loc.GetString(ResourceKeys.Lbl_Ausgabe))
-        ];
+        _verfuegbareTypen ??= BuildTypeOptions();
+
+    private List<TransactionTypeOption> BuildTypeOptions() =>
+    [
+        new(TransactionType.Einnahme, _loc.GetString(EnumResourceKeys.GetTransactionType(TransactionType.Einnahme))),
+        new(TransactionType.Ausgabe, _loc.GetString(EnumResourceKeys.GetTransactionType(TransactionType.Ausgabe)))
+    ];
+
+    public void RefreshLocalizedStrings()
+    {
+        _verfuegbareTypen = null;
+        OnPropertyChanged(nameof(VerfuegbareTypen));
+        OnPropertyChanged(nameof(PageTitle));
+        SelectedTypeOption = VerfuegbareTypen.FirstOrDefault(option => option.Value == Typ);
+    }
 
     partial void OnTypChanged(TransactionType value)
     {

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -354,7 +354,9 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     private static bool ReadExpandedSetting(ISettingsService settingsService, string key, bool defaultExpanded = false)
     {
         var defaultValue = defaultExpanded.ToString().ToLowerInvariant();
-        return bool.TryParse(settingsService.Get(key, defaultValue), out var expanded) && expanded;
+        return bool.TryParse(settingsService.Get(key, defaultValue), out var expanded)
+            ? expanded
+            : defaultExpanded;
     }
 
     protected override async Task OnMonthChangedAsync() => await LoadDashboard();

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -202,11 +202,33 @@ public partial class DashboardViewModel : MonthNavigationViewModel
 
     public bool HasCashflowPreview => CashflowProjectedIncome > 0 || CashflowProjectedExpenses > 0 || CashflowNotableDays > 0;
 
-    [ObservableProperty]
-    private bool isBudgetSectionExpanded = true;
+    public bool ShowCashflowCompact => HasCashflowPreview && !IsCashflowSectionExpanded;
+
+    public bool ShowCashflowExpanded => IsCashflowSectionExpanded && HasCashflowPreview;
+
+    public bool ShowCashflowEmptyLink => IsCashflowSectionExpanded && !HasCashflowPreview;
+
+    public bool ShowSecondarySections => HasAnyDataLoaded || HasKontenUebersicht;
+
+    public bool ShowDueDetailsList => HasDueItems && IsDueDetailsExpanded;
 
     [ObservableProperty]
-    private bool isYearDetailsExpanded = true;
+    private bool isBudgetSectionExpanded;
+
+    [ObservableProperty]
+    private bool isYearDetailsExpanded;
+
+    [ObservableProperty]
+    private bool isDueDetailsExpanded;
+
+    [ObservableProperty]
+    private bool isAccountsSectionExpanded;
+
+    [ObservableProperty]
+    private bool isCashflowSectionExpanded;
+
+    [ObservableProperty]
+    private bool isFilterSectionExpanded;
 
     public bool ShowDashboardSummary => HasKontenUebersicht || HasSelectedAccountSaldo || (IsMonthView && HasMonthData);
 
@@ -219,8 +241,11 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     public bool ShowSummaryBilanz => IsMonthView && HasMonthData;
 
     public string BudgetSectionChevron => IsBudgetSectionExpanded ? "▼" : "▶";
-
     public string YearDetailsChevron => IsYearDetailsExpanded ? "▼" : "▶";
+    public string DueDetailsChevron => IsDueDetailsExpanded ? "▼" : "▶";
+    public string AccountsSectionChevron => IsAccountsSectionExpanded ? "▼" : "▶";
+    public string CashflowSectionChevron => IsCashflowSectionExpanded ? "▼" : "▶";
+    public string FilterSectionChevron => IsFilterSectionExpanded ? "▼" : "▶";
 
     public string DueRecurringText => DueRecurringCount == 1
         ? _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig_Singular, DueRecurringCount)
@@ -246,6 +271,24 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     partial void OnIsBudgetSectionExpandedChanged(bool value) => OnPropertyChanged(nameof(BudgetSectionChevron));
 
     partial void OnIsYearDetailsExpandedChanged(bool value) => OnPropertyChanged(nameof(YearDetailsChevron));
+
+    partial void OnIsDueDetailsExpandedChanged(bool value)
+    {
+        OnPropertyChanged(nameof(DueDetailsChevron));
+        OnPropertyChanged(nameof(ShowDueDetailsList));
+    }
+
+    partial void OnIsAccountsSectionExpandedChanged(bool value) => OnPropertyChanged(nameof(AccountsSectionChevron));
+
+    partial void OnIsCashflowSectionExpandedChanged(bool value)
+    {
+        OnPropertyChanged(nameof(CashflowSectionChevron));
+        OnPropertyChanged(nameof(ShowCashflowCompact));
+        OnPropertyChanged(nameof(ShowCashflowExpanded));
+        OnPropertyChanged(nameof(ShowCashflowEmptyLink));
+    }
+
+    partial void OnIsFilterSectionExpandedChanged(bool value) => OnPropertyChanged(nameof(FilterSectionChevron));
 
     partial void OnGesamtSaldoChanged(decimal value)
     {
@@ -299,16 +342,17 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _getAccountBalancesUseCase = getAccountBalancesUseCase;
         _settingsService = settingsService;
         _logger = logger;
-        IsBudgetSectionExpanded =
-            bool.TryParse(settingsService.Get(SettingsKeys.DashboardBudgetExpanded, "true"), out var budgetExpanded)
-                ? budgetExpanded
-                : true;
-        IsYearDetailsExpanded =
-            bool.TryParse(settingsService.Get(SettingsKeys.DashboardYearDetailsExpanded, "true"), out var yearExpanded)
-                ? yearExpanded
-                : true;
+        IsBudgetSectionExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardBudgetExpanded);
+        IsYearDetailsExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardYearDetailsExpanded);
+        IsDueDetailsExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardDueDetailsExpanded);
+        IsAccountsSectionExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardAccountsExpanded);
+        IsCashflowSectionExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardCashflowExpanded);
+        IsFilterSectionExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardFilterExpanded);
         UpdateJahrAnzeige();
     }
+
+    private static bool ReadExpandedSetting(ISettingsService settingsService, string key) =>
+        bool.TryParse(settingsService.Get(key, "false"), out var expanded) && expanded;
 
     protected override async Task OnMonthChangedAsync() => await LoadDashboard();
 
@@ -334,6 +378,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
             await LadeFaelligeDauerauftraegeAsync();
             await LoadCashflowPreviewAsync();
             HasAnyDataLoaded = HasMonthData || HasYearData;
+            OnPropertyChanged(nameof(ShowSecondarySections));
         }
         finally
         {
@@ -585,6 +630,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel
             CashflowNotableDays = 0;
             CashflowSummaryText = string.Empty;
         }
+
+        OnPropertyChanged(nameof(ShowCashflowCompact));
+        OnPropertyChanged(nameof(ShowCashflowExpanded));
+        OnPropertyChanged(nameof(ShowCashflowEmptyLink));
     }
 
     [RelayCommand]
@@ -599,6 +648,34 @@ public partial class DashboardViewModel : MonthNavigationViewModel
     {
         IsYearDetailsExpanded = !IsYearDetailsExpanded;
         _settingsService.Set(SettingsKeys.DashboardYearDetailsExpanded, IsYearDetailsExpanded.ToString().ToLowerInvariant());
+    }
+
+    [RelayCommand]
+    private void ToggleDueDetails()
+    {
+        IsDueDetailsExpanded = !IsDueDetailsExpanded;
+        _settingsService.Set(SettingsKeys.DashboardDueDetailsExpanded, IsDueDetailsExpanded.ToString().ToLowerInvariant());
+    }
+
+    [RelayCommand]
+    private void ToggleAccountsSection()
+    {
+        IsAccountsSectionExpanded = !IsAccountsSectionExpanded;
+        _settingsService.Set(SettingsKeys.DashboardAccountsExpanded, IsAccountsSectionExpanded.ToString().ToLowerInvariant());
+    }
+
+    [RelayCommand]
+    private void ToggleCashflowSection()
+    {
+        IsCashflowSectionExpanded = !IsCashflowSectionExpanded;
+        _settingsService.Set(SettingsKeys.DashboardCashflowExpanded, IsCashflowSectionExpanded.ToString().ToLowerInvariant());
+    }
+
+    [RelayCommand]
+    private void ToggleFilterSection()
+    {
+        IsFilterSectionExpanded = !IsFilterSectionExpanded;
+        _settingsService.Set(SettingsKeys.DashboardFilterExpanded, IsFilterSectionExpanded.ToString().ToLowerInvariant());
     }
 
     private async Task LadeFaelligeDauerauftraegeAsync()
@@ -622,6 +699,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         DueRecurringCount = actionable.Count;
         DueRecurringItems = new ObservableCollection<DueRecurringItem>(actionable);
         OnPropertyChanged(nameof(DueRecurringText));
+        OnPropertyChanged(nameof(ShowDueDetailsList));
     }
 
     private string? BuildDueRecurringHint(DueRecurringItem item, int dashboardPreviewDays)

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -344,15 +344,18 @@ public partial class DashboardViewModel : MonthNavigationViewModel
         _logger = logger;
         IsBudgetSectionExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardBudgetExpanded);
         IsYearDetailsExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardYearDetailsExpanded);
-        IsDueDetailsExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardDueDetailsExpanded);
+        IsDueDetailsExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardDueDetailsExpanded, defaultExpanded: true);
         IsAccountsSectionExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardAccountsExpanded);
         IsCashflowSectionExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardCashflowExpanded);
         IsFilterSectionExpanded = ReadExpandedSetting(settingsService, SettingsKeys.DashboardFilterExpanded);
         UpdateJahrAnzeige();
     }
 
-    private static bool ReadExpandedSetting(ISettingsService settingsService, string key) =>
-        bool.TryParse(settingsService.Get(key, "false"), out var expanded) && expanded;
+    private static bool ReadExpandedSetting(ISettingsService settingsService, string key, bool defaultExpanded = false)
+    {
+        var defaultValue = defaultExpanded.ToString().ToLowerInvariant();
+        return bool.TryParse(settingsService.Get(key, defaultValue), out var expanded) && expanded;
+    }
 
     protected override async Task OnMonthChangedAsync() => await LoadDashboard();
 

--- a/Finanzuebersicht.Presentation/ViewModels/ILocalizableViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ILocalizableViewModel.cs
@@ -1,0 +1,9 @@
+namespace Finanzuebersicht.ViewModels;
+
+/// <summary>
+/// ViewModels with strings that do not auto-update via <c>loc:Translate</c> bindings.
+/// </summary>
+public interface ILocalizableViewModel
+{
+    void RefreshLocalizedStrings();
+}

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -304,7 +304,12 @@ public partial class ImportPreviewRowItemViewModel : ObservableObject
         _ => _loc.GetString(ResourceKeys.Lbl_ImportStatusUnbekannt)
     };
 
-    public void RefreshLocalizedStrings() => OnPropertyChanged(nameof(StatusText));
+    public void RefreshLocalizedStrings()
+    {
+        OnPropertyChanged(nameof(StatusText));
+        OnPropertyChanged(nameof(AmountText));
+        OnPropertyChanged(nameof(DateText));
+    }
 
     partial void OnIsIncludedChanged(bool value)
     {

--- a/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/ImportPreviewViewModel.cs
@@ -20,7 +20,7 @@ public partial class ImportPreviewViewModel(
     ILocalizationService localizationService,
     IAppEvents appEvents,
     IFeedbackService feedbackService,
-    ILogger<ImportPreviewViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel
+    ILogger<ImportPreviewViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel, ILocalizableViewModel
 {
     private readonly ImportService _importService = importService;
     private readonly IImportSessionStore _importSessionStore = importSessionStore;
@@ -230,6 +230,14 @@ public partial class ImportPreviewViewModel(
 
         FilteredRows = new ObservableCollection<ImportPreviewRowItemViewModel>(filtered);
     }
+
+    public void RefreshLocalizedStrings()
+    {
+        RefreshFilterOptions();
+        RefreshState();
+        foreach (var row in Rows)
+            row.RefreshLocalizedStrings();
+    }
 }
 
 public partial class ImportPreviewRowItemViewModel : ObservableObject
@@ -293,8 +301,10 @@ public partial class ImportPreviewRowItemViewModel : ObservableObject
         ImportPreviewRowStatus.Invalid => _loc.GetString(ResourceKeys.Lbl_ImportStatusUngueltig),
         ImportPreviewRowStatus.Uncategorized => _loc.GetString(ResourceKeys.Lbl_ImportStatusUnkategorisiert),
         ImportPreviewRowStatus.SaveError => _loc.GetString(ResourceKeys.Lbl_ImportStatusSpeicherfehler),
-        _ => Status.ToString()
+        _ => _loc.GetString(ResourceKeys.Lbl_ImportStatusUnbekannt)
     };
+
+    public void RefreshLocalizedStrings() => OnPropertyChanged(nameof(StatusText));
 
     partial void OnIsIncludedChanged(bool value)
     {

--- a/Finanzuebersicht.Presentation/ViewModels/OnboardingViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/OnboardingViewModel.cs
@@ -12,20 +12,26 @@ public partial class OnboardingViewModel(
     IOnboardingCoordinator onboardingCoordinator,
     INavigationService navigationService,
     ILocalizationService localizationService,
+    IDisplayCurrencyService displayCurrency,
     LoadAccountsUseCase loadAccountsUseCase) : ObservableObject
 {
     private readonly IOnboardingCoordinator _onboardingCoordinator = onboardingCoordinator;
     private readonly INavigationService _navigationService = navigationService;
     private readonly ILocalizationService _loc = localizationService;
+    private readonly IDisplayCurrencyService _displayCurrency = displayCurrency;
     private readonly LoadAccountsUseCase _loadAccountsUseCase = loadAccountsUseCase;
 
     [ObservableProperty]
     private int currentStep;
 
+    [ObservableProperty]
+    private int selectedCurrencyIndex = displayCurrency.SelectedIndex;
+
     public int TotalSteps => 5;
 
     public string StepIndicator => $"{CurrentStep + 1} / {TotalSteps}";
 
+    public bool ShowWelcomeSetup => CurrentStep == 0;
     public bool ShowAccountActions => CurrentStep == 1;
     public bool ShowTransactionActions => CurrentStep == 2;
     public bool ShowBackupActions => CurrentStep == 3;
@@ -63,9 +69,20 @@ public partial class OnboardingViewModel(
         OnPropertyChanged(nameof(IsFirstStep));
         OnPropertyChanged(nameof(PrimaryButtonText));
         OnPropertyChanged(nameof(StepIndicator));
+        OnPropertyChanged(nameof(ShowWelcomeSetup));
         OnPropertyChanged(nameof(ShowAccountActions));
         OnPropertyChanged(nameof(ShowTransactionActions));
         OnPropertyChanged(nameof(ShowBackupActions));
+    }
+
+    partial void OnSelectedCurrencyIndexChanged(int value)
+        => _displayCurrency.SelectedIndex = value;
+
+    [RelayCommand]
+    private void SetCurrency(string indexStr)
+    {
+        if (int.TryParse(indexStr, out var idx))
+            SelectedCurrencyIndex = idx;
     }
 
     [RelayCommand]

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -24,7 +24,7 @@ public partial class RecurringTransactionDetailViewModel(
     IFeedbackService feedbackService,
     IAppEvents appEvents,
     ILogger<RecurringTransactionDetailViewModel>? logger = null,
-    Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel, IApplyQueryAttributes
+    Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel, IApplyQueryAttributes, ILocalizableViewModel
 {
     private readonly SaveRecurringTransactionDetailUseCase _saveRecurringTransactionDetailUseCase = saveRecurringTransactionDetailUseCase;
     private readonly LoadRecurringTransactionDetailDataUseCase _loadRecurringTransactionDetailDataUseCase = loadRecurringTransactionDetailDataUseCase;
@@ -346,12 +346,19 @@ public partial class RecurringTransactionDetailViewModel(
 
     private List<RecurrenceIntervalOption> BuildIntervalOptions() =>
     [
-        new(RecurrenceInterval.Daily, _loc.GetString(ResourceKeys.RecurrenceInterval_Daily)),
-        new(RecurrenceInterval.Weekly, _loc.GetString(ResourceKeys.RecurrenceInterval_Weekly)),
-        new(RecurrenceInterval.Monthly, _loc.GetString(ResourceKeys.RecurrenceInterval_Monthly)),
-        new(RecurrenceInterval.Quarterly, _loc.GetString(ResourceKeys.RecurrenceInterval_Quarterly)),
-        new(RecurrenceInterval.Yearly, _loc.GetString(ResourceKeys.RecurrenceInterval_Yearly))
+        new(RecurrenceInterval.Daily, _loc.GetString(EnumResourceKeys.GetRecurrenceInterval(RecurrenceInterval.Daily))),
+        new(RecurrenceInterval.Weekly, _loc.GetString(EnumResourceKeys.GetRecurrenceInterval(RecurrenceInterval.Weekly))),
+        new(RecurrenceInterval.Monthly, _loc.GetString(EnumResourceKeys.GetRecurrenceInterval(RecurrenceInterval.Monthly))),
+        new(RecurrenceInterval.Quarterly, _loc.GetString(EnumResourceKeys.GetRecurrenceInterval(RecurrenceInterval.Quarterly))),
+        new(RecurrenceInterval.Yearly, _loc.GetString(EnumResourceKeys.GetRecurrenceInterval(RecurrenceInterval.Yearly)))
     ];
+
+    public void RefreshLocalizedStrings()
+    {
+        _verfuegbareIntervalle = null;
+        OnPropertyChanged(nameof(VerfuegbareIntervalle));
+        SelectedIntervalOption = VerfuegbareIntervalle.FirstOrDefault(option => option.Value == Interval);
+    }
 }
 
 public sealed record RecurrenceIntervalOption(RecurrenceInterval Value, string DisplayName);

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/AppearanceViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/AppearanceViewModel.cs
@@ -8,6 +8,7 @@ public partial class AppearanceViewModel : ObservableObject
     private readonly ISettingsService _settings;
     private readonly IThemeService _themeService;
     private readonly ILocalizationService _loc;
+    private readonly IDisplayCurrencyService _displayCurrency;
 
     [ObservableProperty]
     private int selectedThemeIndex;
@@ -15,14 +16,19 @@ public partial class AppearanceViewModel : ObservableObject
     [ObservableProperty]
     private int selectedLanguageIndex;
 
+    [ObservableProperty]
+    private int selectedCurrencyIndex;
+
     public AppearanceViewModel(
         ISettingsService settings,
         IThemeService themeService,
-        ILocalizationService localizationService)
+        ILocalizationService localizationService,
+        IDisplayCurrencyService displayCurrency)
     {
         _settings = settings;
         _themeService = themeService;
         _loc = localizationService;
+        _displayCurrency = displayCurrency;
 
         var theme = _settings.Get("Theme", "System");
         selectedThemeIndex = theme switch
@@ -39,6 +45,8 @@ public partial class AppearanceViewModel : ObservableObject
             "en" => 2,
             _ => 0
         };
+
+        selectedCurrencyIndex = _displayCurrency.SelectedIndex;
     }
 
     partial void OnSelectedThemeIndexChanged(int value)
@@ -66,6 +74,11 @@ public partial class AppearanceViewModel : ObservableObject
         _loc.SetLanguage(string.IsNullOrEmpty(code) ? null : code);
     }
 
+    partial void OnSelectedCurrencyIndexChanged(int value)
+    {
+        _displayCurrency.SelectedIndex = value;
+    }
+
     [RelayCommand]
     private void SetTheme(string indexStr)
     {
@@ -81,6 +94,15 @@ public partial class AppearanceViewModel : ObservableObject
         if (int.TryParse(indexStr, out var idx))
         {
             SelectedLanguageIndex = idx;
+        }
+    }
+
+    [RelayCommand]
+    private void SetCurrency(string indexStr)
+    {
+        if (int.TryParse(indexStr, out var idx))
+        {
+            SelectedCurrencyIndex = idx;
         }
     }
 }

--- a/Finanzuebersicht.Presentation/ViewModels/SparZielDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SparZielDetailViewModel.cs
@@ -20,7 +20,7 @@ public partial class SparZielDetailViewModel(
     IDialogService dialogService,
     IFeedbackService feedbackService,
     IAppEvents appEvents,
-    ILogger<SparZielDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes, IAutoLoadViewModel
+    ILogger<SparZielDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes, IAutoLoadViewModel, ILocalizableViewModel
 {
     private readonly SaveSparZielUseCase _saveSparZielUseCase = saveSparZielUseCase;
     private readonly DeleteSparZielUseCase _deleteSparZielUseCase = deleteSparZielUseCase;
@@ -67,6 +67,12 @@ public partial class SparZielDetailViewModel(
     public System.Windows.Input.ICommand AutoLoadCommand => LoadProgressCommand;
 
     public string PageTitle => _loc.GetString(ResourceKeys.Title_SparZielBearbeiten);
+
+    public void RefreshLocalizedStrings()
+    {
+        OnPropertyChanged(nameof(PageTitle));
+        _ = LoadProgressAsync();
+    }
 
     public SparZiel? SparZiel
     {

--- a/Finanzuebersicht.Tests/Core/Services/DisplayCurrencyServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/DisplayCurrencyServiceTests.cs
@@ -52,6 +52,21 @@ public class DisplayCurrencyServiceTests
     }
 
     [Theory]
+    [InlineData("usd", "USD", "en-US")]
+    [InlineData(" usd ", "USD", "en-US")]
+    [InlineData("chf", "CHF", "de-CH")]
+    public void LoadCurrencyCode_NormalizesStoredValue(string stored, string expectedCode, string expectedCulture)
+    {
+        var settings = Substitute.For<ISettingsService>();
+        settings.Get(SettingsKeys.DisplayCurrency, "").Returns(stored);
+
+        var service = new DisplayCurrencyService(settings);
+
+        Assert.Equal(expectedCode, service.CurrencyCode);
+        Assert.Equal(expectedCulture, service.FormatCulture.Name);
+    }
+
+    [Theory]
     [InlineData(0, "EUR", "de-DE")]
     [InlineData(1, "CHF", "de-CH")]
     [InlineData(2, "USD", "en-US")]

--- a/Finanzuebersicht.Tests/Core/Services/DisplayCurrencyServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/DisplayCurrencyServiceTests.cs
@@ -1,0 +1,71 @@
+using Finanzuebersicht.Infrastructure.Services;
+using NSubstitute;
+
+namespace Finanzuebersicht.Tests.Core.Services;
+
+public class DisplayCurrencyServiceTests
+{
+    [Fact]
+    public void DefaultCurrency_IsEur_WithDeDeCulture()
+    {
+        var settings = Substitute.For<ISettingsService>();
+        settings.Get(SettingsKeys.DisplayCurrency, "").Returns("");
+        settings.Get("Currency", "EUR").Returns("EUR");
+
+        var service = new DisplayCurrencyService(settings);
+
+        Assert.Equal("EUR", service.CurrencyCode);
+        Assert.Equal("de-DE", service.FormatCulture.Name);
+        Assert.Equal("de-DE", CurrencyCulture.Instance.Name);
+    }
+
+    [Fact]
+    public void LegacyCurrencyKey_IsUsedWhenDisplayCurrencyMissing()
+    {
+        var settings = Substitute.For<ISettingsService>();
+        settings.Get(SettingsKeys.DisplayCurrency, "").Returns("");
+        settings.Get("Currency", "EUR").Returns("USD");
+
+        var service = new DisplayCurrencyService(settings);
+
+        Assert.Equal("USD", service.CurrencyCode);
+        Assert.Equal("en-US", service.FormatCulture.Name);
+    }
+
+    [Fact]
+    public void SetCurrency_PersistsAndRaisesChanged()
+    {
+        var settings = Substitute.For<ISettingsService>();
+        settings.Get(SettingsKeys.DisplayCurrency, "").Returns("");
+        settings.Get("Currency", "EUR").Returns("EUR");
+
+        var service = new DisplayCurrencyService(settings);
+        var changed = false;
+        service.Changed += () => changed = true;
+
+        service.SelectedIndex = 2;
+
+        Assert.Equal("USD", service.CurrencyCode);
+        Assert.Equal("en-US", CurrencyCulture.Instance.Name);
+        settings.Received(1).Set(SettingsKeys.DisplayCurrency, "USD");
+        Assert.True(changed);
+    }
+
+    [Theory]
+    [InlineData(0, "EUR", "de-DE")]
+    [InlineData(1, "CHF", "de-CH")]
+    [InlineData(2, "USD", "en-US")]
+    [InlineData(3, "GBP", "en-GB")]
+    public void SelectedIndex_MapsToExpectedCulture(int index, string code, string culture)
+    {
+        var settings = Substitute.For<ISettingsService>();
+        settings.Get(SettingsKeys.DisplayCurrency, "").Returns("");
+        settings.Get("Currency", "EUR").Returns("EUR");
+
+        var service = new DisplayCurrencyService(settings);
+        service.SelectedIndex = index;
+
+        Assert.Equal(code, service.CurrencyCode);
+        Assert.Equal(culture, service.FormatCulture.Name);
+    }
+}

--- a/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
@@ -145,7 +145,7 @@ public class DashboardViewModelTests
     public void ToggleBudgetSection_PersistsExpandedState()
     {
         var settings = Substitute.For<ISettingsService>();
-        settings.Get(SettingsKeys.DashboardBudgetExpanded, "true").Returns("true");
+        settings.Get(SettingsKeys.DashboardBudgetExpanded, "false").Returns("true");
 
         var viewModel = CreateSut(settings);
         Assert.True(viewModel.IsBudgetSectionExpanded);

--- a/Finanzuebersicht.Tests/ViewModels/Settings/AppearanceViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/Settings/AppearanceViewModelTests.cs
@@ -12,7 +12,7 @@ public class AppearanceViewModelTests
         var themeService = Substitute.For<IThemeService>();
         var localizationService = CreateLocalizationService();
 
-        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService);
+        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService, CreateDisplayCurrencyService());
 
         Assert.Equal(2, sut.SelectedThemeIndex);
     }
@@ -24,7 +24,7 @@ public class AppearanceViewModelTests
         var themeService = Substitute.For<IThemeService>();
         var localizationService = CreateLocalizationService("en");
 
-        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService);
+        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService, CreateDisplayCurrencyService());
 
         Assert.Equal(2, sut.SelectedLanguageIndex);
     }
@@ -35,7 +35,7 @@ public class AppearanceViewModelTests
         using var settingsScope = new SettingsScope(nameof(AppearanceViewModelTests));
         var themeService = Substitute.For<IThemeService>();
         var localizationService = CreateLocalizationService();
-        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService);
+        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService, CreateDisplayCurrencyService());
 
         sut.SetThemeCommand.Execute("1");
 
@@ -50,7 +50,7 @@ public class AppearanceViewModelTests
         using var settingsScope = new SettingsScope(nameof(AppearanceViewModelTests));
         var themeService = Substitute.For<IThemeService>();
         var localizationService = CreateLocalizationService();
-        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService);
+        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService, CreateDisplayCurrencyService());
 
         sut.SelectedThemeIndex = 2;
 
@@ -64,12 +64,34 @@ public class AppearanceViewModelTests
         using var settingsScope = new SettingsScope(nameof(AppearanceViewModelTests));
         var themeService = Substitute.For<IThemeService>();
         var localizationService = CreateLocalizationService();
-        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService);
+        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService, CreateDisplayCurrencyService());
 
         sut.SetLanguageCommand.Execute("2");
 
         Assert.Equal(2, sut.SelectedLanguageIndex);
         localizationService.Received(1).SetLanguage("en");
+    }
+
+    [Fact]
+    public void SetCurrency_UpdatesIndex()
+    {
+        using var settingsScope = new SettingsScope(nameof(AppearanceViewModelTests));
+        var themeService = Substitute.For<IThemeService>();
+        var localizationService = CreateLocalizationService();
+        var displayCurrency = CreateDisplayCurrencyService();
+        var sut = new AppearanceViewModel(settingsScope.Settings, themeService, localizationService, displayCurrency);
+
+        sut.SetCurrencyCommand.Execute("2");
+
+        Assert.Equal(2, sut.SelectedCurrencyIndex);
+        displayCurrency.Received(1).SelectedIndex = 2;
+    }
+
+    private static IDisplayCurrencyService CreateDisplayCurrencyService(int selectedIndex = 0)
+    {
+        var displayCurrency = Substitute.For<IDisplayCurrencyService>();
+        displayCurrency.SelectedIndex.Returns(selectedIndex);
+        return displayCurrency;
     }
 
     private static ILocalizationService CreateLocalizationService(string currentLanguageCode = "")

--- a/Finanzuebersicht/App.xaml.cs
+++ b/Finanzuebersicht/App.xaml.cs
@@ -1,4 +1,5 @@
-﻿using Finanzuebersicht.Services;
+﻿using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Services;
 
 namespace Finanzuebersicht;
 
@@ -8,6 +9,8 @@ public partial class App : global::Microsoft.Maui.Controls.Application
 	public static event Action? DataChanged;
 
 	public static event Action? LanguageChanged;
+
+	public static event Action? CurrencyChanged;
 
 		public static void NotifyDataChanged()
 		{
@@ -20,11 +23,12 @@ public partial class App : global::Microsoft.Maui.Controls.Application
 	private readonly string _savedTheme;
 
 	public App(InitializationService initService, IRecurringGenerationService recurringGenerationService, ISettingsService settings,
-		ThemeService themeService, ILocalizationService localizationService)
+		ThemeService themeService, ILocalizationService localizationService, IDisplayCurrencyService displayCurrency)
 	{
 		// Sprache vor InitializeComponent setzen, damit XAML-Bindings korrekt aufgelöst werden
 		localizationService.Initialize();
 		localizationService.LanguageChanged += () => LanguageChanged?.Invoke();
+		displayCurrency.Changed += () => CurrencyChanged?.Invoke();
 
 		InitializeComponent();
 		_recurringGenerationService = recurringGenerationService;

--- a/Finanzuebersicht/AppShell.xaml
+++ b/Finanzuebersicht/AppShell.xaml
@@ -5,7 +5,7 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
     xmlns:views="clr-namespace:Finanzuebersicht.Views"
     xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
-    Title="Finanzübersicht"
+    Title="{loc:Translate Title_AppName}"
     Shell.TabBarBackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
     Shell.TabBarTitleColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
     Shell.TabBarUnselectedColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}">

--- a/Finanzuebersicht/Controls/EmptyStateView.xaml
+++ b/Finanzuebersicht/Controls/EmptyStateView.xaml
@@ -8,25 +8,32 @@
                          HorizontalOptions="Center"
                          Margin="0,40,0,0"
                          Padding="16,0">
+        <Image Source="{Binding Source={x:Reference Root}, Path=IconImage}"
+               HeightRequest="48"
+               WidthRequest="48"
+               Aspect="AspectFit"
+               HorizontalOptions="Center"
+               IsVisible="{Binding Source={x:Reference Root}, Path=HasIconImage}"
+               SemanticProperties.Description="{Binding Source={x:Reference Root}, Path=IconAccessibilityDescription}" />
         <Label Text="{Binding Source={x:Reference Root}, Path=IconText}"
                FontSize="48"
                HorizontalTextAlignment="Center"
-               IsVisible="{Binding Source={x:Reference Root}, Path=HasIcon}"
+               IsVisible="{Binding Source={x:Reference Root}, Path=ShowIconText}"
                AutomationProperties.IsInAccessibleTree="False" />
         <Label Text="{Binding Source={x:Reference Root}, Path=Message}"
                FontSize="17"
-               TextColor="Gray"
+               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                HorizontalTextAlignment="Center" />
         <Label Text="{Binding Source={x:Reference Root}, Path=Hint}"
                FontSize="14"
-               TextColor="Gray"
+               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                HorizontalTextAlignment="Center"
                IsVisible="{Binding Source={x:Reference Root}, Path=HasHint}" />
         <Button Text="{Binding Source={x:Reference Root}, Path=ActionText}"
                 Command="{Binding Source={x:Reference Root}, Path=ActionCommand}"
                 HorizontalOptions="Center"
                 BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                TextColor="White"
+                TextColor="{StaticResource White}"
                 CornerRadius="10"
                 Padding="20,10"
                 IsVisible="{Binding Source={x:Reference Root}, Path=HasAction}" />

--- a/Finanzuebersicht/Controls/EmptyStateView.xaml.cs
+++ b/Finanzuebersicht/Controls/EmptyStateView.xaml.cs
@@ -1,8 +1,9 @@
+using System.ComponentModel;
 using System.Windows.Input;
 
 namespace Finanzuebersicht.Controls;
 
-public partial class EmptyStateView : ContentView
+public partial class EmptyStateView : ContentView, INotifyPropertyChanged
 {
     public static readonly BindableProperty MessageProperty =
         BindableProperty.Create(nameof(Message), typeof(string), typeof(EmptyStateView), string.Empty);
@@ -11,7 +12,15 @@ public partial class EmptyStateView : ContentView
         BindableProperty.Create(nameof(Hint), typeof(string), typeof(EmptyStateView), string.Empty);
 
     public static readonly BindableProperty IconTextProperty =
-        BindableProperty.Create(nameof(IconText), typeof(string), typeof(EmptyStateView), string.Empty);
+        BindableProperty.Create(nameof(IconText), typeof(string), typeof(EmptyStateView), string.Empty,
+            propertyChanged: OnIconPropertyChanged);
+
+    public static readonly BindableProperty IconImageProperty =
+        BindableProperty.Create(nameof(IconImage), typeof(string), typeof(EmptyStateView), string.Empty,
+            propertyChanged: OnIconPropertyChanged);
+
+    public static readonly BindableProperty IconAccessibilityDescriptionProperty =
+        BindableProperty.Create(nameof(IconAccessibilityDescription), typeof(string), typeof(EmptyStateView), string.Empty);
 
     public static readonly BindableProperty ActionTextProperty =
         BindableProperty.Create(nameof(ActionText), typeof(string), typeof(EmptyStateView), string.Empty);
@@ -39,6 +48,18 @@ public partial class EmptyStateView : ContentView
         set => SetValue(IconTextProperty, value);
     }
 
+    public string IconImage
+    {
+        get => (string)GetValue(IconImageProperty);
+        set => SetValue(IconImageProperty, value);
+    }
+
+    public string IconAccessibilityDescription
+    {
+        get => (string)GetValue(IconAccessibilityDescriptionProperty);
+        set => SetValue(IconAccessibilityDescriptionProperty, value);
+    }
+
     public string ActionText
     {
         get => (string)GetValue(ActionTextProperty);
@@ -52,6 +73,16 @@ public partial class EmptyStateView : ContentView
     }
 
     public bool HasHint => !string.IsNullOrWhiteSpace(Hint);
-    public bool HasIcon => !string.IsNullOrWhiteSpace(IconText);
+    public bool HasIconImage => !string.IsNullOrWhiteSpace(IconImage);
+    public bool ShowIconText => !HasIconImage && !string.IsNullOrWhiteSpace(IconText);
     public bool HasAction => !string.IsNullOrWhiteSpace(ActionText) && ActionCommand != null;
+
+    private static void OnIconPropertyChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is EmptyStateView view)
+        {
+            view.OnPropertyChanged(nameof(HasIconImage));
+            view.OnPropertyChanged(nameof(ShowIconText));
+        }
+    }
 }

--- a/Finanzuebersicht/Converters/TransactionTypeToLocalizedStringConverter.cs
+++ b/Finanzuebersicht/Converters/TransactionTypeToLocalizedStringConverter.cs
@@ -6,14 +6,14 @@ using Microsoft.Maui.Controls;
 
 namespace Finanzuebersicht.Converters;
 
-public class AccountTypeToLocalizedStringConverter : IValueConverter
+public class TransactionTypeToLocalizedStringConverter : IValueConverter
 {
     public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
     {
-        if (value is not AccountType accountType)
+        if (value is not TransactionType transactionType)
             return string.Empty;
 
-        return LocalizationResourceManager.Current[EnumResourceKeys.GetAccountType(accountType)];
+        return LocalizationResourceManager.Current[EnumResourceKeys.GetTransactionType(transactionType)];
     }
 
     public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)

--- a/Finanzuebersicht/Finanzuebersicht.csproj
+++ b/Finanzuebersicht/Finanzuebersicht.csproj
@@ -95,11 +95,11 @@
 		<ProjectReference Include="..\Finanzuebersicht.Presentation\Finanzuebersicht.Presentation.csproj" />
 	</ItemGroup>
 
-	<!-- Debug/maccatalyst: App nach dem Build nach /Applications kopieren und starten -->
+	<!-- Debug/maccatalyst: nach ~/Applications kopieren (Dev-Signatur startet unter macOS 26+ nicht aus /Applications) -->
 	<Target Name="InstallToApplications"
 			AfterTargets="_CodesignAppBundle"
 			Condition="'$(Configuration)' == 'Debug' AND $([MSBuild]::GetTargetPlatformIdentifier('$(TargetFramework)')) == 'maccatalyst'">
-		<Exec Command="rsync -a --delete '$(AppBundleDir)/' '/Applications/$(ApplicationTitle).app/'" />
+		<Exec Command="mkdir -p &quot;$HOME/Applications&quot; &amp;&amp; rm -rf &quot;$HOME/Applications/$(ApplicationTitle).app&quot; &amp;&amp; ditto &quot;$(AppBundleDir)&quot; &quot;$HOME/Applications/$(ApplicationTitle).app&quot;" />
 	</Target>
 
 	<!-- Set MAUI version properties from Nerdbank.GitVersioning at build time -->

--- a/Finanzuebersicht/Resources/AppIcons.cs
+++ b/Finanzuebersicht/Resources/AppIcons.cs
@@ -1,0 +1,15 @@
+namespace Finanzuebersicht.Resources;
+
+/// <summary>
+/// Shared raster icon names (Resources/Images/*.png from SVG assets).
+/// </summary>
+public static class AppIcons
+{
+    public const string Dashboard = "dashboard.png";
+    public const string Transactions = "transactions.png";
+    public const string Categories = "categories.png";
+    public const string Recurring = "recurring.png";
+    public const string Savings = "savings.png";
+    public const string Settings = "settings.png";
+    public const string Year = "year.png";
+}

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -34,6 +34,7 @@
   <data name="Lbl_Titel" xml:space="preserve"><value>Titel</value></data>
   <data name="Lbl_Kategorie" xml:space="preserve"><value>Kategorie</value></data>
   <data name="Lbl_Konto" xml:space="preserve"><value>Konto</value></data>
+  <data name="Lbl_Konten" xml:space="preserve"><value>Konten</value></data>
   <data name="Lbl_AlleKonten" xml:space="preserve"><value>Alle Konten</value></data>
   <data name="Lbl_Kontosaldo" xml:space="preserve"><value>Kontosaldo</value></data>
   <data name="Lbl_Anfangssaldo" xml:space="preserve"><value>Anfangssaldo</value></data>
@@ -74,6 +75,7 @@
   <data name="Lbl_Verwendungszweck" xml:space="preserve"><value>Verwendungszweck</value></data>
   <data name="Lbl_DatenWerdenGespeichert" xml:space="preserve"><value>Daten werden hier gespeichert:</value></data>
   <data name="Lbl_Sprache" xml:space="preserve"><value>Sprache</value></data>
+  <data name="Lbl_Anzeigewaehrung" xml:space="preserve"><value>Anzeige-Währung</value></data>
   <data name="Lbl_KategorienColon" xml:space="preserve"><value>Kategorien:</value></data>
 
   <!-- Buttons -->
@@ -81,11 +83,11 @@
   <data name="Btn_Loeschen" xml:space="preserve"><value>Löschen</value></data>
   <data name="Btn_Abbrechen" xml:space="preserve"><value>Abbrechen</value></data>
   <data name="Btn_OK" xml:space="preserve"><value>OK</value></data>
-  <data name="Btn_OrdnerWaehlen" xml:space="preserve"><value>📁 Ordner wählen</value></data>
+  <data name="Btn_OrdnerWaehlen" xml:space="preserve"><value>Ordner wählen</value></data>
   <data name="Btn_Zuruecksetzen" xml:space="preserve"><value>Zurücksetzen</value></data>
   <data name="Btn_System" xml:space="preserve"><value>System</value></data>
-  <data name="Btn_Hell" xml:space="preserve"><value>☀️ Hell</value></data>
-  <data name="Btn_Dunkel" xml:space="preserve"><value>🌙 Dunkel</value></data>
+  <data name="Btn_Hell" xml:space="preserve"><value>Hell</value></data>
+  <data name="Btn_Dunkel" xml:space="preserve"><value>Dunkel</value></data>
   <data name="Btn_Ja" xml:space="preserve"><value>Ja</value></data>
   <data name="Btn_Nein" xml:space="preserve"><value>Nein</value></data>
   <data name="Btn_AktivInaktiv" xml:space="preserve"><value>Aktiv/Inaktiv</value></data>
@@ -129,6 +131,12 @@
   <!-- Confirmation Dialogs -->
   <data name="Dlg_KategorieLoeschen" xml:space="preserve"><value>Kategorie löschen</value></data>
   <data name="Dlg_KategorieLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
+  <data name="Dlg_KontoLoeschen" xml:space="preserve"><value>Konto löschen</value></data>
+  <data name="Dlg_KontoLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
+  <data name="Dlg_KontoArchivieren" xml:space="preserve"><value>Konto archivieren</value></data>
+  <data name="Dlg_KontoArchivierenFrage" xml:space="preserve"><value>"{0}" archivieren? Das Konto steht dann nicht mehr für neue Buchungen zur Auswahl.</value></data>
+  <data name="Dlg_KontoReaktivieren" xml:space="preserve"><value>Konto reaktivieren</value></data>
+  <data name="Dlg_KontoReaktivierenFrage" xml:space="preserve"><value>"{0}" wieder aktivieren?</value></data>
   <data name="Dlg_DauerauftragLoeschen" xml:space="preserve"><value>Dauerauftrag löschen</value></data>
   <data name="Dlg_DauerauftragLoeschenFrage" xml:space="preserve"><value>"{0}" wirklich löschen?</value></data>
   <data name="Dlg_DauerauftragBuchen" xml:space="preserve"><value>Dauerauftrag buchen</value></data>
@@ -161,6 +169,10 @@ Bitte starte die App neu.</value></data>
   <data name="Stn_SpracheDeutsch" xml:space="preserve"><value>Deutsch</value></data>
   <data name="Stn_SpracheEnglisch" xml:space="preserve"><value>Englisch</value></data>
   <data name="Stn_SpracheSystem" xml:space="preserve"><value>Systemsprache</value></data>
+  <data name="Stn_CurrencyEur" xml:space="preserve"><value>EUR</value></data>
+  <data name="Stn_CurrencyChf" xml:space="preserve"><value>CHF</value></data>
+  <data name="Stn_CurrencyUsd" xml:space="preserve"><value>USD</value></data>
+  <data name="Stn_CurrencyGbp" xml:space="preserve"><value>GBP</value></data>
 
   <!-- Status -->
   <data name="Status_Aktiv" xml:space="preserve"><value>Aktiv</value></data>
@@ -238,6 +250,8 @@ Bitte starte die App neu.</value></data>
   <data name="Msg_BackupRestoreConfirmBody" xml:space="preserve"><value>Backup vom {0} wiederherstellen? Alle aktuellen Daten werden überschrieben.</value></data>
   <data name="Msg_BackupRestoreDesc" xml:space="preserve"><value>Erstelle Sicherungen deiner Daten und stelle sie bei Bedarf wieder her.</value></data>
   <data name="Btn_Import" xml:space="preserve"><value>Import</value></data>
+  <data name="Btn_Filter" xml:space="preserve"><value>Filter</value></data>
+  <data name="Btn_Umbuchen" xml:space="preserve"><value>Umbuchen</value></data>
   <data name="Btn_FilterZuruecksetzen" xml:space="preserve"><value>Filter zurücksetzen</value></data>
   <data name="Title_ShiftInstance" xml:space="preserve"><value>Instanz verschieben</value></data>
   <data name="Btn_Hinzufuegen" xml:space="preserve"><value>+</value></data>
@@ -303,6 +317,7 @@ Bitte starte die App neu.</value></data>
   <data name="Lbl_ImportStatusUngueltig" xml:space="preserve"><value>Ungültig</value></data>
   <data name="Lbl_ImportStatusUnkategorisiert" xml:space="preserve"><value>Ohne Kategorie</value></data>
   <data name="Lbl_ImportStatusSpeicherfehler" xml:space="preserve"><value>Speicherfehler</value></data>
+  <data name="Lbl_ImportStatusUnbekannt" xml:space="preserve"><value>Unbekannt</value></data>
   <data name="Lbl_ImportBereitCount" xml:space="preserve"><value>Bereit: {0}</value></data>
   <data name="Lbl_ImportDuplikateCount" xml:space="preserve"><value>Duplikate: {0}</value></data>
   <data name="Lbl_ImportProblemeCount" xml:space="preserve"><value>Probleme: {0}</value></data>
@@ -332,6 +347,7 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_TransaktionHinzufuegen" xml:space="preserve"><value>Neue Transaktion hinzufügen</value></data>
   <data name="A11y_UmbuchungHinzufuegen" xml:space="preserve"><value>Neue Umbuchung hinzufügen</value></data>
   <data name="A11y_KategorieHinzufuegen" xml:space="preserve"><value>Neue Kategorie hinzufügen</value></data>
+  <data name="A11y_KontoHinzufuegen" xml:space="preserve"><value>Neues Konto hinzufügen</value></data>
   <data name="A11y_SparZielHinzufuegen" xml:space="preserve"><value>Neues Sparziel hinzufügen</value></data>
   <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Neuen Dauerauftrag hinzufügen</value></data>
   <data name="A11y_BudgetBalken" xml:space="preserve"><value>Budget-Fortschrittsbalken für Kategorie</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -10,7 +10,7 @@
   <data name="Nav_Transaktionen" xml:space="preserve"><value>Transactions</value></data>
   <data name="Nav_Dauerauftraege" xml:space="preserve"><value>Recurring</value></data>
   <data name="Nav_Kategorien" xml:space="preserve"><value>Categories</value></data>
-  <data name="Nav_Verwaltung" xml:space="preserve"><value>Management</value></data>
+  <data name="Nav_Verwaltung" xml:space="preserve"><value>Categories &amp; Accounts</value></data>
   <data name="Nav_Einstellungen" xml:space="preserve"><value>Settings</value></data>
   <data name="Nav_Cashflow" xml:space="preserve"><value>Cashflow (30 days)</value></data>
   <data name="Title_Cashflow" xml:space="preserve"><value>Cashflow Outlook</value></data>
@@ -34,6 +34,7 @@
   <data name="Lbl_Titel" xml:space="preserve"><value>Title</value></data>
   <data name="Lbl_Kategorie" xml:space="preserve"><value>Category</value></data>
   <data name="Lbl_Konto" xml:space="preserve"><value>Account</value></data>
+  <data name="Lbl_Konten" xml:space="preserve"><value>Accounts</value></data>
   <data name="Lbl_AlleKonten" xml:space="preserve"><value>All Accounts</value></data>
   <data name="Lbl_Kontosaldo" xml:space="preserve"><value>Account Balance</value></data>
   <data name="Lbl_Anfangssaldo" xml:space="preserve"><value>Opening balance</value></data>
@@ -74,6 +75,7 @@
   <data name="Lbl_Verwendungszweck" xml:space="preserve"><value>Purpose</value></data>
   <data name="Lbl_DatenWerdenGespeichert" xml:space="preserve"><value>Data is stored here:</value></data>
   <data name="Lbl_Sprache" xml:space="preserve"><value>Language</value></data>
+  <data name="Lbl_Anzeigewaehrung" xml:space="preserve"><value>Display Currency</value></data>
   <data name="Lbl_KategorienColon" xml:space="preserve"><value>Categories:</value></data>
 
   <!-- Buttons -->
@@ -81,11 +83,11 @@
   <data name="Btn_Loeschen" xml:space="preserve"><value>Delete</value></data>
   <data name="Btn_Abbrechen" xml:space="preserve"><value>Cancel</value></data>
   <data name="Btn_OK" xml:space="preserve"><value>OK</value></data>
-  <data name="Btn_OrdnerWaehlen" xml:space="preserve"><value>📁 Choose Folder</value></data>
+  <data name="Btn_OrdnerWaehlen" xml:space="preserve"><value>Choose Folder</value></data>
   <data name="Btn_Zuruecksetzen" xml:space="preserve"><value>Reset</value></data>
   <data name="Btn_System" xml:space="preserve"><value>System</value></data>
-  <data name="Btn_Hell" xml:space="preserve"><value>☀️ Light</value></data>
-  <data name="Btn_Dunkel" xml:space="preserve"><value>🌙 Dark</value></data>
+  <data name="Btn_Hell" xml:space="preserve"><value>Light</value></data>
+  <data name="Btn_Dunkel" xml:space="preserve"><value>Dark</value></data>
   <data name="Btn_Ja" xml:space="preserve"><value>Yes</value></data>
   <data name="Btn_Nein" xml:space="preserve"><value>No</value></data>
   <data name="Btn_AktivInaktiv" xml:space="preserve"><value>Toggle Active</value></data>
@@ -129,6 +131,12 @@
   <!-- Confirmation Dialogs -->
   <data name="Dlg_KategorieLoeschen" xml:space="preserve"><value>Delete Category</value></data>
   <data name="Dlg_KategorieLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
+  <data name="Dlg_KontoLoeschen" xml:space="preserve"><value>Delete account</value></data>
+  <data name="Dlg_KontoLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
+  <data name="Dlg_KontoArchivieren" xml:space="preserve"><value>Archive account</value></data>
+  <data name="Dlg_KontoArchivierenFrage" xml:space="preserve"><value>Archive "{0}"? It will no longer be available for new transactions.</value></data>
+  <data name="Dlg_KontoReaktivieren" xml:space="preserve"><value>Reactivate account</value></data>
+  <data name="Dlg_KontoReaktivierenFrage" xml:space="preserve"><value>Reactivate "{0}"?</value></data>
   <data name="Dlg_DauerauftragLoeschen" xml:space="preserve"><value>Delete Recurring Transaction</value></data>
   <data name="Dlg_DauerauftragLoeschenFrage" xml:space="preserve"><value>Really delete "{0}"?</value></data>
   <data name="Dlg_DauerauftragBuchen" xml:space="preserve"><value>Book Recurring Transaction</value></data>
@@ -161,6 +169,10 @@ Please restart the app.</value></data>
   <data name="Stn_SpracheDeutsch" xml:space="preserve"><value>German</value></data>
   <data name="Stn_SpracheEnglisch" xml:space="preserve"><value>English</value></data>
   <data name="Stn_SpracheSystem" xml:space="preserve"><value>System Language</value></data>
+  <data name="Stn_CurrencyEur" xml:space="preserve"><value>EUR</value></data>
+  <data name="Stn_CurrencyChf" xml:space="preserve"><value>CHF</value></data>
+  <data name="Stn_CurrencyUsd" xml:space="preserve"><value>USD</value></data>
+  <data name="Stn_CurrencyGbp" xml:space="preserve"><value>GBP</value></data>
 
   <!-- Status -->
   <data name="Status_Aktiv" xml:space="preserve"><value>Active</value></data>
@@ -238,6 +250,8 @@ Please restart the app.</value></data>
   <data name="Msg_BackupRestoreConfirmBody" xml:space="preserve"><value>Restore backup from {0}? All current data will be overwritten.</value></data>
   <data name="Msg_BackupRestoreDesc" xml:space="preserve"><value>Create backups of your data and restore when needed.</value></data>
   <data name="Btn_Import" xml:space="preserve"><value>Import</value></data>
+  <data name="Btn_Filter" xml:space="preserve"><value>Filter</value></data>
+  <data name="Btn_Umbuchen" xml:space="preserve"><value>Transfer</value></data>
   <data name="Btn_FilterZuruecksetzen" xml:space="preserve"><value>Clear filter</value></data>
   <data name="Title_ShiftInstance" xml:space="preserve"><value>Shift instance</value></data>
   <data name="Btn_Hinzufuegen" xml:space="preserve"><value>+</value></data>
@@ -303,6 +317,7 @@ Please restart the app.</value></data>
   <data name="Lbl_ImportStatusUngueltig" xml:space="preserve"><value>Invalid</value></data>
   <data name="Lbl_ImportStatusUnkategorisiert" xml:space="preserve"><value>No category</value></data>
   <data name="Lbl_ImportStatusSpeicherfehler" xml:space="preserve"><value>Save error</value></data>
+  <data name="Lbl_ImportStatusUnbekannt" xml:space="preserve"><value>Unknown</value></data>
   <data name="Lbl_ImportBereitCount" xml:space="preserve"><value>Ready: {0}</value></data>
   <data name="Lbl_ImportDuplikateCount" xml:space="preserve"><value>Duplicates: {0}</value></data>
   <data name="Lbl_ImportProblemeCount" xml:space="preserve"><value>Problems: {0}</value></data>
@@ -332,6 +347,7 @@ Please restart the app.</value></data>
   <data name="A11y_TransaktionHinzufuegen" xml:space="preserve"><value>Add new transaction</value></data>
   <data name="A11y_UmbuchungHinzufuegen" xml:space="preserve"><value>Add new transfer</value></data>
   <data name="A11y_KategorieHinzufuegen" xml:space="preserve"><value>Add new category</value></data>
+  <data name="A11y_KontoHinzufuegen" xml:space="preserve"><value>Add new account</value></data>
   <data name="A11y_SparZielHinzufuegen" xml:space="preserve"><value>Add new savings goal</value></data>
   <data name="A11y_DauerauftragHinzufuegen" xml:space="preserve"><value>Add new recurring transaction</value></data>
   <data name="A11y_BudgetBalken" xml:space="preserve"><value>Category budget progress</value></data>

--- a/Finanzuebersicht/Views/AccountDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/AccountDetailPage.xaml.cs
@@ -14,12 +14,14 @@ public partial class AccountDetailPage : ContentPage, IQueryAttributable
     protected override void OnAppearing()
     {
         base.OnAppearing();
-        App.LanguageChanged += OnLanguageChanged;
+        App.LanguageChanged += OnLocalizationChanged;
+        App.CurrencyChanged += OnLocalizationChanged;
     }
 
     protected override void OnDisappearing()
     {
-        App.LanguageChanged -= OnLanguageChanged;
+        App.LanguageChanged -= OnLocalizationChanged;
+        App.CurrencyChanged -= OnLocalizationChanged;
         base.OnDisappearing();
     }
 
@@ -29,7 +31,7 @@ public partial class AccountDetailPage : ContentPage, IQueryAttributable
             vm.ApplyQueryAttributes(query);
     }
 
-    private void OnLanguageChanged()
+    private void OnLocalizationChanged()
     {
         if (BindingContext is ILocalizableViewModel vm)
             vm.RefreshLocalizedStrings();

--- a/Finanzuebersicht/Views/AccountDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/AccountDetailPage.xaml.cs
@@ -11,9 +11,27 @@ public partial class AccountDetailPage : ContentPage, IQueryAttributable
         BindingContext = viewModel;
     }
 
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        App.LanguageChanged += OnLanguageChanged;
+    }
+
+    protected override void OnDisappearing()
+    {
+        App.LanguageChanged -= OnLanguageChanged;
+        base.OnDisappearing();
+    }
+
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
         if (BindingContext is IApplyQueryAttributes vm)
             vm.ApplyQueryAttributes(query);
+    }
+
+    private void OnLanguageChanged()
+    {
+        if (BindingContext is ILocalizableViewModel vm)
+            vm.RefreshLocalizedStrings();
     }
 }

--- a/Finanzuebersicht/Views/BackupListPage.xaml
+++ b/Finanzuebersicht/Views/BackupListPage.xaml
@@ -21,7 +21,8 @@
             <VerticalStackLayout Spacing="12" Padding="16">
 
                 <!-- Leerer Zustand -->
-                <controls:EmptyStateView IconText="💾"
+                <controls:EmptyStateView IconImage="settings.png"
+                                         IconAccessibilityDescription="{loc:Translate Nav_Einstellungen}"
                                          Message="{loc:Translate Empty_KeineBackupsVorhanden}"
                                          Hint="{loc:Translate Empty_HintBackups}"
                                          IsVisible="{Binding IsEmpty}" />

--- a/Finanzuebersicht/Views/BaseContentPage.cs
+++ b/Finanzuebersicht/Views/BaseContentPage.cs
@@ -23,6 +23,7 @@ public abstract class BaseContentPage : ContentPage
     {
         base.OnAppearing();
         App.LanguageChanged += OnLanguageChanged;
+        App.CurrencyChanged += OnLanguageChanged;
         if (BindingContext is IAutoLoadViewModel vm && vm.ShouldAutoLoad)
             vm.AutoLoadCommand.Execute(null);
     }
@@ -30,11 +31,15 @@ public abstract class BaseContentPage : ContentPage
     protected override void OnDisappearing()
     {
         App.LanguageChanged -= OnLanguageChanged;
+        App.CurrencyChanged -= OnLanguageChanged;
         base.OnDisappearing();
     }
 
     private void OnLanguageChanged()
     {
+        if (BindingContext is ILocalizableViewModel locVm)
+            locVm.RefreshLocalizedStrings();
+
         if (BindingContext is IAutoLoadViewModel vm && vm.ShouldAutoLoad)
             vm.AutoLoadCommand.Execute(null);
     }

--- a/Finanzuebersicht/Views/CashflowPage.xaml
+++ b/Finanzuebersicht/Views/CashflowPage.xaml
@@ -41,7 +41,8 @@
                     </VerticalStackLayout>
                 </Grid>
 
-                <controls:EmptyStateView IconText="📅"
+                <controls:EmptyStateView IconImage="year.png"
+                                         IconAccessibilityDescription="{loc:Translate Title_Cashflow}"
                                          Message="{loc:Translate Empty_KeinCashflow}"
                                          Hint="{loc:Translate Empty_HintCashflow}"
                                          IsVisible="{Binding HasDays, Converter={StaticResource InvertBool}}" />

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -13,20 +13,51 @@
 
     <views:BaseContentPage.Resources>
         <conv:AccountTypeToLocalizedStringConverter x:Key="AccountTypeToLocalizedStringConverter" />
+        <conv:TransactionTypeToLocalizedStringConverter x:Key="TransactionTypeToLocalizedStringConverter" />
         <conv:AccountArchiveActionConverter x:Key="AccountArchiveActionConverter" />
         <conv:DecimalCurrencyConverter x:Key="Currency" />
         <conv:BilanzColorConverter x:Key="BilanzColor" />
+        <conv:ToggleActiveColorConverter x:Key="ToggleActiveColor" />
+        <conv:ToggleActiveTextColorConverter x:Key="ToggleActiveText" />
     </views:BaseContentPage.Resources>
 
     <Grid>
         <Grid RowDefinitions="Auto, *">
-            <Grid Grid.Row="0" ColumnDefinitions="*,*" Padding="16,12" ColumnSpacing="8">
-                <Button Text="{loc:Translate Nav_Kategorien}"
-                        Command="{Binding ShowKategorienCommand}" />
-                <Button Grid.Column="1"
-                        Text="{loc:Translate Lbl_Konto}"
-                        Command="{Binding ShowKontenCommand}" />
-            </Grid>
+            <Border Grid.Row="0"
+                    Margin="16,12"
+                    StrokeShape="RoundRectangle 10"
+                    Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray950}}"
+                    Padding="2">
+                <Grid ColumnDefinitions="*,*" ColumnSpacing="2">
+                    <Border Grid.Column="0"
+                            StrokeShape="RoundRectangle 8"
+                            Stroke="Transparent"
+                            BackgroundColor="{Binding IsKategorienVisible, Converter={StaticResource ToggleActiveColor}}"
+                            Padding="8,6">
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ShowKategorienCommand}" />
+                        </Border.GestureRecognizers>
+                        <Label Text="{loc:Translate Nav_Kategorien}"
+                               HorizontalTextAlignment="Center"
+                               FontAttributes="Bold"
+                               TextColor="{Binding IsKategorienVisible, Converter={StaticResource ToggleActiveText}}" />
+                    </Border>
+                    <Border Grid.Column="1"
+                            StrokeShape="RoundRectangle 8"
+                            Stroke="Transparent"
+                            BackgroundColor="{Binding IsKontenVisible, Converter={StaticResource ToggleActiveColor}}"
+                            Padding="8,6">
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ShowKontenCommand}" />
+                        </Border.GestureRecognizers>
+                        <Label Text="{loc:Translate Lbl_Konten}"
+                               HorizontalTextAlignment="Center"
+                               FontAttributes="Bold"
+                               TextColor="{Binding IsKontenVisible, Converter={StaticResource ToggleActiveText}}" />
+                    </Border>
+                </Grid>
+            </Border>
 
             <Grid Grid.Row="1">
                 <RefreshView Command="{Binding LoadKategorienCommand}"
@@ -35,7 +66,8 @@
                     <CollectionView ItemsSource="{Binding Kategorien}"
                                     SelectionMode="None">
                         <CollectionView.EmptyView>
-                            <controls:EmptyStateView IconText="🏷️"
+                            <controls:EmptyStateView IconImage="categories.png"
+                                                     IconAccessibilityDescription="{loc:Translate Nav_Kategorien}"
                                                      Message="{loc:Translate Empty_KeineKategorien}"
                                                      Hint="{loc:Translate Empty_HintKategorien}"
                                                      ActionText="{loc:Translate Btn_Hinzufuegen}"
@@ -71,7 +103,7 @@
 
                                         <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
                                             <Label Text="{Binding Name}" FontSize="16" FontAttributes="Bold" />
-                                            <Label Text="{Binding Typ}" FontSize="13" TextColor="Gray" />
+                                            <Label Text="{Binding Typ, Converter={StaticResource TransactionTypeToLocalizedStringConverter}}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                         </VerticalStackLayout>
 
                                         <Label Grid.Column="2" Text="{loc:Translate Btn_Next}" FontSize="24" TextColor="Gray"
@@ -107,7 +139,8 @@
                             </Border>
                         </CollectionView.Header>
                         <CollectionView.EmptyView>
-                            <controls:EmptyStateView IconText="🏦"
+                            <controls:EmptyStateView IconImage="categories.png"
+                                                     IconAccessibilityDescription="{loc:Translate Lbl_Konten}"
                                                      Message="{loc:Translate Empty_KeineKonten}"
                                                      Hint="{loc:Translate Empty_KontenHinweis}"
                                                      ActionText="{loc:Translate Btn_Hinzufuegen}"
@@ -128,8 +161,13 @@
                                             Stroke="Transparent"
                                             WidthRequest="44" HeightRequest="44"
                                             Padding="0" HorizontalOptions="Center" VerticalOptions="Center">
-                                        <Label Text="🏦" FontSize="20"
-                                               HorizontalOptions="Center" VerticalOptions="Center" />
+                                        <Image Source="categories.png"
+                                               HeightRequest="24"
+                                               WidthRequest="24"
+                                               Aspect="AspectFit"
+                                               HorizontalOptions="Center"
+                                               VerticalOptions="Center"
+                                               SemanticProperties.Description="{loc:Translate Lbl_Konto}" />
                                     </Border>
 
                                     <VerticalStackLayout Grid.Column="1" VerticalOptions="Center">
@@ -188,7 +226,7 @@
                 WidthRequest="56" HeightRequest="56"
                 HorizontalOptions="End" VerticalOptions="End"
                 Margin="0,0,20,20"
-                SemanticProperties.Description="{loc:Translate A11y_KategorieHinzufuegen}"
+                SemanticProperties.Description="{Binding FabAccessibilityDescription}"
                 Shadow="{Shadow Brush='#40000000', Offset='0,4', Radius=8}"
                 Command="{Binding GoToDetailCommand}" />
     </Grid>

--- a/Finanzuebersicht/Views/CategoryDetailPage.xaml.cs
+++ b/Finanzuebersicht/Views/CategoryDetailPage.xaml.cs
@@ -11,9 +11,27 @@ public partial class CategoryDetailPage : ContentPage, IQueryAttributable
         BindingContext = viewModel;
     }
 
+    protected override void OnAppearing()
+    {
+        base.OnAppearing();
+        App.LanguageChanged += OnLanguageChanged;
+    }
+
+    protected override void OnDisappearing()
+    {
+        App.LanguageChanged -= OnLanguageChanged;
+        base.OnDisappearing();
+    }
+
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
         if (BindingContext is IApplyQueryAttributes vm)
             vm.ApplyQueryAttributes(query);
+    }
+
+    private void OnLanguageChanged()
+    {
+        if (BindingContext is ILocalizableViewModel vm)
+            vm.RefreshLocalizedStrings();
     }
 }

--- a/Finanzuebersicht/Views/DashboardPage.xaml
+++ b/Finanzuebersicht/Views/DashboardPage.xaml
@@ -9,7 +9,7 @@
              xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.DashboardPage"
              x:DataType="vm:DashboardViewModel"
-             Title="Dashboard">
+             Title="{loc:Translate Nav_Dashboard}">
 
     <ContentPage.Resources>
         <conv:BilanzColorConverter x:Key="BilanzColor" />
@@ -30,7 +30,36 @@
         <ScrollView>
             <VerticalStackLayout Spacing="16" Padding="16">
 
-                <!-- Fällige Daueraufträge Widget -->
+                <!-- Kern-Kennzahlen zuerst -->
+                <Border StrokeShape="RoundRectangle 12"
+                        Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                        Padding="14"
+                        IsVisible="{Binding ShowDashboardSummary}">
+                    <Grid ColumnDefinitions="*, *" ColumnSpacing="16">
+                        <VerticalStackLayout Spacing="4">
+                            <Label Text="{Binding SummarySaldoLabel}"
+                                   FontSize="12"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
+                            <Label Text="{Binding SummarySaldo, Converter={StaticResource Currency}}"
+                                   FontSize="24"
+                                   FontAttributes="Bold"
+                                   TextColor="{Binding SummarySaldo, Converter={StaticResource BilanzColor}}" />
+                        </VerticalStackLayout>
+                        <VerticalStackLayout Grid.Column="1" Spacing="4"
+                                             IsVisible="{Binding ShowSummaryBilanz}">
+                            <Label Text="{loc:Translate Lbl_Bilanz}"
+                                   FontSize="12"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
+                            <Label Text="{Binding Bilanz, Converter={StaticResource BilanzDisplay}}"
+                                   TextColor="{Binding Bilanz, Converter={StaticResource BilanzColor}}"
+                                   FontSize="24"
+                                   FontAttributes="Bold" />
+                        </VerticalStackLayout>
+                    </Grid>
+                </Border>
+
+                <!-- Fällige Daueraufträge – kompakter Hinweis -->
                 <Border StrokeShape="RoundRectangle 12"
                         Stroke="{StaticResource ReminderBannerBorder}"
                         BackgroundColor="{AppThemeBinding Light={StaticResource ReminderBannerBackground}, Dark={StaticResource ReminderBannerBackgroundDark}}"
@@ -38,33 +67,47 @@
                         IsVisible="{Binding HasDueItems}"
                         SemanticProperties.Description="{Binding DueRecurringText}"
                         SemanticProperties.Hint="{loc:Translate A11y_DauerauftraegeBannerHint}">
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding NavigateToDauerauftraegeCommand}" />
-                    </Border.GestureRecognizers>
-                    <Grid ColumnDefinitions="*, Auto">
+                    <Grid ColumnDefinitions="*, Auto, Auto" ColumnSpacing="8">
                         <Label Grid.Column="0"
                                Text="{Binding DueRecurringText}"
                                FontSize="14" VerticalTextAlignment="Center"
-                               TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
-                        <Label Grid.Column="1" Text="›" FontSize="20" FontAttributes="Bold"
+                               TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding NavigateToDauerauftraegeCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                        <Label Grid.Column="1"
+                               Text="{Binding DueDetailsChevron}"
+                               FontSize="14"
+                               VerticalTextAlignment="Center"
+                               TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding ToggleDueDetailsCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
+                        <Label Grid.Column="2" Text="›" FontSize="20" FontAttributes="Bold"
                                VerticalTextAlignment="Center"
                                AutomationProperties.IsInAccessibleTree="False"
-                               TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}" />
+                               TextColor="{AppThemeBinding Light={StaticResource ReminderBannerText}, Dark={StaticResource ReminderBannerTextDark}}">
+                            <Label.GestureRecognizers>
+                                <TapGestureRecognizer Command="{Binding NavigateToDauerauftraegeCommand}" />
+                            </Label.GestureRecognizers>
+                        </Label>
                     </Grid>
                 </Border>
 
                 <VerticalStackLayout Spacing="8"
-                                     IsVisible="{Binding HasDueItems}"
+                                     IsVisible="{Binding ShowDueDetailsList}"
                                      BindableLayout.ItemsSource="{Binding DueRecurringItems}">
                     <BindableLayout.ItemTemplate>
                         <DataTemplate x:DataType="recurring:DueRecurringItem">
                             <Border StrokeShape="RoundRectangle 10"
-                                    Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                                    BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                                    Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                                    BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
                                     Padding="12">
                                 <VerticalStackLayout Spacing="8">
                                     <Label Text="{Binding Recurring.Titel}" FontSize="15" FontAttributes="Bold" />
-                                    <Label Text="{Binding Hint}" FontSize="13" TextColor="Gray" />
+                                    <Label Text="{Binding Hint}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                     <Button Text="{loc:Translate Btn_Buchen}"
                                             FontSize="14"
                                             HeightRequest="44"
@@ -91,179 +134,213 @@
                     </BindableLayout.ItemTemplate>
                 </VerticalStackLayout>
 
-                <Border StrokeShape="RoundRectangle 12"
-                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
-                        Padding="14"
-                        IsVisible="{Binding ShowDashboardSummary}">
-                    <Grid ColumnDefinitions="*, *" ColumnSpacing="16">
-                        <VerticalStackLayout Spacing="4">
-                            <Label Text="{Binding SummarySaldoLabel}"
-                                   FontSize="12"
-                                   TextColor="Gray" />
-                            <Label Text="{Binding SummarySaldo, Converter={StaticResource Currency}}"
-                                   FontSize="20"
-                                   FontAttributes="Bold"
-                                   TextColor="{Binding SummarySaldo, Converter={StaticResource BilanzColor}}" />
-                        </VerticalStackLayout>
-                        <VerticalStackLayout Grid.Column="1" Spacing="4"
-                                             IsVisible="{Binding ShowSummaryBilanz}">
-                            <Label Text="{loc:Translate Lbl_Bilanz}"
-                                   FontSize="12"
-                                   TextColor="Gray" />
-                            <Label Text="{Binding Bilanz, Converter={StaticResource BilanzDisplay}}"
-                                   TextColor="{Binding Bilanz, Converter={StaticResource BilanzColor}}"
-                                   FontSize="20"
-                                   FontAttributes="Bold" />
-                        </VerticalStackLayout>
-                    </Grid>
-                </Border>
-
-                <Border StrokeShape="RoundRectangle 12"
-                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
-                        Padding="14"
-                        IsVisible="{Binding HasKontenUebersicht}">
-                    <VerticalStackLayout Spacing="12">
+                <!-- Kontenübersicht (einklappbar) -->
+                <VerticalStackLayout Spacing="8" IsVisible="{Binding HasKontenUebersicht}">
+                    <Grid ColumnDefinitions="*, Auto, Auto" ColumnSpacing="8">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ToggleAccountsSectionCommand}" />
+                        </Grid.GestureRecognizers>
                         <Label Text="{loc:Translate Lbl_KontenUebersicht}"
                                FontSize="16"
-                               FontAttributes="Bold" />
-                        <Grid ColumnDefinitions="*, Auto">
-                            <Label Text="{loc:Translate Lbl_Gesamtsaldo}"
-                                   FontSize="14"
-                                   TextColor="Gray"
-                                   VerticalTextAlignment="Center" />
-                            <Label Grid.Column="1"
-                                   Text="{Binding GesamtSaldo, Converter={StaticResource Currency}}"
-                                   FontSize="20"
-                                   FontAttributes="Bold"
-                                   TextColor="{Binding GesamtSaldo, Converter={StaticResource BilanzColor}}" />
-                        </Grid>
-                        <VerticalStackLayout BindableLayout.ItemsSource="{Binding KontenUebersicht}"
-                                             Spacing="10">
-                            <BindableLayout.ItemTemplate>
-                                <DataTemplate x:DataType="vm:AccountOverviewItem">
-                                    <VerticalStackLayout Spacing="4"
-                                                         SemanticProperties.Hint="{loc:Translate A11y_KontoUebersichtTippen}">
-                                        <VerticalStackLayout.GestureRecognizers>
-                                            <TapGestureRecognizer
-                                                Command="{Binding Source={RelativeSource AncestorType={x:Type vm:DashboardViewModel}}, Path=SelectKontoFromOverviewCommand}"
-                                                CommandParameter="{Binding .}" />
-                                        </VerticalStackLayout.GestureRecognizers>
-                                        <Grid ColumnDefinitions="*, Auto">
-                                            <Label Text="{Binding Name}"
-                                                   FontSize="14"
-                                                   VerticalTextAlignment="Center" />
-                                            <Label Grid.Column="1"
-                                                   Text="{Binding Saldo, Converter={StaticResource Currency}}"
-                                                   FontSize="14"
-                                                   FontAttributes="Bold"
-                                                   TextColor="{Binding Saldo, Converter={StaticResource BilanzColor}}" />
-                                        </Grid>
-                                        <ProgressBar
-                                            Progress="{Binding AnteilProzent, Converter={StaticResource ProzentToWidth}}"
-                                            ProgressColor="{Binding Saldo, Converter={StaticResource BilanzColor}}"
-                                            BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}" />
-                                    </VerticalStackLayout>
-                                </DataTemplate>
-                            </BindableLayout.ItemTemplate>
-                        </VerticalStackLayout>
-                    </VerticalStackLayout>
-                </Border>
-
-                <Grid ColumnDefinitions="70,*" ColumnSpacing="8">
-                    <Label Grid.Column="0"
-                           Text="{loc:Translate Lbl_Konto}"
-                           FontSize="13"
-                           TextColor="Gray"
-                           VerticalTextAlignment="Center" />
-                    <controls:SelectionField Grid.Column="1"
-                                             ItemsSource="{Binding AvailableKonten}"
-                                             SelectedItem="{Binding SelectedKontoFilterItem, Mode=TwoWay}"
-                                             DisplayMemberPath="DisplayName"
-                                             Placeholder="{loc:Translate Lbl_AlleKonten}" />
-                </Grid>
-
-                <Grid ColumnDefinitions="70,*" ColumnSpacing="8"
-                      IsVisible="{Binding HasSelectedAccountSaldo}">
-                    <Label Grid.Column="0"
-                           Text="{loc:Translate Lbl_Kontosaldo}"
-                           FontSize="13"
-                           TextColor="Gray"
-                           VerticalTextAlignment="Center" />
-                    <Label Grid.Column="1"
-                           Text="{Binding SelectedAccountSaldo, Converter={StaticResource Currency}}"
-                           FontSize="15"
-                           FontAttributes="Bold"
-                           TextColor="{Binding SelectedAccountSaldo, Converter={StaticResource BilanzColor}}"
-                           VerticalTextAlignment="Center" />
-                </Grid>
-
-                <Border StrokeShape="RoundRectangle 12"
-                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
-                        Padding="14"
-                        IsVisible="{Binding HasCashflowPreview}">
-                    <Border.GestureRecognizers>
-                        <TapGestureRecognizer Command="{Binding NavigateToCashflowCommand}" />
-                    </Border.GestureRecognizers>
-                    <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto, Auto" RowSpacing="6">
-                        <Label Grid.Row="0" Grid.Column="0"
-                               Text="{loc:Translate Lbl_Cashflow30Tage}"
-                               FontSize="16"
                                FontAttributes="Bold"
                                VerticalTextAlignment="Center" />
-                        <Label Grid.Row="0" Grid.Column="1"
-                               Text="›"
-                               FontSize="20"
+                        <Label Grid.Column="1"
+                               Text="{Binding GesamtSaldo, Converter={StaticResource Currency}}"
+                               FontSize="14"
                                FontAttributes="Bold"
-                               VerticalTextAlignment="Center"
-                               AutomationProperties.IsInAccessibleTree="False" />
-                        <Label Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
-                               Text="{loc:Translate Lbl_CashflowNetto}"
-                               FontSize="12"
-                               TextColor="Gray" />
-                        <Label Grid.Row="2" Grid.Column="0"
-                               Text="{Binding CashflowNetAmount, Converter={StaticResource Currency}}"
-                               FontSize="18"
-                               FontAttributes="Bold"
-                               TextColor="{Binding CashflowNetAmount, Converter={StaticResource BilanzColor}}" />
-                        <Label Grid.Row="2" Grid.Column="1"
-                               Text="{Binding CashflowSummaryText}"
-                               FontSize="12"
-                               TextColor="Gray"
-                               HorizontalTextAlignment="End"
+                               IsVisible="{Binding IsAccountsSectionExpanded, Converter={StaticResource InvertBool}}"
+                               TextColor="{Binding GesamtSaldo, Converter={StaticResource BilanzColor}}"
+                               VerticalTextAlignment="Center" />
+                        <Label Grid.Column="2"
+                               Text="{Binding AccountsSectionChevron}"
+                               FontSize="14"
+                               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                                VerticalTextAlignment="Center" />
                     </Grid>
-                </Border>
+                    <Border StrokeShape="RoundRectangle 12"
+                            Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                            Padding="14"
+                            IsVisible="{Binding IsAccountsSectionExpanded}">
+                        <VerticalStackLayout Spacing="12">
+                            <Grid ColumnDefinitions="*, Auto">
+                                <Label Text="{loc:Translate Lbl_Gesamtsaldo}"
+                                       FontSize="14"
+                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
+                                       VerticalTextAlignment="Center" />
+                                <Label Grid.Column="1"
+                                       Text="{Binding GesamtSaldo, Converter={StaticResource Currency}}"
+                                       FontSize="20"
+                                       FontAttributes="Bold"
+                                       TextColor="{Binding GesamtSaldo, Converter={StaticResource BilanzColor}}" />
+                            </Grid>
+                            <VerticalStackLayout BindableLayout.ItemsSource="{Binding KontenUebersicht}"
+                                                 Spacing="10">
+                                <BindableLayout.ItemTemplate>
+                                    <DataTemplate x:DataType="vm:AccountOverviewItem">
+                                        <VerticalStackLayout Spacing="4"
+                                                             SemanticProperties.Hint="{loc:Translate A11y_KontoUebersichtTippen}">
+                                            <VerticalStackLayout.GestureRecognizers>
+                                                <TapGestureRecognizer
+                                                    Command="{Binding Source={RelativeSource AncestorType={x:Type vm:DashboardViewModel}}, Path=SelectKontoFromOverviewCommand}"
+                                                    CommandParameter="{Binding .}" />
+                                            </VerticalStackLayout.GestureRecognizers>
+                                            <Grid ColumnDefinitions="*, Auto">
+                                                <Label Text="{Binding Name}"
+                                                       FontSize="14"
+                                                       VerticalTextAlignment="Center" />
+                                                <Label Grid.Column="1"
+                                                       Text="{Binding Saldo, Converter={StaticResource Currency}}"
+                                                       FontSize="14"
+                                                       FontAttributes="Bold"
+                                                       TextColor="{Binding Saldo, Converter={StaticResource BilanzColor}}" />
+                                            </Grid>
+                                            <ProgressBar
+                                                Progress="{Binding AnteilProzent, Converter={StaticResource ProzentToWidth}}"
+                                                ProgressColor="{Binding Saldo, Converter={StaticResource BilanzColor}}"
+                                                BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}" />
+                                        </VerticalStackLayout>
+                                    </DataTemplate>
+                                </BindableLayout.ItemTemplate>
+                            </VerticalStackLayout>
+                        </VerticalStackLayout>
+                    </Border>
+                </VerticalStackLayout>
 
-                <Border StrokeShape="RoundRectangle 12"
-                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
-                        Padding="14"
-                        IsVisible="{Binding HasCashflowPreview, Converter={StaticResource InvertBool}}">
-                    <VerticalStackLayout Spacing="6">
+                <!-- Konto-Filter (einklappbar) -->
+                <VerticalStackLayout Spacing="8" IsVisible="{Binding ShowSecondarySections}">
+                    <Grid ColumnDefinitions="*, Auto">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ToggleFilterSectionCommand}" />
+                        </Grid.GestureRecognizers>
+                        <Label Text="{loc:Translate Btn_Filter}"
+                               FontSize="16"
+                               FontAttributes="Bold"
+                               VerticalTextAlignment="Center" />
+                        <Label Grid.Column="1"
+                               Text="{Binding FilterSectionChevron}"
+                               FontSize="14"
+                               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
+                               VerticalTextAlignment="Center" />
+                    </Grid>
+                    <VerticalStackLayout Spacing="8" IsVisible="{Binding IsFilterSectionExpanded}">
+                        <Grid ColumnDefinitions="70,*" ColumnSpacing="8">
+                            <Label Grid.Column="0"
+                                   Text="{loc:Translate Lbl_Konto}"
+                                   FontSize="13"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
+                                   VerticalTextAlignment="Center" />
+                            <controls:SelectionField Grid.Column="1"
+                                                     ItemsSource="{Binding AvailableKonten}"
+                                                     SelectedItem="{Binding SelectedKontoFilterItem, Mode=TwoWay}"
+                                                     DisplayMemberPath="DisplayName"
+                                                     Placeholder="{loc:Translate Lbl_AlleKonten}" />
+                        </Grid>
+                        <Grid ColumnDefinitions="70,*" ColumnSpacing="8"
+                              IsVisible="{Binding HasSelectedAccountSaldo}">
+                            <Label Grid.Column="0"
+                                   Text="{loc:Translate Lbl_Kontosaldo}"
+                                   FontSize="13"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
+                                   VerticalTextAlignment="Center" />
+                            <Label Grid.Column="1"
+                                   Text="{Binding SelectedAccountSaldo, Converter={StaticResource Currency}}"
+                                   FontSize="15"
+                                   FontAttributes="Bold"
+                                   TextColor="{Binding SelectedAccountSaldo, Converter={StaticResource BilanzColor}}"
+                                   VerticalTextAlignment="Center" />
+                        </Grid>
+                    </VerticalStackLayout>
+                </VerticalStackLayout>
+
+                <!-- Cashflow-Vorschau (einklappbar) -->
+                <VerticalStackLayout Spacing="8" IsVisible="{Binding ShowSecondarySections}">
+                    <Grid ColumnDefinitions="*, Auto, Auto" ColumnSpacing="8">
+                        <Grid.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding ToggleCashflowSectionCommand}" />
+                        </Grid.GestureRecognizers>
                         <Label Text="{loc:Translate Lbl_Cashflow30Tage}"
                                FontSize="16"
-                               FontAttributes="Bold" />
-                        <Label Text="{loc:Translate Empty_KeinCashflow}"
+                               FontAttributes="Bold"
+                               VerticalTextAlignment="Center" />
+                        <Label Grid.Column="1"
+                               Text="{Binding CashflowNetAmount, Converter={StaticResource Currency}}"
                                FontSize="14"
-                               TextColor="Gray" />
-                        <Label Text="{loc:Translate Empty_HintCashflow}"
-                               FontSize="12"
-                               TextColor="Gray" />
-                        <Button Text="{loc:Translate Nav_Cashflow}"
-                                Command="{Binding NavigateToCashflowCommand}"
-                                BackgroundColor="Transparent"
-                                TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                                FontSize="14"
-                                HorizontalOptions="Start"
-                                Padding="0" />
-                    </VerticalStackLayout>
-                </Border>
+                               FontAttributes="Bold"
+                               IsVisible="{Binding ShowCashflowCompact}"
+                               TextColor="{Binding CashflowNetAmount, Converter={StaticResource BilanzColor}}"
+                               VerticalTextAlignment="Center" />
+                        <Label Grid.Column="2"
+                               Text="{Binding CashflowSectionChevron}"
+                               FontSize="14"
+                               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
+                               VerticalTextAlignment="Center" />
+                    </Grid>
+
+                    <Border StrokeShape="RoundRectangle 12"
+                            Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                            Padding="14"
+                            IsVisible="{Binding ShowCashflowExpanded}">
+                        <Border.GestureRecognizers>
+                            <TapGestureRecognizer Command="{Binding NavigateToCashflowCommand}" />
+                        </Border.GestureRecognizers>
+                        <Grid ColumnDefinitions="*, Auto" RowDefinitions="Auto, Auto, Auto" RowSpacing="6">
+                            <Label Grid.Row="0" Grid.Column="0"
+                                   Text="{loc:Translate Lbl_Cashflow30Tage}"
+                                   FontSize="16"
+                                   FontAttributes="Bold"
+                                   VerticalTextAlignment="Center" />
+                            <Label Grid.Row="0" Grid.Column="1"
+                                   Text="›"
+                                   FontSize="20"
+                                   FontAttributes="Bold"
+                                   VerticalTextAlignment="Center"
+                                   AutomationProperties.IsInAccessibleTree="False" />
+                            <Label Grid.Row="1" Grid.Column="0" Grid.ColumnSpan="2"
+                                   Text="{loc:Translate Lbl_CashflowNetto}"
+                                   FontSize="12"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
+                            <Label Grid.Row="2" Grid.Column="0"
+                                   Text="{Binding CashflowNetAmount, Converter={StaticResource Currency}}"
+                                   FontSize="18"
+                                   FontAttributes="Bold"
+                                   TextColor="{Binding CashflowNetAmount, Converter={StaticResource BilanzColor}}" />
+                            <Label Grid.Row="2" Grid.Column="1"
+                                   Text="{Binding CashflowSummaryText}"
+                                   FontSize="12"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
+                                   HorizontalTextAlignment="End"
+                                   VerticalTextAlignment="Center" />
+                        </Grid>
+                    </Border>
+
+                    <Border StrokeShape="RoundRectangle 12"
+                            Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                            Padding="14"
+                            IsVisible="{Binding ShowCashflowEmptyLink}">
+                        <VerticalStackLayout Spacing="6">
+                            <Label Text="{loc:Translate Empty_KeinCashflow}"
+                                   FontSize="14"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
+                            <Label Text="{loc:Translate Empty_HintCashflow}"
+                                   FontSize="12"
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
+                            <Button Text="{loc:Translate Nav_Cashflow}"
+                                    Command="{Binding NavigateToCashflowCommand}"
+                                    BackgroundColor="Transparent"
+                                    TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                                    FontSize="14"
+                                    HorizontalOptions="Start"
+                                    Padding="0" />
+                        </VerticalStackLayout>
+                    </Border>
+                </VerticalStackLayout>
 
                 <!-- Global Empty State – keine Transaktionen vorhanden -->
-                <controls:EmptyStateView IconText="📊"
+                <controls:EmptyStateView IconImage="dashboard.png"
+                                         IconAccessibilityDescription="{loc:Translate Nav_Dashboard}"
                                          Message="{loc:Translate Empty_NochKeineTransaktionen}"
                                          ActionText="{loc:Translate Btn_ZuTransaktionen}"
                                          ActionCommand="{Binding NavigateToTransaktionenCommand}"
@@ -274,7 +351,7 @@
 
                 <!-- Ansicht-Umschalter -->
                 <Border StrokeShape="RoundRectangle 10"
-                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                        Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                         BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#2C2C2E}" Padding="2">
                     <Grid ColumnDefinitions="*, *" ColumnSpacing="2">
                         <Border Grid.Column="0" StrokeShape="RoundRectangle 8" Stroke="Transparent"
@@ -314,7 +391,7 @@
                         <Label Text="{Binding MonatAnzeige}"
                                FontSize="20" FontAttributes="Bold"
                                HorizontalTextAlignment="Center" />
-                        <Label Text="{loc:Translate Lbl_Prognose}" FontSize="12" TextColor="Gray"
+                        <Label Text="{loc:Translate Lbl_Prognose}" FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                                HorizontalTextAlignment="Center"
                                IsVisible="{Binding IstPrognose}" />
                     </VerticalStackLayout>
@@ -358,7 +435,7 @@
                             BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
                             Padding="12">
                         <VerticalStackLayout Spacing="4">
-                            <Label Text="{loc:Translate Lbl_Bilanz}" FontSize="11" TextColor="Gray" />
+                            <Label Text="{loc:Translate Lbl_Bilanz}" FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                             <Label Text="{Binding Bilanz, Converter={StaticResource BilanzDisplay}}"
                                    TextColor="{Binding Bilanz, Converter={StaticResource BilanzColor}}"
                                    FontSize="15" FontAttributes="Bold" />
@@ -381,12 +458,12 @@
                         <Label Grid.Column="1"
                                Text="{Binding BudgetSectionChevron}"
                                FontSize="14"
-                               TextColor="Gray"
+                               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                                VerticalTextAlignment="Center" />
                     </Grid>
                 <Border StrokeShape="RoundRectangle 12"
-                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                        BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                        Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
                         Padding="12"
                         IsVisible="{Binding IsBudgetSectionExpanded}">
                     <VerticalStackLayout Spacing="10">
@@ -402,17 +479,17 @@
                             <Label Grid.Column="0"
                                    Text="{loc:Translate Lbl_BudgetVerbraucht}"
                                    FontSize="13"
-                                   TextColor="Gray" />
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                             <HorizontalStackLayout Grid.Column="1" Spacing="4">
                                 <Label Text="{Binding BudgetVerbraucht, Converter={StaticResource Currency}}"
                                        FontSize="13"
                                        FontAttributes="Bold" />
                                 <Label Text="{loc:Translate Lbl_Von}"
                                        FontSize="13"
-                                       TextColor="Gray" />
+                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                 <Label Text="{Binding BudgetGesamt, Converter={StaticResource Currency}}"
                                        FontSize="13"
-                                       TextColor="Gray" />
+                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                             </HorizontalStackLayout>
                         </Grid>
 
@@ -421,7 +498,7 @@
                             <Label Grid.Column="0"
                                    Text="{loc:Translate Lbl_TagesbudgetBisMonatsende}"
                                    FontSize="13"
-                                   TextColor="Gray" />
+                                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                             <Label Grid.Column="1"
                                    Text="{Binding BudgetTagesbudget, Converter={StaticResource Currency}}"
                                    FontSize="13"
@@ -452,7 +529,7 @@
                                         <ProgressBar
                                             Progress="{Binding VerbrauchProzent, Converter={StaticResource ProzentToWidth}}"
                                             ProgressColor="{Binding IstAusgeschoepft, Converter={StaticResource BudgetProgressColor}}"
-                                            BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                                             SemanticProperties.Description="{loc:Translate A11y_BudgetBalken}" />
                                         <Grid ColumnDefinitions="*, Auto">
                                             <Label Grid.Column="0"
@@ -468,13 +545,13 @@
                                             <HorizontalStackLayout Grid.Column="1" Spacing="2">
                                                 <Label Text="{Binding Verbrauch, Converter={StaticResource Currency}}"
                                                        FontSize="11"
-                                                       TextColor="Gray" />
+                                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                                 <Label Text="{loc:Translate Lbl_Von}"
                                                        FontSize="11"
-                                                       TextColor="Gray" />
+                                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                                 <Label Text="{Binding BudgetBetrag, Converter={StaticResource Currency}}"
                                                        FontSize="11"
-                                                       TextColor="Gray" />
+                                                       TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                             </HorizontalStackLayout>
                                         </Grid>
                                     </VerticalStackLayout>
@@ -519,7 +596,7 @@
                                     <ProgressBar
                                         Progress="{Binding BudgetAusgeschoepft, Converter={StaticResource ProzentToWidth}}"
                                         ProgressColor="{Binding IstUeberBudget, Converter={StaticResource BudgetProgressColor}}"
-                                        BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                                         SemanticProperties.Description="{loc:Translate A11y_BudgetBalken}"
                                         VerticalOptions="Center" />
                                     <!-- Über Budget: rote Warnung mit Überschreitungsbetrag -->
@@ -544,9 +621,9 @@
                                         IsVisible="{Binding IstUeberBudget, Converter={StaticResource InvertBool}}"
                                         HorizontalOptions="End" Spacing="2">
                                         <Label Text="{loc:Translate Lbl_Von}"
-                                               FontSize="11" TextColor="Gray" />
+                                               FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                         <Label Text="{Binding BudgetBetrag, Converter={StaticResource Currency}}"
-                                               FontSize="11" TextColor="Gray" />
+                                               FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                                     </HorizontalStackLayout>
                                 </VerticalStackLayout>
                             </VerticalStackLayout>
@@ -584,7 +661,7 @@
 
                 <!-- Forecast nächster Monat -->
                 <Border StrokeShape="RoundRectangle 12"
-                        Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                        Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                         BackgroundColor="{AppThemeBinding Light=#F2F2F7, Dark=#2C2C2E}"
                         Padding="12"
                         Margin="0,8,0,0"
@@ -605,7 +682,7 @@
 
                 <!-- Empty State Monatsansicht -->
                 <Label Text="{loc:Translate Empty_KeineDashboardDaten}"
-                       FontSize="15" TextColor="Gray"
+                       FontSize="15" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                        HorizontalTextAlignment="Center" Margin="0,24,0,0"
                        IsVisible="{Binding HasMonthData, Converter={StaticResource InvertBool}}" />
 
@@ -656,7 +733,7 @@
                         <Label Grid.Column="1"
                                Text="{Binding YearDetailsChevron}"
                                FontSize="14"
-                               TextColor="Gray"
+                               TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                                VerticalTextAlignment="Center" />
                     </Grid>
 
@@ -699,7 +776,7 @@
                                            TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}" VerticalTextAlignment="Center" />
                                     <Label Grid.Column="3"
                                            Text="{Binding PercentageDisplay}"
-                                           FontSize="13" TextColor="Gray"
+                                           FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                                            VerticalTextAlignment="Center" />
                                 </Grid>
                             </VerticalStackLayout>
@@ -711,7 +788,7 @@
 
                 <!-- Empty State Jahresansicht -->
                 <Label Text="{loc:Translate Empty_KeineJahresDaten}"
-                       FontSize="15" TextColor="Gray"
+                       FontSize="15" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                        HorizontalTextAlignment="Center" Margin="0,24,0,0"
                        IsVisible="{Binding HasYearData, Converter={StaticResource InvertBool}}" />
 

--- a/Finanzuebersicht/Views/DashboardPage.xaml.cs
+++ b/Finanzuebersicht/Views/DashboardPage.xaml.cs
@@ -64,6 +64,7 @@ public partial class DashboardPage : ContentPage
 
         App.DataChanged += OnAppDataChanged;
         App.LanguageChanged += OnLanguageChanged;
+        App.CurrencyChanged += OnLanguageChanged;
     }
 
     protected override void OnDisappearing()
@@ -71,6 +72,7 @@ public partial class DashboardPage : ContentPage
         base.OnDisappearing();
         App.DataChanged -= OnAppDataChanged;
         App.LanguageChanged -= OnLanguageChanged;
+        App.CurrencyChanged -= OnLanguageChanged;
     }
 
     private void OnLanguageChanged()

--- a/Finanzuebersicht/Views/ImportPreviewPage.xaml
+++ b/Finanzuebersicht/Views/ImportPreviewPage.xaml
@@ -33,7 +33,8 @@
         </Border>
 
         <controls:EmptyStateView Grid.Row="1"
-                                 IconText="📄"
+                                 IconImage="transactions.png"
+                                 IconAccessibilityDescription="{loc:Translate Ttl_ImportVorschau}"
                                  Message="{loc:Translate Empty_ImportVorschauLeer}"
                                  IsVisible="{Binding HasRows, Converter={StaticResource InvertBool}}" />
 

--- a/Finanzuebersicht/Views/OnboardingPage.xaml
+++ b/Finanzuebersicht/Views/OnboardingPage.xaml
@@ -35,6 +35,38 @@
                    TextColor="Gray"
                    HorizontalTextAlignment="Center" />
 
+            <VerticalStackLayout Spacing="12" IsVisible="{Binding ShowWelcomeSetup}">
+                <Label Text="{loc:Translate Lbl_Anzeigewaehrung}"
+                       FontSize="15"
+                       FontAttributes="Bold"
+                       HorizontalTextAlignment="Center" />
+                <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="8">
+                    <Button Text="{loc:Translate Stn_CurrencyEur}"
+                            Command="{Binding SetCurrencyCommand}"
+                            CommandParameter="0"
+                            BackgroundColor="{Binding SelectedCurrencyIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=0}"
+                            TextColor="{Binding SelectedCurrencyIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=0}" />
+                    <Button Text="{loc:Translate Stn_CurrencyChf}"
+                            Grid.Column="1"
+                            Command="{Binding SetCurrencyCommand}"
+                            CommandParameter="1"
+                            BackgroundColor="{Binding SelectedCurrencyIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=1}"
+                            TextColor="{Binding SelectedCurrencyIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=1}" />
+                    <Button Text="{loc:Translate Stn_CurrencyUsd}"
+                            Grid.Column="2"
+                            Command="{Binding SetCurrencyCommand}"
+                            CommandParameter="2"
+                            BackgroundColor="{Binding SelectedCurrencyIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=2}"
+                            TextColor="{Binding SelectedCurrencyIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=2}" />
+                    <Button Text="{loc:Translate Stn_CurrencyGbp}"
+                            Grid.Column="3"
+                            Command="{Binding SetCurrencyCommand}"
+                            CommandParameter="3"
+                            BackgroundColor="{Binding SelectedCurrencyIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=3}"
+                            TextColor="{Binding SelectedCurrencyIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=3}" />
+                </Grid>
+            </VerticalStackLayout>
+
             <VerticalStackLayout Spacing="12" IsVisible="{Binding ShowAccountActions}">
                 <Button Text="{loc:Translate Onboarding_Btn_Anfangssaldo}"
                         Command="{Binding OpenDefaultAccountCommand}"

--- a/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionsPage.xaml
@@ -9,7 +9,7 @@
              xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.RecurringTransactionsPage"
              x:DataType="vm:RecurringTransactionsViewModel"
-             Title="Daueraufträge">
+             Title="{loc:Translate Nav_Dauerauftraege}">
 
     <views:BaseContentPage.Resources>
         <conv:TransactionTypToColorConverter x:Key="TypToColor" />
@@ -25,7 +25,8 @@
                         SelectionMode="None">
 
             <CollectionView.EmptyView>
-                <controls:EmptyStateView IconText="🔄"
+                <controls:EmptyStateView IconImage="recurring.png"
+                                         IconAccessibilityDescription="{loc:Translate Nav_Dauerauftraege}"
                                          Message="{loc:Translate Empty_KeineDauerauftraege}"
                                          Hint="{loc:Translate Empty_HintDauerauftraege}"
                                          ActionText="{loc:Translate Btn_ErsterDauerauftrag}"

--- a/Finanzuebersicht/Views/SettingsPage.xaml
+++ b/Finanzuebersicht/Views/SettingsPage.xaml
@@ -5,7 +5,7 @@
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.SettingsPage"
              x:DataType="vm:SettingsViewModel"
-             Title="Einstellungen"
+             Title="{loc:Translate Nav_Einstellungen}"
              BackgroundColor="{AppThemeBinding Light={StaticResource PageBackground}, Dark={StaticResource PageBackgroundDark}}">
 
     <Grid RowDefinitions="*, Auto">
@@ -74,6 +74,45 @@
                                 CommandParameter="2"
                                 BackgroundColor="{Binding Appearance.SelectedLanguageIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=2}"
                                 TextColor="{Binding Appearance.SelectedLanguageIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=2}" />
+                    </Grid>
+                </VerticalStackLayout>
+            </Border>
+
+            <!-- Anzeige-Währung -->
+            <Border StrokeShape="RoundRectangle 12"
+                    Stroke="{AppThemeBinding Light={StaticResource Separator}, Dark={StaticResource SeparatorDark}}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+                    Padding="16">
+                <VerticalStackLayout Spacing="12">
+                    <Label Text="{loc:Translate Lbl_Anzeigewaehrung}"
+                           FontSize="18"
+                           FontAttributes="Bold"
+                           TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource TextPrimaryDark}}" />
+
+                    <Grid ColumnDefinitions="*,*,*,*" ColumnSpacing="8">
+                        <Button Text="{loc:Translate Stn_CurrencyEur}"
+                                Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.Appearance.SetCurrencyCommand}"
+                                CommandParameter="0"
+                                BackgroundColor="{Binding Appearance.SelectedCurrencyIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=0}"
+                                TextColor="{Binding Appearance.SelectedCurrencyIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=0}" />
+                        <Button Text="{loc:Translate Stn_CurrencyChf}"
+                                Grid.Column="1"
+                                Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.Appearance.SetCurrencyCommand}"
+                                CommandParameter="1"
+                                BackgroundColor="{Binding Appearance.SelectedCurrencyIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=1}"
+                                TextColor="{Binding Appearance.SelectedCurrencyIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=1}" />
+                        <Button Text="{loc:Translate Stn_CurrencyUsd}"
+                                Grid.Column="2"
+                                Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.Appearance.SetCurrencyCommand}"
+                                CommandParameter="2"
+                                BackgroundColor="{Binding Appearance.SelectedCurrencyIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=2}"
+                                TextColor="{Binding Appearance.SelectedCurrencyIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=2}" />
+                        <Button Text="{loc:Translate Stn_CurrencyGbp}"
+                                Grid.Column="3"
+                                Command="{Binding Source={RelativeSource AncestorType={x:Type ContentPage}}, Path=BindingContext.Appearance.SetCurrencyCommand}"
+                                CommandParameter="3"
+                                BackgroundColor="{Binding Appearance.SelectedCurrencyIndex, Converter={StaticResource ThemeButtonConverter}, ConverterParameter=3}"
+                                TextColor="{Binding Appearance.SelectedCurrencyIndex, Converter={StaticResource ThemeButtonTextConverter}, ConverterParameter=3}" />
                     </Grid>
                 </VerticalStackLayout>
             </Border>

--- a/Finanzuebersicht/Views/SparZielDetailPage.xaml
+++ b/Finanzuebersicht/Views/SparZielDetailPage.xaml
@@ -19,35 +19,35 @@
         <VerticalStackLayout Spacing="20">
 
             <VerticalStackLayout Spacing="8">
-                <Label Text="{Binding FortschrittText}" FontSize="14" TextColor="Gray" />
+                <Label Text="{Binding FortschrittText}" FontSize="14" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                 <ProgressBar Progress="{Binding FortschrittProzent, Converter={StaticResource ProzentToWidth}}"
                              ProgressColor="{AppThemeBinding Light={StaticResource Einnahme}, Dark={StaticResource EinnahmeDark}}"
-                             BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                             BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                              SemanticProperties.Description="{loc:Translate A11y_SparZielBalken}" />
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                 <Entry Text="{Binding Titel}" Placeholder="{loc:Translate Hint_ZielTitel}" FontSize="16" />
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Icon}" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_Icon}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                 <Entry Text="{Binding Icon}" FontSize="24" MaxLength="2" />
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_ZielBetrag}" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_ZielBetrag}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                 <Entry Text="{Binding ZielBetragText}" Keyboard="Numeric" FontSize="16" />
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_AktuellerBetrag}" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_AktuellerBetrag}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                 <Entry Text="{Binding AktuellerBetragText}" Keyboard="Numeric" FontSize="16" />
             </VerticalStackLayout>
 
             <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_MonatlicheSparrate}" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_MonatlicheSparrate}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                 <Entry Text="{Binding MonatlicheSparrateText}" Keyboard="Numeric" FontSize="16" />
             </VerticalStackLayout>
 
@@ -55,7 +55,7 @@
                 <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8">
                     <Label Text="{loc:Translate Lbl_Faelligkeit}"
                            FontSize="13"
-                           TextColor="Gray"
+                           TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                            VerticalTextAlignment="Center" />
                     <Switch Grid.Column="1" IsToggled="{Binding UseFaelligkeit}" />
                 </Grid>
@@ -68,14 +68,14 @@
             <Button Text="{loc:Translate Btn_BeitragBuchen}"
                     Command="{Binding BookContributionCommand}"
                     BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                    TextColor="White"
+                    TextColor="{StaticResource White}"
                     CornerRadius="12"
                     HeightRequest="44" />
 
             <Button Text="{loc:Translate Btn_Speichern}"
                     Command="{Binding SaveCommand}"
                     BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                    TextColor="White"
+                    TextColor="{StaticResource White}"
                     CornerRadius="12"
                     HeightRequest="50"
                     FontSize="16"
@@ -84,7 +84,7 @@
 
             <Button Text="{loc:Translate Btn_Loeschen}"
                     Command="{Binding DeleteCommand}"
-                    BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                    BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                     TextColor="{AppThemeBinding Light={StaticResource Ausgabe}, Dark={StaticResource AusgabeDark}}"
                     CornerRadius="12"
                     HeightRequest="44" />

--- a/Finanzuebersicht/Views/SparZielePage.xaml
+++ b/Finanzuebersicht/Views/SparZielePage.xaml
@@ -21,7 +21,8 @@
             <ScrollView>
                 <VerticalStackLayout Spacing="16" Padding="16">
 
-                    <controls:EmptyStateView IconText="🎯"
+                    <controls:EmptyStateView IconImage="savings.png"
+                                             IconAccessibilityDescription="{loc:Translate Nav_SparZiele}"
                                              Message="{loc:Translate Empty_KeineSparZiele}"
                                              Hint="{loc:Translate Empty_HintSparZiele}"
                                              ActionText="{loc:Translate Btn_NeuesZiel}"
@@ -42,8 +43,8 @@
                                         </SwipeItems>
                                     </SwipeView.RightItems>
                                     <Border StrokeShape="RoundRectangle 12"
-                                            Stroke="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                                            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                                            Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                                            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
                                             Padding="16">
                                         <Border.GestureRecognizers>
                                             <TapGestureRecognizer
@@ -83,19 +84,19 @@
                                             </Grid>
                                             <ProgressBar Progress="{Binding FortschrittDecimal}"
                                                          ProgressColor="{AppThemeBinding Light={StaticResource Einnahme}, Dark={StaticResource EinnahmeDark}}"
-                                                         BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
+                                                         BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                                                          SemanticProperties.Description="{loc:Translate A11y_SparZielBalken}" />
                                         </VerticalStackLayout>
 
                                         <HorizontalStackLayout Spacing="4" IsVisible="{Binding HatVerknuepfungen}">
-                                            <Label FontSize="12" TextColor="Gray" Text="{loc:Translate Lbl_VerknuepftAusBuchungen}" />
-                                            <Label FontSize="12" TextColor="Gray"
+                                            <Label FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" Text="{loc:Translate Lbl_VerknuepftAusBuchungen}" />
+                                            <Label FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                                                    Text="{Binding VerknuepfterBetrag, Converter={StaticResource Currency}}" />
                                         </HorizontalStackLayout>
 
                                         <HorizontalStackLayout Spacing="4" IsVisible="{Binding HatPrognose}">
-                                            <Label FontSize="12" TextColor="Gray" Text="{loc:Translate Lbl_PrognoseZielerreichung}" />
-                                            <Label FontSize="12" TextColor="Gray"
+                                            <Label FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" Text="{loc:Translate Lbl_PrognoseZielerreichung}" />
+                                            <Label FontSize="12" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}"
                                                    Text="{Binding PrognostiziertesDatum, StringFormat='{0:dd.MM.yyyy}'}" />
                                         </HorizontalStackLayout>
 
@@ -109,7 +110,7 @@
                     <!-- Formular: Neues Ziel -->
                     <Border StrokeShape="RoundRectangle 12"
                             Stroke="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                            BackgroundColor="{AppThemeBinding Light=#FFFFFF, Dark=#1C1C1E}"
+                            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
                             Padding="16"
                             IsVisible="{Binding ShowAddForm}">
                         <VerticalStackLayout Spacing="14">
@@ -161,8 +162,8 @@
                             <Grid ColumnDefinitions="*, *" ColumnSpacing="10">
                                 <Button Grid.Column="0"
                                         Text="{loc:Translate Btn_Abbrechen}"
-                                        BackgroundColor="{AppThemeBinding Light=#E5E5EA, Dark=#3A3A3C}"
-                                        TextColor="{AppThemeBinding Light=#000000, Dark=#FFFFFF}"
+                                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                                        TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource TextPrimaryDark}}"
                                         CornerRadius="10" HeightRequest="44"
                                         Command="{Binding ToggleAddFormCommand}" />
                                 <Button Grid.Column="1"

--- a/Finanzuebersicht/Views/TransactionsPage.xaml
+++ b/Finanzuebersicht/Views/TransactionsPage.xaml
@@ -9,7 +9,7 @@
              xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              x:Class="Finanzuebersicht.Views.TransactionsPage"
              x:DataType="vm:TransactionsViewModel"
-             Title="Transaktionen">
+             Title="{loc:Translate Nav_Transaktionen}">
 
     <views:BaseContentPage.Resources>
         <conv:TransactionTypToColorConverter x:Key="TypToColor" />
@@ -77,15 +77,14 @@
                        Placeholder="{loc:Translate Hint_SucheTransaktionen}"
                        CancelButtonColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" />
             <Button Grid.Column="1"
-                    Text="⚙"
-                    FontSize="20"
+                    Text="{loc:Translate Btn_Filter}"
+                    FontSize="14"
                     Command="{Binding ToggleFilterPanelCommand}"
                     BackgroundColor="Transparent"
                     TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                     BorderWidth="0"
                     CornerRadius="10"
-                    Padding="0"
-                    WidthRequest="44" HeightRequest="44"
+                    Padding="12,8"
                     VerticalOptions="Center"
                     SemanticProperties.Description="{loc:Translate A11y_FilterUmschalten}">
                 <Button.Triggers>
@@ -263,7 +262,8 @@
                                 IsGrouped="True"
                                 SelectionMode="None">
                     <CollectionView.EmptyView>
-                        <controls:EmptyStateView IconText="💳"
+                        <controls:EmptyStateView IconImage="transactions.png"
+                                                 IconAccessibilityDescription="{loc:Translate Nav_Transaktionen}"
                                                  Message="{loc:Translate Empty_KeineTransaktionen}"
                                                  Hint="{loc:Translate Empty_HintTransaktionen}"
                                                  ActionText="{loc:Translate Btn_ErsteTransaktion}"
@@ -368,12 +368,11 @@
                 <Button Text="{loc:Translate Btn_Import}" FontSize="14" TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                         BackgroundColor="Transparent"
                         Command="{Binding ImportCsvCommand}" />
-                <Button Text="↔"
-                        FontSize="20"
+                <Button Text="{loc:Translate Btn_Umbuchen}"
+                        FontSize="14"
                         TextColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                         BackgroundColor="Transparent"
-                        WidthRequest="44"
-                        HeightRequest="44"
+                        Padding="12,8"
                         SemanticProperties.Description="{loc:Translate A11y_UmbuchungHinzufuegen}"
                         Command="{Binding GoToTransferCommand}" />
             </HorizontalStackLayout>

--- a/README.md
+++ b/README.md
@@ -132,9 +132,8 @@ Build & Start (Mac Catalyst):
 
 ```bash
 dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst
-# Apple Silicon: maccatalyst-arm64 · Intel: maccatalyst-x64
-cp -R "Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app" "/Applications/Finanzübersicht.app"
-open "/Applications/Finanzübersicht.app"
+# Debug-Build kopiert automatisch nach ~/Applications (nicht /Applications — macOS 26+ Dev-Signatur)
+open ~/Applications/Finanzübersicht.app
 
 # Tests
 dotnet test Finanzuebersicht.Tests

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Finanzuebersicht.Tests/            ← xUnit Tests (net10.0)
 
 ## Versionierung & CI
 
-- Nerdbank.GitVersioning (`version.json`) steuert Versionsnummern (aktuell Basis `1.15`)
+- Nerdbank.GitVersioning (`version.json`) steuert Versionsnummern (aktuell Basis `1.16`)
 - CI / Pre-Release / Release Workflows in `.github/workflows/`
 
 ### Full MAUI build (macCatalyst)

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -26,25 +26,25 @@ dotnet workload install maui
 
 ### Mac Catalyst (lokal starten)
 
-`dotnet run` und `-t:Run` scheitern wegen macOS-Sandboxing — die `.app` nach `/Applications` kopieren:
+`dotnet run` und `-t:Run` scheitern wegen macOS-Sandboxing — Debug-Builds landen automatisch in `~/Applications`:
 
 ```bash
 dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst
+open ~/Applications/Finanzübersicht.app
+```
 
-# Apple Silicon (arm64) — typisch auf modernen Macs
-cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/
-open /Applications/Finanzübersicht.app
+Manuell kopieren (Apple Silicon `arm64`, Intel `x64`):
 
-# Intel (x64)
-cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-x64/Finanzübersicht.app /Applications/
+```bash
+cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app ~/Applications/
+open ~/Applications/Finanzübersicht.app
 ```
 
 **Ein-Liner nach jedem Build (arm64):**
 
 ```bash
 dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst \
-  && cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/ \
-  && open /Applications/Finanzübersicht.app
+  && open ~/Applications/Finanzübersicht.app
 ```
 
 > Nur das MAUI-Projekt bauen, nicht die ganze Solution mit `-f net10.0-maccatalyst` — sonst werden auch `net10.0`-only-Projekte (Tests, Core, …) auf das Plattform-TFM gezwungen.

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -198,8 +198,8 @@ Neue Migratoren als `IDataMigrator`-Implementierungen in DI registrieren.
 
 ## 11. Versionierung
 
-- **System:** Nerdbank.GitVersioning (`version.json`, aktuell Basis `1.15`)
-- **Format:** `<major>.<minor>.<git-height>` (z.B. `1.15.9`)
+- **System:** Nerdbank.GitVersioning (`version.json`, aktuell Basis `1.16`)
+- **Format:** `<major>.<minor>.<git-height>` (z.B. `1.16.9`)
 - **MAUI-Version:** Automatisch gesetzt via `ApplicationDisplayVersion` und `ApplicationVersion` zur Buildzeit
 
 ```bash

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -15,25 +15,25 @@ dotnet workload install maui
 
 ### Mac Catalyst
 
-`dotnet run` fails due to macOS sandboxing — copy the `.app` to `/Applications`:
+`dotnet run` fails due to macOS sandboxing — Debug builds install to `~/Applications`:
 
 ```bash
 dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst
+open ~/Applications/Finanzübersicht.app
+```
 
-# Apple Silicon (arm64)
-cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/
-open /Applications/Finanzübersicht.app
+Manual copy (Apple Silicon `arm64`, Intel `x64`):
 
-# Intel (x64)
-cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-x64/Finanzübersicht.app /Applications/
+```bash
+cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app ~/Applications/
+open ~/Applications/Finanzübersicht.app
 ```
 
 One-liner (arm64):
 
 ```bash
 dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst \
-  && cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/ \
-  && open /Applications/Finanzübersicht.app
+  && open ~/Applications/Finanzübersicht.app
 ```
 
 > Build the MAUI project only, not the whole solution with `-f net10.0-maccatalyst`.

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -100,7 +100,7 @@ dotnet test Finanzuebersicht.Tests
 
 ## Versioning
 
-Automatic SemVer via **Nerdbank.GitVersioning** (`version.json`, base `1.15`):
+Automatic SemVer via **Nerdbank.GitVersioning** (`version.json`, base `1.16`):
 
 ```bash
 nbgv get-version

--- a/docs/RECURRING_UI.md
+++ b/docs/RECURRING_UI.md
@@ -20,11 +20,10 @@ Kurzbeschreibung der UI-Funktion zum Verschieben einzelner Instanzen eines Dauer
 dotnet build Finanzuebersicht/Finanzuebersicht.csproj -f net10.0-maccatalyst
 ```
 
-2. App installieren und starten:
+2. App starten (Debug-Build kopiert automatisch nach `~/Applications`):
 
 ```bash
-cp -R Finanzuebersicht/bin/Debug/net10.0-maccatalyst/maccatalyst-arm64/Finanzübersicht.app /Applications/
-open /Applications/Finanzübersicht.app
+open ~/Applications/Finanzübersicht.app
 ```
 
 3. In der App: **Daueraufträge** → Dauerauftrag auswählen → **Instanz verschieben**

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -101,6 +101,7 @@ Fokus: Onboarding, einheitliche Empty States, Aktion-Feedback, Saldo-Vertrauen.
 |-------|-------|-----------|
 | [#252](https://github.com/tom4711/finanzuebersicht/issues/252) | Dashboard Runde 2 — weniger Karten, klarer erster Blick | B |
 | [#253](https://github.com/tom4711/finanzuebersicht/issues/253) | Anzeige-Währung beim Erststart (getrennt von Sprache) | B |
+| [#254](https://github.com/tom4711/finanzuebersicht/issues/254) | Hardcoded XAML-Farben → zentrale Theme-Ressourcen | B |
 | [#234](https://github.com/tom4711/finanzuebersicht/issues/234) | Seitentitel und Enum-Labels lokalisieren | B |
 | [#236](https://github.com/tom4711/finanzuebersicht/issues/236) | Verwaltung Kategorien/Konten — Segment klarer | B |
 | [#238](https://github.com/tom4711/finanzuebersicht/issues/238) | Filter und Umbuchung mit Text statt Emoji | B |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -99,6 +99,8 @@ Fokus: Onboarding, einheitliche Empty States, Aktion-Feedback, Saldo-Vertrauen.
 
 | Issue | Thema | Priorität |
 |-------|-------|-----------|
+| [#252](https://github.com/tom4711/finanzuebersicht/issues/252) | Dashboard Runde 2 — weniger Karten, klarer erster Blick | B |
+| [#253](https://github.com/tom4711/finanzuebersicht/issues/253) | Anzeige-Währung beim Erststart (getrennt von Sprache) | B |
 | [#234](https://github.com/tom4711/finanzuebersicht/issues/234) | Seitentitel und Enum-Labels lokalisieren | B |
 | [#236](https://github.com/tom4711/finanzuebersicht/issues/236) | Verwaltung Kategorien/Konten — Segment klarer | B |
 | [#238](https://github.com/tom4711/finanzuebersicht/issues/238) | Filter und Umbuchung mit Text statt Emoji | B |

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 > **Hinweis:** Die Milestone-Bezeichnungen (v1.14, v1.2, v2.0) sind thematische GitHub-Planungslabels, keine sequenziellen Release-Versionen. Tatsächliche Releases (v1.0, v1.6, v1.12 …) werden durch Git-Commit-Höhe via Nerdbank.GitVersioning bestimmt.
 
-**Aktueller Stand:** Release **v1.15** (Latest). Nächste geplante UX-Releases: **v1.16–v1.17** (vor v2.0).
+**Aktueller Stand:** Release **v1.16** (Latest). Nächster geplanter UX-Release: **v1.17** (vor v2.0).
 
 ---
 
@@ -95,17 +95,17 @@ Fokus: Onboarding, einheitliche Empty States, Aktion-Feedback, Saldo-Vertrauen.
 
 ---
 
-## 🎯 v1.16 — UI-Konsistenz & Lokalisierung *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/20)
+## ✅ v1.16 — UI-Konsistenz & Lokalisierung *(abgeschlossen)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/20)
 
-| Issue | Thema | Priorität |
-|-------|-------|-----------|
-| [#252](https://github.com/tom4711/finanzuebersicht/issues/252) | Dashboard Runde 2 — weniger Karten, klarer erster Blick | B |
-| [#253](https://github.com/tom4711/finanzuebersicht/issues/253) | Anzeige-Währung beim Erststart (getrennt von Sprache) | B |
-| [#254](https://github.com/tom4711/finanzuebersicht/issues/254) | Hardcoded XAML-Farben → zentrale Theme-Ressourcen | B |
-| [#234](https://github.com/tom4711/finanzuebersicht/issues/234) | Seitentitel und Enum-Labels lokalisieren | B |
-| [#236](https://github.com/tom4711/finanzuebersicht/issues/236) | Verwaltung Kategorien/Konten — Segment klarer | B |
-| [#238](https://github.com/tom4711/finanzuebersicht/issues/238) | Filter und Umbuchung mit Text statt Emoji | B |
-| [#240](https://github.com/tom4711/finanzuebersicht/issues/240) | Einheitliches Icon-Set statt Emoji | C |
+| Issue | Thema | Status |
+|-------|-------|--------|
+| [#252](https://github.com/tom4711/finanzuebersicht/issues/252) | Dashboard Runde 2 — weniger Karten, klarer erster Blick | ✅ Closed |
+| [#253](https://github.com/tom4711/finanzuebersicht/issues/253) | Anzeige-Währung beim Erststart (getrennt von Sprache) | ✅ Closed |
+| [#254](https://github.com/tom4711/finanzuebersicht/issues/254) | Hardcoded XAML-Farben → zentrale Theme-Ressourcen | ✅ Closed |
+| [#234](https://github.com/tom4711/finanzuebersicht/issues/234) | Seitentitel und Enum-Labels lokalisieren | ✅ Closed |
+| [#236](https://github.com/tom4711/finanzuebersicht/issues/236) | Verwaltung Kategorien/Konten — Segment klarer | ✅ Closed |
+| [#238](https://github.com/tom4711/finanzuebersicht/issues/238) | Filter und Umbuchung mit Text statt Emoji | ✅ Closed |
+| [#240](https://github.com/tom4711/finanzuebersicht/issues/240) | Einheitliches Icon-Set statt Emoji | ✅ Closed |
 
 ---
 

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.15",
+  "version": "1.16",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## Summary

- Release **v1.16** mit UI-Konsistenz, Lokalisierung und Dashboard-Fokus (#234, #236, #238, #240, #252, #253, #254)
- Anzeige-Währung getrennt von UI-Sprache; Theme-Tokens statt Hardcoded-Farben; Icons statt Emoji
- Version bump `version.json` → `1.16`, CHANGELOG und ROADMAP aktualisiert

Closes #234
Closes #236
Closes #238
Closes #240
Closes #252
Closes #253
Closes #254

## Test plan

- [ ] `dotnet test` — 297 Tests grün
- [ ] Dashboard: Summary oben, einklappbare Bereiche, fällige Daueraufträge sichtbar
- [ ] Einstellungen/Onboarding: Anzeige-Währung wechseln → Beträge aktualisieren
- [ ] Verwaltung Segment, Transaktionen Filter/Umbuchen, lokale Seitentitel DE/EN
- [ ] Mac Catalyst Build + Start aus `~/Applications/Finanzübersicht.app`
- [ ] Nach Merge: Tag `v1.16` setzen → Release-Workflow


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# Release Notes Version 1.16

* **New Features**
  * Selektive Anzeigewährung (EUR, USD, GBP, CHF) mit automatischer Betragsaktualisierung
  * Einklappbare Dashboard-Bereiche (Due, Konten, Cashflow, Filter)

* **Improvements**
  * Überarbeitete, konsistente Icons und leere Zustände (inkl. besserer Barrierefreiheit)
  * Umstellung auf lokalisierte Titel/Beschriftungen sowie einheitliche Theme-Farben

* **Bug Fixes**
  * Verbesserungen bei Daueraufträgen und bei Währungswechsel-Aktualisierungen

* **Documentation**
  * Angepasste macOS-Startanleitung für Debug-Builds (~/Applications)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->