### PR TITLE
Architektur: Recurring-Logik konsolidieren und Repository-Zugriffe in Use Cases

### DIFF
--- a/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Application/DependencyInjection/ApplicationServiceCollectionExtensions.cs
@@ -17,6 +17,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<SaveCategoryDetailUseCase>();
         services.AddTransient<SaveCategoryBudgetUseCase>();
         services.AddTransient<LoadAccountsUseCase>();
+        services.AddTransient<LoadActiveAccountsUseCase>();
         services.AddTransient<SaveAccountDetailUseCase>();
         services.AddTransient<ToggleAccountArchiveUseCase>();
         services.AddTransient<DeleteAccountUseCase>();
@@ -27,6 +28,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<LoadDashboardYearUseCase>();
         services.AddTransient<LoadForecastUseCase>();
         services.AddTransient<LoadCashflowOutlookUseCase>();
+        services.AddTransient<GetDefaultBudgetTotalUseCase>();
 
         services.AddTransient<DeleteRecurringTransactionUseCase>();
         services.AddTransient<LoadRecurringTransactionDetailDataUseCase>();
@@ -43,6 +45,7 @@ public static class ApplicationServiceCollectionExtensions
         services.AddTransient<DeleteTransactionUseCase>();
         services.AddTransient<RestoreTransactionUseCase>();
         services.AddTransient<HasAnyTransactionsUseCase>();
+        services.AddTransient<GetEarliestTransactionYearUseCase>();
         services.AddTransient<LoadTransactionsMonthUseCase>();
         services.AddTransient<LoadTransactionTemplatesUseCase>();
         services.AddTransient<SearchTransactionsUseCase>();

--- a/Finanzuebersicht.Application/UseCases/Accounts/LoadActiveAccountsUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Accounts/LoadActiveAccountsUseCase.cs
@@ -1,0 +1,18 @@
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Application.UseCases.Accounts;
+
+public class LoadActiveAccountsUseCase(IAccountRepository accountRepository)
+{
+    private readonly IAccountRepository _accountRepository = accountRepository;
+
+    public async Task<List<Account>> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+        var accounts = await _accountRepository.GetAccountsAsync();
+        return accounts
+            .Where(a => !a.IsArchived)
+            .OrderBy(a => a.Name)
+            .ToList();
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Dashboard/GetDefaultBudgetTotalUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/GetDefaultBudgetTotalUseCase.cs
@@ -1,0 +1,16 @@
+namespace Finanzuebersicht.Application.UseCases.Dashboard;
+
+public class GetDefaultBudgetTotalUseCase(IBudgetRepository budgetRepository)
+{
+    private readonly IBudgetRepository _budgetRepository = budgetRepository;
+
+    public async Task<decimal> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var budgets = await _budgetRepository.GetBudgetsAsync() ?? [];
+        return budgets
+            .Where(b => b.Monat == null && b.Jahr == null && b.Betrag > 0)
+            .Sum(b => b.Betrag);
+    }
+}

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadCashflowOutlookUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadCashflowOutlookUseCase.cs
@@ -52,7 +52,7 @@ public class LoadCashflowOutlookUseCase(
 
             for (var day = from; day <= to; day = day.AddDays(1))
             {
-                if (!OccursOnDate(recurring, day))
+                if (!RecurringScheduleCalculator.OccursOnDate(recurring, day))
                     continue;
 
                 if (IsRecurringBooked(allTransactions, recurring.Id, day))
@@ -143,9 +143,4 @@ public class LoadCashflowOutlookUseCase(
     private static bool IsRecurringBooked(IEnumerable<Transaction> transactions, string recurringId, DateTime day)
         => transactions.Any(t => t.DauerauftragId == recurringId && t.Datum.Date == day.Date);
 
-    private static bool OccursOnDate(RecurringTransaction recurring, DateTime date)
-    {
-        var instance = RecurringScheduleCalculator.GetNextDueInstance(recurring, date);
-        return instance.HasValue && instance.Value.EffectiveDate.Date == date.Date;
-    }
 }

--- a/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Dashboard/LoadDashboardMonthUseCase.cs
@@ -1,4 +1,4 @@
-using System;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
 
 namespace Finanzuebersicht.Application.UseCases.Dashboard;
@@ -37,7 +37,7 @@ public class LoadDashboardMonthUseCase(
                 if (da.Startdatum <= bis && (!da.Enddatum.HasValue || da.Enddatum.Value >= von))
                 {
                     // Only add a forecast transaction for this month if the recurrence actually occurs in the month
-                    if (!transaktionen.Any(t => t.DauerauftragId == da.Id) && OccursInRange(da, von, bis))
+                    if (!transaktionen.Any(t => t.DauerauftragId == da.Id) && RecurringScheduleCalculator.OccursInRange(da, von, bis))
                     {
                         transaktionen.Add(new Transaction
                         {
@@ -171,108 +171,6 @@ public class LoadDashboardMonthUseCase(
             item.PercentageAmount = item.Total / total * 100;
     }
 
-    private static bool OccursInRange(RecurringTransaction da, DateTime rangeStart, DateTime rangeEnd)
-    {
-        // Grundlegende Plausibilitätsprüfung: Zeitraum vollständig vor/nach dem Dauerauftrag
-        if (da.Startdatum > rangeEnd) return false;
-        if (da.Enddatum.HasValue && da.Enddatum.Value < rangeStart) return false;
-
-        // Starte bei der letzten Ausführung oder dem Startdatum
-        var candidate = da.LetzteAusfuehrung ?? da.Startdatum;
-        if (candidate < da.Startdatum) candidate = da.Startdatum;
-
-        var safety = 0;
-
-        // Iteriere über Basis-Vorkommen bis zum Ende des betrachteten Zeitraums
-        while (candidate <= rangeEnd && safety++ < 1000)
-        {
-            // Nur innerhalb der generellen Lebensdauer des Dauerauftrags berücksichtigen
-            if (candidate >= da.Startdatum && (!da.Enddatum.HasValue || candidate <= da.Enddatum.Value))
-            {
-                if (TryGetEffectiveDateWithExceptions(da, candidate, out var effectiveDate))
-                {
-                    if (effectiveDate >= rangeStart && effectiveDate <= rangeEnd)
-                    {
-                        return true;
-                    }
-                }
-            }
-
-            candidate = GetNextInstance(da, candidate);
-        }
-
-        return false;
-    }
-
-    private static bool TryGetEffectiveDateWithExceptions(RecurringTransaction recurring, DateTime baseDate, out DateTime effectiveDate)
-    {
-        // Standardfall: kein Eintrag in den Ausnahmen → Basisdatum ist das effektive Datum
-        effectiveDate = baseDate.Date;
-
-        // Wenn keine Ausnahmen definiert sind, direkt zurück
-        if (recurring.Exceptions == null)
-        {
-            return true;
-        }
-
-        RecurringException? matchingException = null;
-
-        foreach (var ex in recurring.Exceptions)
-        {
-            // Vergleich nur auf Datumsebene
-            if (ex.InstanceDate.Date == baseDate.Date)
-            {
-                matchingException = ex;
-                break;
-            }
-        }
-
-        if (matchingException == null)
-        {
-            // Keine Ausnahme für dieses Vorkommen → Basisdatum bleibt gültig
-            return true;
-        }
-
-        // Skip → dieses Vorkommen existiert nicht
-        if (matchingException.Type == RecurringExceptionType.Skip)
-        {
-            return false;
-        }
-
-        // Shift → effektives Datum ist das hinterlegte Shift-Datum, falls vorhanden
-        if (matchingException.Type == RecurringExceptionType.Shift && matchingException.ShiftToDate.HasValue)
-        {
-            effectiveDate = matchingException.ShiftToDate.Value.Date;
-            return true;
-        }
-
-        // Fallback: falls Ausnahme-Typ unbekannt oder Shift ohne Ziel-Datum, Basisdatum verwenden
-        return true;
-    }
-
-    private static DateTime GetNextInstance(RecurringTransaction recurring, DateTime fromDate)
-    {
-        var factor = Math.Max(1, recurring.IntervalFactor);
-        return recurring.Interval switch
-        {
-            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7L * factor),
-            RecurrenceInterval.Monthly => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
-            RecurrenceInterval.Quarterly => AddMonthsPreserveDay(fromDate.Date, 3 * factor),
-            RecurrenceInterval.Yearly => AddMonthsPreserveDay(fromDate.Date, 12 * factor),
-            RecurrenceInterval.Daily => fromDate.Date.AddDays(1 * factor),
-            _ => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
-        };
-    }
-
-    private static DateTime AddMonthsPreserveDay(DateTime date, int months)
-    {
-        var target = date.AddMonths(months);
-        var day = date.Day;
-        var daysInTarget = DateTime.DaysInMonth(target.Year, target.Month);
-        if (day > daysInTarget)
-            day = daysInTarget;
-        return new DateTime(target.Year, target.Month, day);
-    }
 }
 
 public class DashboardMonthData

--- a/Finanzuebersicht.Application/UseCases/Transactions/GetEarliestTransactionYearUseCase.cs
+++ b/Finanzuebersicht.Application/UseCases/Transactions/GetEarliestTransactionYearUseCase.cs
@@ -1,0 +1,14 @@
+namespace Finanzuebersicht.Application.UseCases.Transactions;
+
+public class GetEarliestTransactionYearUseCase(ITransactionRepository transactionRepository)
+{
+    private readonly ITransactionRepository _transactionRepository = transactionRepository;
+
+    public async Task<int?> ExecuteAsync(CancellationToken cancellationToken = default)
+    {
+        cancellationToken.ThrowIfCancellationRequested();
+
+        var transactions = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
+        return transactions.Count > 0 ? transactions.Min(t => t.Datum.Year) : null;
+    }
+}

--- a/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
+++ b/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
@@ -5,8 +5,8 @@ namespace Finanzuebersicht.Core.Services;
 /// <summary>
 /// Pure domain component for calculating recurring transaction schedules.
 /// Single source of truth for: next-due calculation, exception application,
-/// and active-range checks. Used by both <see cref="RecurringGenerationService"/>
-/// and <c>GetDueRecurringWithHintsUseCase</c>.
+/// active-range checks, and occurrence-on-date/range queries. Used by
+/// <see cref="RecurringGenerationService"/>, dashboard month forecast, and cashflow outlook.
 /// </summary>
 public static class RecurringScheduleCalculator
 {
@@ -110,6 +110,36 @@ public static class RecurringScheduleCalculator
 
         var effective = ApplyExceptions(recurring, candidate);
         return (candidate.Date, effective);
+    }
+
+    /// <summary>
+    /// Returns true if the recurring transaction has an effective occurrence on <paramref name="date"/>.
+    /// </summary>
+    public static bool OccursOnDate(RecurringTransaction recurring, DateTime date)
+    {
+        var instance = GetNextDueInstance(recurring, date);
+        return instance.HasValue && instance.Value.EffectiveDate.Date == date.Date;
+    }
+
+    /// <summary>
+    /// Returns true if any effective occurrence falls within
+    /// [<paramref name="rangeStart"/>, <paramref name="rangeEnd"/>] (inclusive).
+    /// </summary>
+    public static bool OccursInRange(RecurringTransaction recurring, DateTime rangeStart, DateTime rangeEnd)
+    {
+        if (recurring.Startdatum.Date > rangeEnd.Date)
+            return false;
+
+        if (recurring.Enddatum.HasValue && recurring.Enddatum.Value.Date < rangeStart.Date)
+            return false;
+
+        for (var day = rangeStart.Date; day <= rangeEnd.Date; day = day.AddDays(1))
+        {
+            if (OccursOnDate(recurring, day))
+                return true;
+        }
+
+        return false;
     }
 
     /// <summary>

--- a/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
+++ b/Finanzuebersicht.Core/Services/RecurringScheduleCalculator.cs
@@ -116,10 +116,7 @@ public static class RecurringScheduleCalculator
     /// Returns true if the recurring transaction has an effective occurrence on <paramref name="date"/>.
     /// </summary>
     public static bool OccursOnDate(RecurringTransaction recurring, DateTime date)
-    {
-        var instance = GetNextDueInstance(recurring, date);
-        return instance.HasValue && instance.Value.EffectiveDate.Date == date.Date;
-    }
+        => OccursInRange(recurring, date.Date, date.Date);
 
     /// <summary>
     /// Returns true if any effective occurrence falls within
@@ -127,19 +124,58 @@ public static class RecurringScheduleCalculator
     /// </summary>
     public static bool OccursInRange(RecurringTransaction recurring, DateTime rangeStart, DateTime rangeEnd)
     {
+        if (!recurring.Aktiv)
+            return false;
+
         if (recurring.Startdatum.Date > rangeEnd.Date)
             return false;
 
         if (recurring.Enddatum.HasValue && recurring.Enddatum.Value.Date < rangeStart.Date)
             return false;
 
-        for (var day = rangeStart.Date; day <= rangeEnd.Date; day = day.AddDays(1))
+        var candidate = recurring.LetzteAusfuehrung ?? recurring.Startdatum;
+        if (candidate.Date < recurring.Startdatum.Date)
+            candidate = recurring.Startdatum;
+
+        var safety = 0;
+        while (candidate.Date <= rangeEnd.Date && safety++ < 1000)
         {
-            if (OccursOnDate(recurring, day))
+            if (candidate.Date >= recurring.Startdatum.Date &&
+                (!recurring.Enddatum.HasValue || candidate.Date <= recurring.Enddatum.Value.Date) &&
+                TryGetEffectiveDate(recurring, candidate, out var effectiveDate) &&
+                effectiveDate >= rangeStart.Date &&
+                effectiveDate <= rangeEnd.Date)
+            {
                 return true;
+            }
+
+            candidate = GetNextInstance(recurring, candidate);
         }
 
         return false;
+    }
+
+    private static bool TryGetEffectiveDate(
+        RecurringTransaction recurring,
+        DateTime candidate,
+        out DateTime effectiveDate)
+    {
+        effectiveDate = candidate.Date;
+
+        var exception = recurring.Exceptions?.FirstOrDefault(e => e.InstanceDate.Date == candidate.Date);
+        if (exception is null)
+            return true;
+
+        if (exception.Type == RecurringExceptionType.Skip)
+            return false;
+
+        if (exception.Type == RecurringExceptionType.Shift && exception.ShiftToDate.HasValue)
+        {
+            effectiveDate = exception.ShiftToDate.Value.Date;
+            return true;
+        }
+
+        return true;
     }
 
     /// <summary>

--- a/Finanzuebersicht.Presentation/ViewModels/CashflowViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CashflowViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Presentation;
@@ -12,13 +13,13 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class CashflowViewModel(
     LoadCashflowOutlookUseCase loadCashflowOutlookUseCase,
-    IAccountRepository accountRepository,
+    LoadActiveAccountsUseCase loadActiveAccountsUseCase,
     ILocalizationService localizationService,
     IDialogService dialogService,
     ILogger<CashflowViewModel>? logger = null) : ObservableObject, IAutoLoadViewModel, ICurrencyRefreshViewModel
 {
     private readonly LoadCashflowOutlookUseCase _loadCashflowOutlookUseCase = loadCashflowOutlookUseCase;
-    private readonly IAccountRepository _accountRepository = accountRepository;
+    private readonly LoadActiveAccountsUseCase _loadActiveAccountsUseCase = loadActiveAccountsUseCase;
     private readonly ILocalizationService _loc = localizationService;
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILogger<CashflowViewModel>? _logger = logger;
@@ -91,13 +92,13 @@ public partial class CashflowViewModel(
     {
         if (AvailableKonten.Count > 0) return;
 
-        var accounts = await _accountRepository.GetAccountsAsync();
+        var accounts = await _loadActiveAccountsUseCase.ExecuteAsync();
         var items = new ObservableCollection<KategorieFilterItem>
         {
             new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten), ResourceKeys.Lbl_AlleKonten)
         };
 
-        foreach (var account in accounts.Where(a => !a.IsArchived).OrderBy(a => a.Name))
+        foreach (var account in accounts)
             items.Add(new KategorieFilterItem(account.Id, account.Name));
 
         AvailableKonten = items;

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -5,6 +5,7 @@ using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
@@ -25,8 +26,9 @@ public partial class DashboardViewModel : MonthNavigationViewModel, ILocalizable
     private readonly LoadCashflowOutlookUseCase _loadCashflowOutlookUseCase;
     private readonly ISettingsService _settingsService;
     private readonly IDialogService _dialogService;
-    private readonly IBudgetRepository _budgetRepository;
-    private readonly IAccountRepository _accountRepository;
+    private readonly GetDefaultBudgetTotalUseCase _getDefaultBudgetTotalUseCase;
+    private readonly LoadActiveAccountsUseCase _loadActiveAccountsUseCase;
+    private readonly GetEarliestTransactionYearUseCase _getEarliestTransactionYearUseCase;
     private readonly GetAccountBalancesUseCase _getAccountBalancesUseCase;
     private readonly ILocalizationService _loc;
     private readonly INavigationService _navigationService;
@@ -301,7 +303,6 @@ public partial class DashboardViewModel : MonthNavigationViewModel, ILocalizable
         ? _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig_Singular, DueRecurringCount)
         : _loc.GetString(ResourceKeys.Lbl_DauerauftraegeFaellig, DueRecurringCount);
 
-    private readonly ITransactionRepository _transactionRepository;
     private int _aktuellesJahr;
     private int _minJahr;
     private bool _minJahrLoaded;
@@ -377,12 +378,12 @@ public partial class DashboardViewModel : MonthNavigationViewModel, ILocalizable
         GetDueRecurringWithHintsUseCase getDueRecurringUseCase,
         BookDueRecurringInstanceUseCase bookDueRecurringUseCase,
         SkipDueRecurringInstanceUseCase skipDueRecurringUseCase,
-        IBudgetRepository budgetRepository,
+        GetDefaultBudgetTotalUseCase getDefaultBudgetTotalUseCase,
+        LoadActiveAccountsUseCase loadActiveAccountsUseCase,
+        GetEarliestTransactionYearUseCase getEarliestTransactionYearUseCase,
         ILocalizationService localizationService,
         INavigationService navigationService,
         IDialogService dialogService,
-        ITransactionRepository transactionRepository,
-        IAccountRepository accountRepository,
         GetAccountBalancesUseCase getAccountBalancesUseCase,
         ISettingsService settingsService,
         IClock? clock = null,
@@ -398,12 +399,12 @@ public partial class DashboardViewModel : MonthNavigationViewModel, ILocalizable
         _getDueRecurringUseCase = getDueRecurringUseCase;
         _bookDueRecurringUseCase = bookDueRecurringUseCase;
         _skipDueRecurringUseCase = skipDueRecurringUseCase;
-        _budgetRepository = budgetRepository;
+        _getDefaultBudgetTotalUseCase = getDefaultBudgetTotalUseCase;
+        _loadActiveAccountsUseCase = loadActiveAccountsUseCase;
+        _getEarliestTransactionYearUseCase = getEarliestTransactionYearUseCase;
         _loc = localizationService;
         _navigationService = navigationService;
         _dialogService = dialogService;
-        _transactionRepository = transactionRepository;
-        _accountRepository = accountRepository;
         _getAccountBalancesUseCase = getAccountBalancesUseCase;
         _settingsService = settingsService;
         _logger = logger;
@@ -471,10 +472,10 @@ public partial class DashboardViewModel : MonthNavigationViewModel, ILocalizable
         _minJahrLoaded = true;
         try
         {
-            var all = await _transactionRepository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue);
-            if (all.Count > 0)
+            var earliestYear = await _getEarliestTransactionYearUseCase.ExecuteAsync();
+            if (earliestYear.HasValue)
             {
-                _minJahr = all.Min(t => t.Datum.Year);
+                _minJahr = earliestYear.Value;
                 _foundTransactions = true;
             }
             else
@@ -558,13 +559,13 @@ public partial class DashboardViewModel : MonthNavigationViewModel, ILocalizable
     {
         if (AvailableKonten.Count > 0) return;
 
-        var accounts = await _accountRepository.GetAccountsAsync();
+        var accounts = await _loadActiveAccountsUseCase.ExecuteAsync();
         var items = new ObservableCollection<KategorieFilterItem>
         {
             new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten), ResourceKeys.Lbl_AlleKonten)
         };
 
-        foreach (var account in accounts.Where(a => !a.IsArchived).OrderBy(a => a.Name))
+        foreach (var account in accounts)
             items.Add(new KategorieFilterItem(account.Id, account.Name));
 
         AvailableKonten = items;
@@ -641,10 +642,7 @@ public partial class DashboardViewModel : MonthNavigationViewModel, ILocalizable
         // Summe der Default-Kategorie-Budgets (monat=null, jahr=null) als Referenzlinie
         // Hinweis: Monat- oder jahresspezifische Budget-Overrides werden bewusst nicht einberechnet,
         // da die Linie einen stabilen Jahres-Richtwert darstellen soll.
-        var budgets = await _budgetRepository.GetBudgetsAsync();
-        JahrBudgetTotal = budgets
-            .Where(b => b.Monat == null && b.Jahr == null && b.Betrag > 0)
-            .Sum(b => b.Betrag);
+        JahrBudgetTotal = await _getDefaultBudgetTotalUseCase.ExecuteAsync();
 
         // Forecast-Balken für nächsten Monat (nur im aktuellen Jahr)
         var today = _clock.Today;

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Logging;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Presentation.Services;
@@ -243,7 +244,7 @@ public partial class RecurringTransactionDetailViewModel(
         DateTime next;
         if (_existing.LetzteAusfuehrung.HasValue)
         {
-            next = GetNextInstanceLocal(_existing, _existing.LetzteAusfuehrung.Value, IntervalFactor);
+            next = RecurringScheduleCalculator.GetNextInstance(_existing, _existing.LetzteAusfuehrung.Value);
         }
         else
         {
@@ -264,7 +265,7 @@ public partial class RecurringTransactionDetailViewModel(
         DateTime next;
         if (_existing.LetzteAusfuehrung.HasValue)
         {
-            next = GetNextInstanceLocal(_existing, _existing.LetzteAusfuehrung.Value, IntervalFactor);
+            next = RecurringScheduleCalculator.GetNextInstance(_existing, _existing.LetzteAusfuehrung.Value);
         }
         else
         {
@@ -278,30 +279,6 @@ public partial class RecurringTransactionDetailViewModel(
         };
 
         await _navigationService.GoToAsync(Routes.RecurringInstanceShift, parameters);
-    }
-
-    private static DateTime GetNextInstanceLocal(RecurringTransaction recurring, DateTime fromDate, int intervalFactor)
-    {
-        var factor = Math.Max(1, intervalFactor);
-        return recurring.Interval switch
-        {
-            RecurrenceInterval.Weekly => fromDate.Date.AddDays(7L * factor),
-            RecurrenceInterval.Monthly => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
-            RecurrenceInterval.Quarterly => AddMonthsPreserveDay(fromDate.Date, 3 * factor),
-            RecurrenceInterval.Yearly => AddMonthsPreserveDay(fromDate.Date, 12 * factor),
-            RecurrenceInterval.Daily => fromDate.Date.AddDays(1 * factor),
-            _ => AddMonthsPreserveDay(fromDate.Date, 1 * factor),
-        };
-    }
-
-    private static DateTime AddMonthsPreserveDay(DateTime date, int months)
-    {
-        var target = date.AddMonths(months);
-        var day = date.Day;
-        var daysInTarget = DateTime.DaysInMonth(target.Year, target.Month);
-        if (day > daysInTarget)
-            day = daysInTarget;
-        return new DateTime(target.Year, target.Month, day);
     }
 
     [RelayCommand]

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -1,6 +1,8 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Application.UseCases.Categories;
 using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
@@ -22,8 +24,8 @@ public partial class TransactionsViewModel(
     IDialogService dialogService,
     IFeedbackService feedbackService,
     ILocalizationService localizationService,
-    ICategoryRepository categoryRepository,
-    IAccountRepository accountRepository,
+    LoadCategoriesUseCase loadCategoriesUseCase,
+    LoadAccountsUseCase loadAccountsUseCase,
     IMainThreadDispatcher dispatcher,
     IFilePicker filePicker,
     IAppEvents appEvents,
@@ -44,8 +46,8 @@ public partial class TransactionsViewModel(
     private readonly IDialogService _dialogService = dialogService;
     private readonly IFeedbackService _feedbackService = feedbackService;
     private readonly ILocalizationService _loc = localizationService;
-    private readonly ICategoryRepository _categoryRepository = categoryRepository;
-    private readonly IAccountRepository _accountRepository = accountRepository;
+    private readonly LoadCategoriesUseCase _loadCategoriesUseCase = loadCategoriesUseCase;
+    private readonly LoadAccountsUseCase _loadAccountsUseCase = loadAccountsUseCase;
     private readonly IMainThreadDispatcher _dispatcher = dispatcher;
     private readonly IFilePicker _filePicker = filePicker;
     private readonly IAppEvents _appEvents = appEvents;
@@ -354,7 +356,7 @@ public partial class TransactionsViewModel(
 
     private async Task LoadKategorienAsync()
     {
-        var kategorien = await _categoryRepository.GetCategoriesAsync();
+        var kategorien = await _loadCategoriesUseCase.ExecuteAsync();
         var items = new ObservableCollection<KategorieFilterItem>
         {
             new(null, _loc.GetString(ResourceKeys.Lbl_AlleKategorien), ResourceKeys.Lbl_AlleKategorien)
@@ -368,7 +370,7 @@ public partial class TransactionsViewModel(
 
     private async Task LoadKontenAsync()
     {
-        var konten = await _accountRepository.GetAccountsAsync();
+        var konten = await _loadAccountsUseCase.ExecuteAsync();
         var items = new ObservableCollection<KategorieFilterItem>
         {
             new(null, _loc.GetString(ResourceKeys.Lbl_AlleKonten), ResourceKeys.Lbl_AlleKonten)

--- a/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransferDetailViewModel.cs
@@ -1,6 +1,7 @@
 using System.Collections.ObjectModel;
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
@@ -12,7 +13,7 @@ namespace Finanzuebersicht.ViewModels;
 
 public partial class TransferDetailViewModel(
     SaveTransferUseCase saveTransferUseCase,
-    IAccountRepository accountRepository,
+    LoadActiveAccountsUseCase loadActiveAccountsUseCase,
     INavigationService navigationService,
     IDialogService dialogService,
     ILocalizationService localizationService,
@@ -22,7 +23,7 @@ public partial class TransferDetailViewModel(
     Finanzuebersicht.Core.Services.IClock? clock = null) : ObservableObject, IAutoLoadViewModel
 {
     private readonly SaveTransferUseCase _saveTransferUseCase = saveTransferUseCase;
-    private readonly IAccountRepository _accountRepository = accountRepository;
+    private readonly LoadActiveAccountsUseCase _loadActiveAccountsUseCase = loadActiveAccountsUseCase;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
     private readonly ILocalizationService _loc = localizationService;
@@ -61,13 +62,12 @@ public partial class TransferDetailViewModel(
         if (string.IsNullOrWhiteSpace(Title))
             Title = _loc.GetString(ResourceKeys.Title_Umbuchung);
 
-        var accounts = await _accountRepository.GetAccountsAsync();
-        var active = accounts.Where(a => !a.IsArchived).OrderBy(a => a.Name).ToList();
-        Accounts = new ObservableCollection<Account>(active);
+        var accounts = await _loadActiveAccountsUseCase.ExecuteAsync();
+        Accounts = new ObservableCollection<Account>(accounts);
 
-        SourceAccount = active.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
-            ?? active.FirstOrDefault();
-        TargetAccount = active.FirstOrDefault(a => a.Id != SourceAccount?.Id);
+        SourceAccount = accounts.FirstOrDefault(a => a.SystemKey == Finanzuebersicht.Constants.SystemAccountKeys.Default)
+            ?? accounts.FirstOrDefault();
+        TargetAccount = accounts.FirstOrDefault(a => a.Id != SourceAccount?.Id);
     }
 
     [RelayCommand]

--- a/Finanzuebersicht.Tests/Application/UseCases/RecurringScheduleConsistencyTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/RecurringScheduleConsistencyTests.cs
@@ -1,0 +1,142 @@
+using Finanzuebersicht.Application.UseCases.Dashboard;
+using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Tests.TestHelpers;
+
+namespace Finanzuebersicht.Tests.Application.UseCases;
+
+public class RecurringScheduleConsistencyTests
+{
+    [Fact]
+    public void MonthForecastAndCashflowDayLoop_AgreeOnSkippedMonthlyInstance()
+    {
+        var recurring = new RecurringTransaction
+        {
+            Id = "rec-skip",
+            Titel = "Abo",
+            Betrag = 15m,
+            Typ = TransactionType.Ausgabe,
+            Aktiv = true,
+            Startdatum = new DateTime(2026, 1, 1),
+            Interval = RecurrenceInterval.Monthly,
+            Exceptions =
+            [
+                new RecurringException
+                {
+                    InstanceDate = new DateTime(2026, 4, 1),
+                    Type = RecurringExceptionType.Skip
+                }
+            ]
+        };
+
+        var monthStart = new DateTime(2026, 4, 1);
+        var monthEnd = new DateTime(2026, 4, 30);
+
+        var occursInMonth = RecurringScheduleCalculator.OccursInRange(recurring, monthStart, monthEnd);
+        var occursOnAnyDayInMonth = false;
+        for (var day = monthStart; day <= monthEnd; day = day.AddDays(1))
+        {
+            if (RecurringScheduleCalculator.OccursOnDate(recurring, day))
+            {
+                occursOnAnyDayInMonth = true;
+                break;
+            }
+        }
+
+        Assert.False(occursInMonth);
+        Assert.False(occursOnAnyDayInMonth);
+    }
+
+    [Fact]
+    public async Task DashboardMonthForecast_ExcludesSkippedRecurringInFutureMonth()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        var budgetRepository = Substitute.For<IBudgetRepository>();
+
+        categoryRepository.GetCategoriesAsync().Returns(
+        [
+            new Category { Id = "cat-a", Name = "Abo", Typ = TransactionType.Ausgabe }
+        ]);
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns([]);
+        recurringRepository.GetRecurringTransactionsAsync().Returns(
+        [
+            new RecurringTransaction
+            {
+                Id = "rec-1",
+                Titel = "Streaming",
+                Betrag = 15m,
+                KategorieId = "cat-a",
+                Typ = TransactionType.Ausgabe,
+                Aktiv = true,
+                Startdatum = new DateTime(2026, 1, 1),
+                Interval = RecurrenceInterval.Monthly,
+                Exceptions =
+                [
+                    new RecurringException
+                    {
+                        InstanceDate = new DateTime(2026, 4, 1),
+                        Type = RecurringExceptionType.Skip
+                    }
+                ]
+            }
+        ]);
+
+        var useCase = new LoadDashboardMonthUseCase(
+            categoryRepository,
+            transactionRepository,
+            recurringRepository,
+            budgetRepository);
+
+        var result = await useCase.ExecuteAsync(new DateTime(2026, 4, 1), new DateTime(2026, 3, 15));
+
+        Assert.True(result.IstPrognose);
+        Assert.Equal(0m, result.GesamtAusgaben);
+    }
+
+    [Fact]
+    public async Task CashflowOutlook_DoesNotProjectSkippedDayInstance()
+    {
+        var today = new DateTime(2026, 4, 1);
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns([]);
+
+        var recurringRepository = Substitute.For<IRecurringTransactionRepository>();
+        recurringRepository.GetRecurringTransactionsAsync().Returns(
+        [
+            new RecurringTransaction
+            {
+                Id = "rec-1",
+                Titel = "Streaming",
+                Betrag = 15m,
+                Typ = TransactionType.Ausgabe,
+                Aktiv = true,
+                Startdatum = new DateTime(2026, 1, 1),
+                Interval = RecurrenceInterval.Monthly,
+                AccountId = "acc-1",
+                Exceptions =
+                [
+                    new RecurringException
+                    {
+                        InstanceDate = new DateTime(2026, 4, 1),
+                        Type = RecurringExceptionType.Skip
+                    }
+                ]
+            }
+        ]);
+
+        var sut = new LoadCashflowOutlookUseCase(
+            transactionRepository,
+            recurringRepository,
+            new FixedClock(today));
+
+        var result = await sut.ExecuteAsync(accountId: "acc-1");
+
+        Assert.DoesNotContain(
+            result.Days.SelectMany(d => d.Entries),
+            e => e.Title == "Streaming" && e.IsProjected && e.Date == new DateTime(2026, 4, 1) && !e.IsOverdue);
+    }
+}

--- a/Finanzuebersicht.Tests/Application/UseCases/Transactions/GetEarliestTransactionYearUseCaseTests.cs
+++ b/Finanzuebersicht.Tests/Application/UseCases/Transactions/GetEarliestTransactionYearUseCaseTests.cs
@@ -1,0 +1,38 @@
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Models;
+
+namespace Finanzuebersicht.Tests.Application.UseCases.Transactions;
+
+public class GetEarliestTransactionYearUseCaseTests
+{
+    [Fact]
+    public async Task ExecuteAsync_ReturnsMinimumYear_WhenTransactionsExist()
+    {
+        var repository = Substitute.For<ITransactionRepository>();
+        repository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue).Returns(
+        [
+            new Transaction { Datum = new DateTime(2024, 6, 1) },
+            new Transaction { Datum = new DateTime(2022, 1, 15) },
+            new Transaction { Datum = new DateTime(2026, 3, 1) }
+        ]);
+
+        var sut = new GetEarliestTransactionYearUseCase(repository);
+
+        var result = await sut.ExecuteAsync();
+
+        Assert.Equal(2022, result);
+    }
+
+    [Fact]
+    public async Task ExecuteAsync_ReturnsNull_WhenNoTransactionsExist()
+    {
+        var repository = Substitute.For<ITransactionRepository>();
+        repository.GetTransactionsAsync(DateTime.MinValue, DateTime.MaxValue).Returns([]);
+
+        var sut = new GetEarliestTransactionYearUseCase(repository);
+
+        var result = await sut.ExecuteAsync();
+
+        Assert.Null(result);
+    }
+}

--- a/Finanzuebersicht.Tests/Core/Services/RecurringScheduleCalculatorTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/RecurringScheduleCalculatorTests.cs
@@ -261,6 +261,26 @@ public class RecurringScheduleCalculatorTests
     }
 
     [Fact]
+    public void OccursOnDate_ShiftLaterMonthInstance_ReturnsTrueOnShiftTargetDate()
+    {
+        var r = Make(
+            RecurrenceInterval.Monthly,
+            start: new DateTime(2026, 1, 31),
+            exceptions:
+            [
+                new RecurringException
+                {
+                    InstanceDate = new DateTime(2026, 2, 28),
+                    Type = RecurringExceptionType.Shift,
+                    ShiftToDate = new DateTime(2026, 3, 2)
+                }
+            ]);
+
+        Assert.False(RecurringScheduleCalculator.OccursOnDate(r, new DateTime(2026, 2, 28)));
+        Assert.True(RecurringScheduleCalculator.OccursOnDate(r, new DateTime(2026, 3, 2)));
+    }
+
+    [Fact]
     public void OccursInRange_AgreesWithDayByDayOccursOnDateScan()
     {
         var r = Make(

--- a/Finanzuebersicht.Tests/Core/Services/RecurringScheduleCalculatorTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/RecurringScheduleCalculatorTests.cs
@@ -217,4 +217,77 @@ public class RecurringScheduleCalculatorTests
         var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2025, 1, 1), end: new DateTime(2025, 3, 31));
         Assert.Null(RecurringScheduleCalculator.GetNextDueDate(r, new DateTime(2025, 5, 1)));
     }
+
+    // ── OccursOnDate / OccursInRange ─────────────────────────────────────────
+
+    [Fact]
+    public void OccursOnDate_MonthlyOnFifteenth_ReturnsTrueOnDueDay()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2026, 3, 15));
+        Assert.True(RecurringScheduleCalculator.OccursOnDate(r, new DateTime(2026, 3, 15)));
+        Assert.False(RecurringScheduleCalculator.OccursOnDate(r, new DateTime(2026, 3, 14)));
+    }
+
+    [Fact]
+    public void OccursInRange_MonthlyRecurring_ReturnsTrueForMonthContainingDueDate()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2026, 1, 1));
+        Assert.True(RecurringScheduleCalculator.OccursInRange(
+            r,
+            new DateTime(2026, 3, 1),
+            new DateTime(2026, 3, 31)));
+    }
+
+    [Fact]
+    public void OccursInRange_SkippedMonthInstance_ReturnsFalseForThatMonth()
+    {
+        var r = Make(RecurrenceInterval.Monthly, start: new DateTime(2026, 1, 1), exceptions:
+        [
+            new RecurringException
+            {
+                InstanceDate = new DateTime(2026, 3, 1),
+                Type = RecurringExceptionType.Skip
+            }
+        ]);
+
+        Assert.False(RecurringScheduleCalculator.OccursInRange(
+            r,
+            new DateTime(2026, 3, 1),
+            new DateTime(2026, 3, 31)));
+        Assert.True(RecurringScheduleCalculator.OccursInRange(
+            r,
+            new DateTime(2026, 4, 1),
+            new DateTime(2026, 4, 30)));
+    }
+
+    [Fact]
+    public void OccursInRange_AgreesWithDayByDayOccursOnDateScan()
+    {
+        var r = Make(
+            RecurrenceInterval.Monthly,
+            start: new DateTime(2026, 1, 31),
+            exceptions:
+            [
+                new RecurringException
+                {
+                    InstanceDate = new DateTime(2026, 2, 28),
+                    Type = RecurringExceptionType.Shift,
+                    ShiftToDate = new DateTime(2026, 3, 2)
+                }
+            ]);
+
+        var rangeStart = new DateTime(2026, 2, 1);
+        var rangeEnd = new DateTime(2026, 3, 31);
+        var dayScan = false;
+        for (var day = rangeStart; day <= rangeEnd; day = day.AddDays(1))
+        {
+            if (RecurringScheduleCalculator.OccursOnDate(r, day))
+            {
+                dayScan = true;
+                break;
+            }
+        }
+
+        Assert.Equal(dayScan, RecurringScheduleCalculator.OccursInRange(r, rangeStart, rangeEnd));
+    }
 }

--- a/Finanzuebersicht.Tests/ViewModels/AccountDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/AccountDetailViewModelTests.cs
@@ -1,0 +1,128 @@
+using System.Globalization;
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Tests.ViewModels;
+
+public class AccountDetailViewModelTests
+{
+    [Fact]
+    public void ApplyQueryAttributes_LoadsAccountFields()
+    {
+        var viewModel = CreateSut(out _);
+        var account = new Account
+        {
+            Id = "acc-1",
+            Name = "Giro",
+            Type = AccountType.Girokonto,
+            OpeningBalance = 1500m,
+            OpeningBalanceDate = new DateTime(2026, 1, 1)
+        };
+
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { ["Account"] = account });
+
+        Assert.Equal("Giro", viewModel.Name);
+        Assert.Equal(AccountType.Girokonto, viewModel.Type);
+        Assert.Equal(1500m.ToString("F2", CultureInfo.CurrentCulture), viewModel.OpeningBalanceText);
+        Assert.True(viewModel.UseOpeningBalanceDate);
+    }
+
+    [Fact]
+    public async Task Save_WithEmptyName_DoesNotPersist()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        var viewModel = CreateSut(out _, accountRepository);
+        viewModel.Name = "   ";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        await accountRepository.DidNotReceive().SaveAccountAsync(Arg.Any<Account>());
+    }
+
+    [Fact]
+    public async Task Save_WithValidData_PersistsAndNavigatesBack()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.SaveAccountAsync(Arg.Any<Account>()).Returns(Task.CompletedTask);
+
+        var viewModel = CreateSut(out var navigationService, accountRepository);
+        viewModel.Name = "Neues Konto";
+        viewModel.OpeningBalanceText = "250";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        await accountRepository.Received(1).SaveAccountAsync(Arg.Is<Account>(a => a.Name == "Neues Konto"));
+        await navigationService.Received(1).GoBackAsync();
+    }
+
+    [Fact]
+    public async Task Reconcile_WithInvalidActualBalance_ShowsValidationDialog()
+    {
+        var viewModel = CreateSut(out _, out var dialogService);
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object>
+        {
+            ["Account"] = new Account { Id = "acc-1", Name = "Giro", OpeningBalance = 1000m }
+        });
+        viewModel.ActualBalanceText = "abc";
+
+        await viewModel.ReconcileCommand.ExecuteAsync(null);
+
+        await dialogService.Received(1).ShowAlertAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>());
+    }
+
+    private static AccountDetailViewModel CreateSut(
+        out INavigationService navigationService,
+        IAccountRepository? accountRepository = null,
+        ITransactionRepository? transactionRepository = null)
+        => CreateSut(out navigationService, out _, accountRepository, transactionRepository);
+
+    private static AccountDetailViewModel CreateSut(
+        out INavigationService navigationService,
+        out IDialogService dialogService,
+        IAccountRepository? accountRepository = null,
+        ITransactionRepository? transactionRepository = null)
+    {
+        accountRepository ??= Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns([]);
+        accountRepository.SaveAccountAsync(Arg.Any<Account>()).Returns(Task.CompletedTask);
+
+        transactionRepository ??= Substitute.For<ITransactionRepository>();
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns([]);
+
+        navigationService = Substitute.For<INavigationService>();
+        navigationService.GoBackAsync().Returns(Task.CompletedTask);
+
+        var localizationService = Substitute.For<ILocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(call => call.Arg<string>());
+        localizationService.GetString(Arg.Any<string>(), Arg.Any<object[]>()).Returns(call => call.Arg<string>());
+
+        dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.CompletedTask);
+
+        var feedbackService = Substitute.For<IFeedbackService>();
+        feedbackService.ShowSnackbarAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+
+        var appEvents = Substitute.For<IAppEvents>();
+
+        return new AccountDetailViewModel(
+            new SaveAccountDetailUseCase(accountRepository),
+            new GetAccountBalancesUseCase(accountRepository, transactionRepository),
+            new ReconcileAccountBalanceUseCase(
+                accountRepository,
+                new GetAccountBalancesUseCase(accountRepository, transactionRepository),
+                new SaveAccountDetailUseCase(accountRepository)),
+            navigationService,
+            localizationService,
+            dialogService,
+            feedbackService,
+            appEvents);
+    }
+}

--- a/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/DashboardViewModelTests.cs
@@ -1,6 +1,7 @@
 using Finanzuebersicht.Application.UseCases.Accounts;
 using Finanzuebersicht.Application.UseCases.Dashboard;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Models;
@@ -214,12 +215,12 @@ public class DashboardViewModelTests
             new GetDueRecurringWithHintsUseCase(recurringTransactionRepository),
             new BookDueRecurringInstanceUseCase(recurringTransactionRepository, transactionRepository, accountRepository),
             new SkipDueRecurringInstanceUseCase(new AddRecurringExceptionUseCase(recurringTransactionRepository)),
-            budgetRepository,
+            new GetDefaultBudgetTotalUseCase(budgetRepository),
+            new LoadActiveAccountsUseCase(accountRepository),
+            new GetEarliestTransactionYearUseCase(transactionRepository),
             localizationService,
             navigationService,
             Substitute.For<IDialogService>(),
-            transactionRepository,
-            accountRepository,
             new GetAccountBalancesUseCase(accountRepository, transactionRepository),
             settingsService,
             clock);

--- a/Finanzuebersicht.Tests/ViewModels/TransactionDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/TransactionDetailViewModelTests.cs
@@ -1,0 +1,134 @@
+using System.Globalization;
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Application.UseCases.SparZiele;
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Tests.ViewModels;
+
+public class TransactionDetailViewModelTests
+{
+    [Fact]
+    public void ApplyQueryAttributes_LoadsExistingTransactionFields()
+    {
+        var viewModel = CreateSut(out _);
+        var transaction = new Transaction
+        {
+            Id = "tx-1",
+            Titel = "Supermarkt",
+            Betrag = 42.50m,
+            KategorieId = "cat-1",
+            AccountId = "acc-1",
+            Typ = TransactionType.Ausgabe,
+            Datum = new DateTime(2026, 3, 10),
+            Verwendungszweck = "Wocheneinkauf"
+        };
+
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { ["Transaction"] = transaction });
+
+        Assert.Equal("Supermarkt", viewModel.Titel);
+        Assert.Equal(42.50m.ToString("F2", CultureInfo.CurrentCulture), viewModel.BetragText);
+        Assert.Equal(TransactionType.Ausgabe, viewModel.Typ);
+        Assert.Equal("Wocheneinkauf", viewModel.Verwendungszweck);
+    }
+
+    [Fact]
+    public async Task Save_WithMissingTitle_ShowsValidationDialog()
+    {
+        var viewModel = CreateSut(out var dialogService);
+        viewModel.BetragText = "10";
+        viewModel.Titel = "   ";
+        viewModel.SelectedKategorie = new Category { Id = "cat-1", Name = "Essen" };
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        await dialogService.Received(1).ShowAlertAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Save_WithValidData_PersistsAndNavigatesBack()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.SaveTransactionAsync(Arg.Any<Transaction>()).Returns(Task.CompletedTask);
+
+        var viewModel = CreateSut(out _, out var navigationService, transactionRepository);
+
+        viewModel.BetragText = "25,50";
+        viewModel.Titel = "Test";
+        viewModel.SelectedKategorie = new Category { Id = "cat-1", Name = "Essen" };
+        viewModel.SelectedAccount = new Account { Id = "acc-1", Name = "Giro" };
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        await transactionRepository.Received(1).SaveTransactionAsync(Arg.Is<Transaction>(t => t.Titel == "Test"));
+        await navigationService.Received(1).GoBackAsync();
+    }
+
+    private static TransactionDetailViewModel CreateSut(
+        out IDialogService dialogService,
+        ITransactionRepository? transactionRepository = null)
+        => CreateSut(out dialogService, out _, transactionRepository);
+
+    private static TransactionDetailViewModel CreateSut(
+        out IDialogService dialogService,
+        out INavigationService navigationService,
+        ITransactionRepository? transactionRepository = null)
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(
+        [
+            new Category { Id = "cat-1", Name = "Essen", SystemKey = Finanzuebersicht.Constants.SystemCategoryKeys.Sonstiges }
+        ]);
+
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(
+        [
+            new Account { Id = "acc-1", Name = "Giro", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        ]);
+
+        transactionRepository ??= Substitute.For<ITransactionRepository>();
+        transactionRepository.SaveTransactionAsync(Arg.Any<Transaction>()).Returns(Task.CompletedTask);
+        transactionRepository.GetTransactionsAsync(Arg.Any<DateTime>(), Arg.Any<DateTime>())
+            .Returns([]);
+
+        var sparZielRepository = Substitute.For<ISparZielRepository>();
+        sparZielRepository.GetSparZieleAsync().Returns([]);
+
+        var saveUseCase = new SaveTransactionDetailUseCase(transactionRepository, accountRepository);
+
+        dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.CompletedTask);
+
+        var navigationServiceSubstitute = Substitute.For<INavigationService>();
+        navigationServiceSubstitute.GoBackAsync().Returns(Task.CompletedTask);
+        navigationService = navigationServiceSubstitute;
+
+        var localizationService = Substitute.For<ILocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(call => call.Arg<string>());
+        localizationService.GetString(Arg.Any<string>(), Arg.Any<object[]>()).Returns(call => call.Arg<string>());
+
+        var feedbackService = Substitute.For<IFeedbackService>();
+        feedbackService.ShowSnackbarAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+
+        var appEvents = Substitute.For<IAppEvents>();
+
+        return new TransactionDetailViewModel(
+            saveUseCase,
+            new LoadTransactionDetailDataUseCase(categoryRepository, accountRepository),
+            new LoadSparZieleUseCase(sparZielRepository, transactionRepository),
+            new TransactionValidationService(),
+            localizationService,
+            navigationServiceSubstitute,
+            dialogService,
+            feedbackService,
+            appEvents);
+    }
+}

--- a/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/TransactionsViewModelTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Threading.Tasks;
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Application.UseCases.Categories;
 using Finanzuebersicht.Application.UseCases.Transactions;
 using Finanzuebersicht.Models;
 using Finanzuebersicht.Navigation;
@@ -333,8 +335,8 @@ public class TransactionsViewModelTests
             dialogService,
             feedbackService,
             localizationService,
-            loadCategoryRepository,
-            loadAccountRepository,
+            new LoadCategoriesUseCase(loadCategoryRepository),
+            new LoadAccountsUseCase(loadAccountRepository),
             dispatcher,
             filePicker,
             appEvents,

--- a/Finanzuebersicht.Tests/ViewModels/TransferDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/TransferDetailViewModelTests.cs
@@ -1,0 +1,128 @@
+using System.Globalization;
+using Finanzuebersicht.Application.UseCases.Accounts;
+using Finanzuebersicht.Application.UseCases.Transactions;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Tests.ViewModels;
+
+public class TransferDetailViewModelTests
+{
+    [Fact]
+    public async Task LoadAccounts_SelectsDefaultSourceAndDifferentTarget()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(
+        [
+            new Account { Id = "acc-1", Name = "Giro", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default },
+            new Account { Id = "acc-2", Name = "Sparkonto" }
+        ]);
+
+        var viewModel = CreateSut(accountRepository, out _, out _);
+
+        await viewModel.LoadAccountsCommand.ExecuteAsync(null);
+
+        Assert.Equal("acc-1", viewModel.SourceAccount?.Id);
+        Assert.Equal("acc-2", viewModel.TargetAccount?.Id);
+    }
+
+    [Fact]
+    public async Task Save_WithInvalidAmount_ShowsValidationDialog()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns([]);
+        var viewModel = CreateSut(accountRepository, out var dialogService, out _);
+        await viewModel.LoadAccountsCommand.ExecuteAsync(null);
+        viewModel.AmountText = "abc";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        await dialogService.Received(1).ShowAlertAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Save_WithSameAccounts_ShowsValidationDialog()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(
+        [
+            new Account { Id = "acc-1", Name = "Giro", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        ]);
+
+        var viewModel = CreateSut(accountRepository, out var dialogService, out _);
+        await viewModel.LoadAccountsCommand.ExecuteAsync(null);
+        viewModel.AmountText = "100";
+        viewModel.TargetAccount = viewModel.SourceAccount;
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        await dialogService.Received(1).ShowAlertAsync(
+            Arg.Any<string>(),
+            Arg.Any<string>(),
+            Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task Save_WithValidData_PersistsAndNavigatesBack()
+    {
+        var transactionRepository = Substitute.For<ITransactionRepository>();
+        transactionRepository.SaveTransactionsAsync(Arg.Any<IEnumerable<Transaction>>()).Returns(Task.CompletedTask);
+
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(
+        [
+            new Account { Id = "acc-1", Name = "Giro", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default },
+            new Account { Id = "acc-2", Name = "Sparkonto" }
+        ]);
+
+        var viewModel = CreateSut(accountRepository, out _, out var navigationService, transactionRepository);
+        await viewModel.LoadAccountsCommand.ExecuteAsync(null);
+        viewModel.AmountText = 150m.ToString("F2", CultureInfo.CurrentCulture);
+        viewModel.Title = "Umbuchung";
+
+        await viewModel.SaveCommand.ExecuteAsync(null);
+
+        await transactionRepository.Received(1).SaveTransactionsAsync(Arg.Any<IEnumerable<Transaction>>());
+        await navigationService.Received(1).GoBackAsync();
+    }
+
+    private static TransferDetailViewModel CreateSut(
+        IAccountRepository accountRepository,
+        out IDialogService dialogService,
+        out INavigationService navigationService,
+        ITransactionRepository? transactionRepository = null)
+    {
+        transactionRepository ??= Substitute.For<ITransactionRepository>();
+        transactionRepository.SaveTransactionsAsync(Arg.Any<IEnumerable<Transaction>>()).Returns(Task.CompletedTask);
+
+        dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.CompletedTask);
+
+        navigationService = Substitute.For<INavigationService>();
+        navigationService.GoBackAsync().Returns(Task.CompletedTask);
+
+        var localizationService = Substitute.For<ILocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(call => call.Arg<string>());
+        localizationService.GetString(Arg.Any<string>(), Arg.Any<object[]>()).Returns(call => call.Arg<string>());
+
+        var feedbackService = Substitute.For<IFeedbackService>();
+        feedbackService.ShowSnackbarAsync(Arg.Any<string>()).Returns(Task.CompletedTask);
+
+        var appEvents = Substitute.For<IAppEvents>();
+
+        return new TransferDetailViewModel(
+            new SaveTransferUseCase(transactionRepository, accountRepository),
+            new LoadActiveAccountsUseCase(accountRepository),
+            navigationService,
+            dialogService,
+            localizationService,
+            feedbackService,
+            appEvents);
+    }
+}


### PR DESCRIPTION
## Summary

- **Recurring-Schedule als Single Source of Truth:** `OccursOnDate` und `OccursInRange` in `RecurringScheduleCalculator`; duplizierte Logik aus `LoadDashboardMonthUseCase`, `LoadCashflowOutlookUseCase` und `RecurringTransactionDetailViewModel` entfernt
- **Neue Use Cases:** `GetEarliestTransactionYearUseCase`, `LoadActiveAccountsUseCase`, `GetDefaultBudgetTotalUseCase` — ViewModels greifen nicht mehr direkt auf Repositories zu
- **Tests:** Regressionstests für Schedule-Konsistenz (Dashboard vs. Cashflow); neue VM-Tests für Transaction/Transfer/Account-Detail

## Offene Follow-ups (Issues angelegt)

| # | Thema | Priorität |
|---|-------|-----------|
| #267 | DashboardViewModel aufteilen | medium |
| #268 | IDataService entfernen | low |
| #269 | Import/Backup in Application-Layer | medium |
| #270 | CategoryDetailViewModel Budget-Use-Case | low |
| #271 | App-Static-Events → IAppEvents | medium |
| #272 | Magic Strings zentralisieren | low |
| #273 | Vollscan `GetTransactionsAsync` eliminieren | medium |
| #274 | Einheitliches Fehler-/Result-Modell | medium |

## Test plan

- [x] `dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj -c Release` — 330/330 grün
- [ ] Dashboard: Monatsprognose mit Dauerauftrag (inkl. Skip/Shift) manuell prüfen
- [ ] Cashflow-Seite: Kontofilter und projizierte Einträge
- [ ] Transaktion anlegen / Umbuchung / Konto bearbeiten

Made with [Cursor](https://cursor.com)