### PR TITLE
feat(ux): Einheitliches Anlegen — Inline-Panel & Sheet (#265)

### DIFF
--- a/.cursor/rules/app-domain.mdc
+++ b/.cursor/rules/app-domain.mdc
@@ -20,6 +20,13 @@ alwaysApply: true
 - Native `Picker` durch `SelectionField` + `SelectionPopup` ersetzt (macOS 27 Beta Workaround, PR #218)
 - `DatePicker` bleibt nativ; Details: `.cursor/rules/maccatalyst-picker-investigation.mdc`
 
+## Einheitliches Anlegen (#265 ✅ v1.19)
+
+- **Inline:** `CreateFormCard` — Konten, Sparziele (Panel oben, Scroll-to-top)
+- **Sheet:** `FormSheetPopup` — Kategorien, Daueraufträge
+- **Bearbeiten:** weiter auf `*DetailPage`
+- Doku: `docs/CREATE_UX.md`
+
 ## Konten & Salden
 
 - `GetAccountBalancesUseCase`: Saldo = Anfangssaldo + Σ Buchungen (Transfers korrekt)

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -146,6 +146,19 @@ Layered clean architecture with MVVM (`CommunityToolkit.Mvvm` source generators)
 
 Native `Picker` controls freeze on **macOS 27 Beta** when scrolling inside picker dialogs in `ScrollView` forms. Workaround: **`SelectionField`** + **`SelectionPopup`** (`Finanzuebersicht/Controls/`, `Finanzuebersicht/Views/Popups/`). Used across detail pages, filters, and import preview. `DatePicker` remains native. Revert to native `Picker` when MAUI SR6 ([#33146](https://github.com/dotnet/maui/pull/33146)) is available. Details: `.cursor/rules/maccatalyst-picker-investigation.mdc`
 
+### Create UX (#265, v1.19)
+
+Unified **create** flows — no navigation push for new entries from list FAB/empty state:
+
+| Entity | Create | Edit |
+|--------|--------|------|
+| Konto | `CreateFormCard` inline top (`CategoriesPage`) | `AccountDetailPage` |
+| Sparziel | `CreateFormCard` inline top (`SparZielePage`) | `SparZielDetailPage` |
+| Kategorie | `FormSheetPopup` + `CategoryFormView` | `CategoryDetailPage` |
+| Dauerauftrag | `FormSheetPopup` + `RecurringTransactionFormView` | `RecurringTransactionDetailPage` |
+
+Components: `CreateFormCard`, `FormSheetPopup`, `CategoryCreateSheetService`, `RecurringTransactionCreateSheetService`. Full reference: `docs/CREATE_UX.md`.
+
 ## Versioning
 
 Automatic **SemVer** via **Nerdbank.GitVersioning** (`version.json`):

--- a/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
+++ b/Finanzuebersicht.Presentation/Resources/Strings/ResourceKeys.cs
@@ -423,4 +423,6 @@ public static class ResourceKeys
     public const string A11y_SelectionField = nameof(A11y_SelectionField);
     public const string A11y_SelectionFieldLeer = nameof(A11y_SelectionFieldLeer);
     public const string A11y_SegmentUmschalten = nameof(A11y_SegmentUmschalten);
+    public const string A11y_CreateFormPanel = nameof(A11y_CreateFormPanel);
+    public const string A11y_FormSheetDialog = nameof(A11y_FormSheetDialog);
 }

--- a/Finanzuebersicht.Presentation/Services/ICategoryCreateSheetService.cs
+++ b/Finanzuebersicht.Presentation/Services/ICategoryCreateSheetService.cs
@@ -1,0 +1,8 @@
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Presentation.Services;
+
+public interface ICategoryCreateSheetService
+{
+    Task<bool> ShowAsync(CategoryDetailViewModel viewModel);
+}

--- a/Finanzuebersicht.Presentation/Services/IRecurringTransactionCreateSheetService.cs
+++ b/Finanzuebersicht.Presentation/Services/IRecurringTransactionCreateSheetService.cs
@@ -1,0 +1,8 @@
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Presentation.Services;
+
+public interface IRecurringTransactionCreateSheetService
+{
+    Task<bool> ShowAsync(RecurringTransactionDetailViewModel viewModel);
+}

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -19,6 +19,7 @@ public partial class CategoriesViewModel(
     LoadCategoriesUseCase loadCategoriesUseCase,
     LoadAccountsUseCase loadAccountsUseCase,
     GetAccountBalancesUseCase getAccountBalancesUseCase,
+    SaveAccountDetailUseCase saveAccountDetailUseCase,
     ToggleAccountArchiveUseCase toggleAccountArchiveUseCase,
     DeleteAccountUseCase deleteAccountUseCase,
     ILocalizationService localizationService,
@@ -32,6 +33,7 @@ public partial class CategoriesViewModel(
     private readonly LoadCategoriesUseCase _loadCategoriesUseCase = loadCategoriesUseCase;
     private readonly LoadAccountsUseCase _loadAccountsUseCase = loadAccountsUseCase;
     private readonly GetAccountBalancesUseCase _getAccountBalancesUseCase = getAccountBalancesUseCase;
+    private readonly SaveAccountDetailUseCase _saveAccountDetailUseCase = saveAccountDetailUseCase;
     private readonly ToggleAccountArchiveUseCase _toggleAccountArchiveUseCase = toggleAccountArchiveUseCase;
     private readonly DeleteAccountUseCase _deleteAccountUseCase = deleteAccountUseCase;
     private readonly ILocalizationService _loc = localizationService;
@@ -54,6 +56,7 @@ public partial class CategoriesViewModel(
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(ShowGesamtSaldoHeader))]
     [NotifyPropertyChangedFor(nameof(IsKontenEmpty))]
+    [NotifyPropertyChangedFor(nameof(IsKontenEmptyStateVisible))]
     private ObservableCollection<AccountListItem> konten = [];
 
     public bool IsKontenEmpty => Konten.Count == 0;
@@ -79,11 +82,15 @@ public partial class CategoriesViewModel(
     partial void OnSelectedSectionIndexChanged(int value)
     {
         OnPropertyChanged(nameof(FabAccessibilityDescription));
+        if (value == 0)
+            ShowAddKontoForm = false;
     }
 
     public void RefreshLocalizedStrings()
     {
         OnPropertyChanged(nameof(FabAccessibilityDescription));
+        OnPropertyChanged(nameof(NeuesKontoFormTitle));
+        OnPropertyChanged(nameof(VerfuegbareKontoTypen));
         _ = LoadKategorienCore();
     }
 
@@ -91,6 +98,33 @@ public partial class CategoriesViewModel(
 
     [ObservableProperty]
     private bool isLoading;
+
+    [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsKontenEmptyStateVisible))]
+    private bool showAddKontoForm;
+
+    [ObservableProperty]
+    private string neuerKontoName = string.Empty;
+
+    [ObservableProperty]
+    private AccountTypeOption? selectedKontoTypeOption;
+
+    [ObservableProperty]
+    private string neuerAnfangssaldoText = string.Empty;
+
+    public bool IsKontenEmptyStateVisible => IsKontenEmpty && !ShowAddKontoForm;
+
+    public string NeuesKontoFormTitle => _loc.GetString(ResourceKeys.Title_KontoHinzufuegen);
+
+    public List<AccountTypeOption> VerfuegbareKontoTypen =>
+    [
+        new(AccountType.Girokonto, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Girokonto))),
+        new(AccountType.Tagesgeld, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Tagesgeld))),
+        new(AccountType.Kreditkarte, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Kreditkarte))),
+        new(AccountType.Bargeld, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Bargeld))),
+        new(AccountType.Depot, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Depot))),
+        new(AccountType.Sonstiges, _loc.GetString(EnumResourceKeys.GetAccountType(AccountType.Sonstiges)))
+    ];
 
     [RelayCommand]
     private void ShowKategorien() => SelectedSectionIndex = 0;
@@ -239,6 +273,60 @@ public partial class CategoriesViewModel(
     }
 
     [RelayCommand]
+    private void ToggleAddKontoForm()
+    {
+        ShowAddKontoForm = !ShowAddKontoForm;
+        if (!ShowAddKontoForm)
+            return;
+
+        NeuerKontoName = string.Empty;
+        NeuerAnfangssaldoText = string.Empty;
+        SelectedKontoTypeOption = VerfuegbareKontoTypen.FirstOrDefault(t => t.Value == AccountType.Girokonto)
+            ?? VerfuegbareKontoTypen.FirstOrDefault();
+    }
+
+    [RelayCommand]
+    private async Task SaveNewKonto()
+    {
+        if (string.IsNullOrWhiteSpace(NeuerKontoName))
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_TitelErforderlich),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        if (!TryParseAnfangssaldo(out var openingBalance))
+        {
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_UngueltigerBetrag),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return;
+        }
+
+        try
+        {
+            var type = SelectedKontoTypeOption?.Value ?? AccountType.Girokonto;
+            await _saveAccountDetailUseCase.ExecuteAsync(
+                null, NeuerKontoName.Trim(), type, openingBalance: openingBalance);
+            ShowAddKontoForm = false;
+            _appEvents.NotifyDataChanged();
+            await LoadKategorienCore(force: true);
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "CategoriesViewModel: {Context}", nameof(SaveNewKonto));
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+        }
+    }
+
+    [RelayCommand]
     private async Task GoToDetail(object? item = null)
     {
         if (item is AccountListItem kontoItem)
@@ -253,7 +341,7 @@ public partial class CategoriesViewModel(
 
         if (item == null && IsKontenVisible)
         {
-            await _navigationService.GoToAsync(Routes.AccountDetail);
+            ToggleAddKontoForm();
             return;
         }
 
@@ -262,5 +350,20 @@ public partial class CategoriesViewModel(
             parameter["Category"] = kategorie;
 
         await _navigationService.GoToAsync(Routes.CategoryDetail, parameter);
+    }
+
+    private bool TryParseAnfangssaldo(out decimal openingBalance)
+    {
+        if (string.IsNullOrWhiteSpace(NeuerAnfangssaldoText))
+        {
+            openingBalance = 0m;
+            return true;
+        }
+
+        return decimal.TryParse(
+            NeuerAnfangssaldoText,
+            NumberStyles.Number,
+            CultureInfo.CurrentCulture,
+            out openingBalance);
     }
 }

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -22,6 +22,8 @@ public partial class CategoriesViewModel(
     SaveAccountDetailUseCase saveAccountDetailUseCase,
     ToggleAccountArchiveUseCase toggleAccountArchiveUseCase,
     DeleteAccountUseCase deleteAccountUseCase,
+    CategoryDetailViewModel createCategoryViewModel,
+    ICategoryCreateSheetService categoryCreateSheetService,
     ILocalizationService localizationService,
     INavigationService navigationService,
     IDialogService dialogService,
@@ -36,6 +38,8 @@ public partial class CategoriesViewModel(
     private readonly SaveAccountDetailUseCase _saveAccountDetailUseCase = saveAccountDetailUseCase;
     private readonly ToggleAccountArchiveUseCase _toggleAccountArchiveUseCase = toggleAccountArchiveUseCase;
     private readonly DeleteAccountUseCase _deleteAccountUseCase = deleteAccountUseCase;
+    private readonly CategoryDetailViewModel _createCategoryViewModel = createCategoryViewModel;
+    private readonly ICategoryCreateSheetService _categoryCreateSheetService = categoryCreateSheetService;
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
@@ -345,11 +349,22 @@ public partial class CategoriesViewModel(
             return;
         }
 
-        var parameter = new Dictionary<string, object>();
-        if (item is Category kategorie)
-            parameter["Category"] = kategorie;
+        if (item == null && IsKategorienVisible)
+        {
+            _createCategoryViewModel.ResetForCreate();
+            if (await _categoryCreateSheetService.ShowAsync(_createCategoryViewModel))
+                await LoadKategorienCore(force: true);
+            return;
+        }
 
-        await _navigationService.GoToAsync(Routes.CategoryDetail, parameter);
+        if (item is Category kategorie)
+        {
+            var parameter = new Dictionary<string, object> { ["Category"] = kategorie };
+            await _navigationService.GoToAsync(Routes.CategoryDetail, parameter);
+            return;
+        }
+
+        await _navigationService.GoToAsync(Routes.CategoryDetail);
     }
 
     private bool TryParseAnfangssaldo(out decimal openingBalance)

--- a/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
@@ -16,6 +16,7 @@ public partial class CategoryDetailViewModel(
     ILocalizationService localizationService,
     IFeedbackService feedbackService,
     IAppEvents appEvents,
+    IDialogService dialogService,
     SaveCategoryBudgetUseCase? saveCategoryBudgetUseCase = null,
     IBudgetRepository? budgetRepository = null,
     ILogger<CategoryDetailViewModel>? logger = null) : ObservableObject, IApplyQueryAttributes, ILocalizableViewModel
@@ -25,6 +26,7 @@ public partial class CategoryDetailViewModel(
     private readonly ILocalizationService _loc = localizationService;
     private readonly IFeedbackService _feedbackService = feedbackService;
     private readonly IAppEvents _appEvents = appEvents;
+    private readonly IDialogService _dialogService = dialogService;
     private readonly SaveCategoryBudgetUseCase? _saveCategoryBudgetUseCase = saveCategoryBudgetUseCase;
     private readonly IBudgetRepository? _budgetRepository = budgetRepository;
     private readonly ILogger<CategoryDetailViewModel>? _logger = logger;
@@ -140,17 +142,55 @@ public partial class CategoryDetailViewModel(
     [RelayCommand]
     private async Task Save()
     {
-        if (string.IsNullOrWhiteSpace(Name)) return;
+        if (await TrySaveAsync())
+            await _navigationService.GoBackAsync();
+    }
 
-        var savedCategory = await _saveCategoryDetailUseCase.ExecuteAsync(_existingCategory, Name, Icon, Color, Typ);
-        if (_saveCategoryBudgetUseCase != null && !string.IsNullOrEmpty(savedCategory.Id))
+    public void ResetForCreate()
+    {
+        _existingCategory = null;
+        Name = string.Empty;
+        Icon = "💰";
+        Color = "#007AFF";
+        Typ = TransactionType.Ausgabe;
+        MonthlyBudgetText = string.Empty;
+        SelectedTypeOption = VerfuegbareTypen.FirstOrDefault(option => option.Value == Typ);
+        OnPropertyChanged(nameof(PageTitle));
+    }
+
+    public async Task<bool> TrySaveAsync()
+    {
+        if (string.IsNullOrWhiteSpace(Name))
         {
-            decimal.TryParse(MonthlyBudgetText, NumberStyles.Any, CultureInfo.CurrentCulture, out var budget);
-            await _saveCategoryBudgetUseCase.ExecuteAsync(savedCategory.Id, budget);
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_TitelErforderlich),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return false;
         }
-        _appEvents.NotifyDataChanged();
-        await _navigationService.GoBackAsync();
-        await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
+
+        try
+        {
+            var savedCategory = await _saveCategoryDetailUseCase.ExecuteAsync(_existingCategory, Name, Icon, Color, Typ);
+            if (_saveCategoryBudgetUseCase != null && !string.IsNullOrEmpty(savedCategory.Id))
+            {
+                decimal.TryParse(MonthlyBudgetText, NumberStyles.Any, CultureInfo.CurrentCulture, out var budget);
+                await _saveCategoryBudgetUseCase.ExecuteAsync(savedCategory.Id, budget);
+            }
+
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "CategoryDetailViewModel: {Context}", nameof(TrySaveAsync));
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return false;
+        }
     }
 }
 

--- a/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
@@ -172,6 +172,9 @@ public partial class CategoryDetailViewModel(
         try
         {
             var savedCategory = await _saveCategoryDetailUseCase.ExecuteAsync(_existingCategory, Name, Icon, Color, Typ);
+            _existingCategory = savedCategory;
+            OnPropertyChanged(nameof(PageTitle));
+
             if (_saveCategoryBudgetUseCase != null && !string.IsNullOrEmpty(savedCategory.Id))
             {
                 decimal.TryParse(MonthlyBudgetText, NumberStyles.Any, CultureInfo.CurrentCulture, out var budget);

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -201,6 +201,8 @@ public partial class RecurringTransactionDetailViewModel(
         ReminderDaysBefore = 0;
         ReminderDaysBeforeText = "0";
         Exceptions = [];
+        SelectedKategorie = null;
+        SelectedAccount = null;
         SelectedIntervalOption = VerfuegbareIntervalle.FirstOrDefault(option => option.Value == Interval);
         OnPropertyChanged(nameof(IsEditing));
         await LoadKategorienCommand.ExecuteAsync(null);

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -106,6 +106,10 @@ public partial class RecurringTransactionDetailViewModel(
     public IReadOnlyList<RecurrenceIntervalOption> VerfuegbareIntervalle =>
         _verfuegbareIntervalle ??= BuildIntervalOptions();
 
+    public string PageTitle => _loc.GetString(ResourceKeys.Title_Dauerauftrag);
+
+    public bool IsEditing => _existing != null;
+
     partial void OnIntervalChanged(RecurrenceInterval value)
     {
         SelectedIntervalOption = VerfuegbareIntervalle.FirstOrDefault(option => option.Value == value);
@@ -144,6 +148,7 @@ public partial class RecurringTransactionDetailViewModel(
                 ReminderDaysBefore = value.ReminderDaysBefore;
                 ReminderDaysBeforeText = value.ReminderDaysBefore.ToString();
                 Exceptions = new ObservableCollection<RecurringException>(value.Exceptions ?? new List<RecurringException>());
+                OnPropertyChanged(nameof(IsEditing));
             }
         }
     }
@@ -176,6 +181,33 @@ public partial class RecurringTransactionDetailViewModel(
     [RelayCommand]
     private async Task Save()
     {
+        if (await TrySaveAsync())
+            await _navigationService.GoBackAsync();
+    }
+
+    public async Task ResetForCreateAsync()
+    {
+        _existing = null;
+        BetragText = string.Empty;
+        Titel = string.Empty;
+        Typ = TransactionType.Ausgabe;
+        Startdatum = _clock.Today;
+        HatEnddatum = false;
+        EnddatumWert = _clock.Today.AddYears(1);
+        Aktiv = true;
+        Interval = RecurrenceInterval.Monthly;
+        IntervalFactor = 1;
+        IntervalFactorText = "1";
+        ReminderDaysBefore = 0;
+        ReminderDaysBeforeText = "0";
+        Exceptions = [];
+        SelectedIntervalOption = VerfuegbareIntervalle.FirstOrDefault(option => option.Value == Interval);
+        OnPropertyChanged(nameof(IsEditing));
+        await LoadKategorienCommand.ExecuteAsync(null);
+    }
+
+    public async Task<bool> TrySaveAsync()
+    {
         if (!_validationService.TryValidate(
                 BetragText,
                 Titel,
@@ -196,20 +228,17 @@ public partial class RecurringTransactionDetailViewModel(
                 _loc.GetString(ResourceKeys.Err_Titel),
                 message,
                 _loc.GetString(ResourceKeys.Btn_OK));
-            return;
+            return false;
         }
 
-        // parse numeric text fields (Entry bindings)
         if (!int.TryParse(IntervalFactorText, out var parsedFactor) || parsedFactor <= 0)
         {
-            // Ungültige oder zu kleine Werte auf 1 clampen und im UI anzeigen
             parsedFactor = 1;
             IntervalFactorText = "1";
         }
 
         if (!int.TryParse(ReminderDaysBeforeText, out var parsedReminder) || parsedReminder < 0)
         {
-            // Ungültige oder negative Werte auf 0 clampen und im UI anzeigen
             parsedReminder = 0;
             ReminderDaysBeforeText = "0";
         }
@@ -217,23 +246,35 @@ public partial class RecurringTransactionDetailViewModel(
         IntervalFactor = parsedFactor;
         ReminderDaysBefore = parsedReminder;
 
-        await _saveRecurringTransactionDetailUseCase.ExecuteAsync(
-            _existing,
-            betrag,
-            Titel,
-            SelectedKategorie!.Id,
-            SelectedAccount?.Id,
-            Typ,
-            Startdatum,
-            HatEnddatum ? EnddatumWert : null,
-            Aktiv,
-            Interval,
-            IntervalFactor,
-            ReminderDaysBefore,
-            Exceptions.ToList());
-        _appEvents.NotifyDataChanged();
-        await _navigationService.GoBackAsync();
-        await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
+        try
+        {
+            await _saveRecurringTransactionDetailUseCase.ExecuteAsync(
+                _existing,
+                betrag,
+                Titel,
+                SelectedKategorie!.Id,
+                SelectedAccount?.Id,
+                Typ,
+                Startdatum,
+                HatEnddatum ? EnddatumWert : null,
+                Aktiv,
+                Interval,
+                IntervalFactor,
+                ReminderDaysBefore,
+                Exceptions.ToList());
+            _appEvents.NotifyDataChanged();
+            await _feedbackService.ShowSnackbarAsync(_loc.GetString(ResourceKeys.Msg_Gespeichert));
+            return true;
+        }
+        catch (Exception ex)
+        {
+            _logger?.LogError(ex, "RecurringTransactionDetailViewModel: {Context}", nameof(TrySaveAsync));
+            await _dialogService.ShowAlertAsync(
+                _loc.GetString(ResourceKeys.Err_Titel),
+                _loc.GetString(ResourceKeys.Err_SpeichernFehlgeschlagen, ex.Message),
+                _loc.GetString(ResourceKeys.Btn_OK));
+            return false;
+        }
     }
 
     [RelayCommand]
@@ -334,6 +375,7 @@ public partial class RecurringTransactionDetailViewModel(
     {
         _verfuegbareIntervalle = null;
         OnPropertyChanged(nameof(VerfuegbareIntervalle));
+        OnPropertyChanged(nameof(PageTitle));
         SelectedIntervalOption = VerfuegbareIntervalle.FirstOrDefault(option => option.Value == Interval);
     }
 }

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionsViewModel.cs
@@ -15,6 +15,8 @@ public partial class RecurringTransactionsViewModel(
     DeleteRecurringTransactionUseCase deleteRecurringTransactionUseCase,
     LoadRecurringTransactionsUseCase loadRecurringTransactionsUseCase,
     ToggleRecurringTransactionActiveUseCase toggleRecurringTransactionActiveUseCase,
+    RecurringTransactionDetailViewModel createRecurringTransactionViewModel,
+    IRecurringTransactionCreateSheetService recurringTransactionCreateSheetService,
     ILocalizationService localizationService,
     INavigationService navigationService,
     IDialogService dialogService,
@@ -25,6 +27,8 @@ public partial class RecurringTransactionsViewModel(
     private readonly DeleteRecurringTransactionUseCase _deleteRecurringTransactionUseCase = deleteRecurringTransactionUseCase;
     private readonly LoadRecurringTransactionsUseCase _loadRecurringTransactionsUseCase = loadRecurringTransactionsUseCase;
     private readonly ToggleRecurringTransactionActiveUseCase _toggleRecurringTransactionActiveUseCase = toggleRecurringTransactionActiveUseCase;
+    private readonly RecurringTransactionDetailViewModel _createRecurringTransactionViewModel = createRecurringTransactionViewModel;
+    private readonly IRecurringTransactionCreateSheetService _recurringTransactionCreateSheetService = recurringTransactionCreateSheetService;
     private readonly ILocalizationService _loc = localizationService;
     private readonly INavigationService _navigationService = navigationService;
     private readonly IDialogService _dialogService = dialogService;
@@ -103,11 +107,18 @@ public partial class RecurringTransactionsViewModel(
     [RelayCommand]
     private async Task GoToDetail(RecurringTransaction? dauerauftrag)
     {
-        var parameter = new Dictionary<string, object>();
-        if (dauerauftrag != null)
+        if (dauerauftrag == null)
         {
-            parameter["RecurringTransaction"] = dauerauftrag;
+            await _createRecurringTransactionViewModel.ResetForCreateAsync();
+            if (await _recurringTransactionCreateSheetService.ShowAsync(_createRecurringTransactionViewModel))
+                await LoadDauerauftraege();
+            return;
         }
+
+        var parameter = new Dictionary<string, object>
+        {
+            ["RecurringTransaction"] = dauerauftrag
+        };
 
         await _navigationService.GoToAsync(Routes.RecurringTransactionDetail, parameter);
     }

--- a/Finanzuebersicht.Presentation/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SparZieleViewModel.cs
@@ -27,9 +27,12 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel, 
 
     [ObservableProperty]
     [NotifyPropertyChangedFor(nameof(IsEmpty))]
+    [NotifyPropertyChangedFor(nameof(IsEmptyStateVisible))]
     private ObservableCollection<SparZielSummary> sparZiele = [];
 
     public bool IsEmpty => SparZiele.Count == 0;
+
+    public bool IsEmptyStateVisible => IsEmpty && !ShowAddForm;
 
     [ObservableProperty]
     private bool isLoading;
@@ -53,6 +56,7 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel, 
     private decimal neueMonatlicheSparrate;
 
     [ObservableProperty]
+    [NotifyPropertyChangedFor(nameof(IsEmptyStateVisible))]
     private bool showAddForm;
 
     public SparZieleViewModel(

--- a/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
@@ -136,6 +136,58 @@ public class CategoriesViewModelTests
     }
 
     [Fact]
+    public async Task GoToDetail_WhenKontenTabAndNoItem_OpensInlineCreateForm()
+    {
+        var sut = CreateSut(
+            Substitute.For<ICategoryRepository>(),
+            Substitute.For<ITransactionRepository>(),
+            Substitute.For<IRecurringTransactionRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<ITransactionTemplateRepository>(),
+            out _,
+            out var navigationService);
+
+        sut.SelectedSectionIndex = 1;
+
+        await sut.GoToDetailCommand.ExecuteAsync(null);
+
+        Assert.True(sut.ShowAddKontoForm);
+        await navigationService.DidNotReceive().GoToAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object>>());
+        await navigationService.DidNotReceive().GoToAsync(Arg.Any<string>());
+    }
+
+    [Fact]
+    public async Task SaveNewKonto_WhenValid_SavesAccountAndClosesForm()
+    {
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>()));
+        accountRepository.SaveAccountAsync(Arg.Any<Account>()).Returns(call => Task.FromResult(call.Arg<Account>()));
+
+        var sut = CreateSut(
+            Substitute.For<ICategoryRepository>(),
+            Substitute.For<ITransactionRepository>(),
+            Substitute.For<IRecurringTransactionRepository>(),
+            accountRepository,
+            Substitute.For<ITransactionTemplateRepository>(),
+            out _,
+            out _);
+
+        sut.SelectedSectionIndex = 1;
+        sut.ShowAddKontoForm = true;
+        sut.NeuerKontoName = "Sparkonto";
+        sut.SelectedKontoTypeOption = new AccountTypeOption(AccountType.Tagesgeld, "Tagesgeld");
+        sut.NeuerAnfangssaldoText = "1000";
+
+        await sut.SaveNewKontoCommand.ExecuteAsync(null);
+
+        await accountRepository.Received(1).SaveAccountAsync(Arg.Is<Account>(a =>
+            a.Name == "Sparkonto" &&
+            a.Type == AccountType.Tagesgeld &&
+            a.OpeningBalance == 1000m));
+        Assert.False(sut.ShowAddKontoForm);
+    }
+
+    [Fact]
     public async Task GoToDetail_NavigatesToCategoryDetailRoute()
     {
         var category = new Category { Id = "cat-1", Name = "Miete" };
@@ -207,6 +259,7 @@ public class CategoriesViewModelTests
             new LoadCategoriesUseCase(categoryRepository),
             new LoadAccountsUseCase(accountRepository),
             new GetAccountBalancesUseCase(accountRepository, transactionRepository),
+            new SaveAccountDetailUseCase(accountRepository),
             new ToggleAccountArchiveUseCase(accountRepository),
             new DeleteAccountUseCase(accountRepository, transactionRepository, templateRepository),
             localizationService,

--- a/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
@@ -188,6 +188,29 @@ public class CategoriesViewModelTests
     }
 
     [Fact]
+    public async Task GoToDetail_WhenKategorienTabAndNoItem_ShowsCreateSheet()
+    {
+        var categoryCreateSheet = Substitute.For<ICategoryCreateSheetService>();
+        categoryCreateSheet.ShowAsync(Arg.Any<CategoryDetailViewModel>()).Returns(Task.FromResult(false));
+
+        var sut = CreateSut(
+            Substitute.For<ICategoryRepository>(),
+            Substitute.For<ITransactionRepository>(),
+            Substitute.For<IRecurringTransactionRepository>(),
+            Substitute.For<IAccountRepository>(),
+            Substitute.For<ITransactionTemplateRepository>(),
+            categoryCreateSheet,
+            out _,
+            out var navigationService);
+
+        await sut.GoToDetailCommand.ExecuteAsync(null);
+
+        await categoryCreateSheet.Received(1).ShowAsync(Arg.Any<CategoryDetailViewModel>());
+        await navigationService.DidNotReceive().GoToAsync(Arg.Any<string>());
+        await navigationService.DidNotReceive().GoToAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object>>());
+    }
+
+    [Fact]
     public async Task GoToDetail_NavigatesToCategoryDetailRoute()
     {
         var category = new Category { Id = "cat-1", Name = "Miete" };
@@ -242,6 +265,27 @@ public class CategoriesViewModelTests
         out IDialogService dialogService,
         out INavigationService navigationService)
     {
+        return CreateSut(
+            categoryRepository,
+            transactionRepository,
+            recurringTransactionRepository,
+            accountRepository,
+            templateRepository,
+            Substitute.For<ICategoryCreateSheetService>(),
+            out dialogService,
+            out navigationService);
+    }
+
+    private static CategoriesViewModel CreateSut(
+        ICategoryRepository categoryRepository,
+        ITransactionRepository transactionRepository,
+        IRecurringTransactionRepository recurringTransactionRepository,
+        IAccountRepository accountRepository,
+        ITransactionTemplateRepository templateRepository,
+        ICategoryCreateSheetService categoryCreateSheetService,
+        out IDialogService dialogService,
+        out INavigationService navigationService)
+    {
         dialogService = Substitute.For<IDialogService>();
         dialogService.ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
             .Returns(Task.CompletedTask);
@@ -254,6 +298,14 @@ public class CategoriesViewModelTests
 
         navigationService = Substitute.For<INavigationService>();
 
+        var createCategoryViewModel = new CategoryDetailViewModel(
+            new SaveCategoryDetailUseCase(categoryRepository),
+            navigationService,
+            localizationService,
+            Substitute.For<IFeedbackService>(),
+            Substitute.For<IAppEvents>(),
+            dialogService);
+
         return new CategoriesViewModel(
             new DeleteCategoryUseCase(categoryRepository, transactionRepository, recurringTransactionRepository),
             new LoadCategoriesUseCase(categoryRepository),
@@ -262,6 +314,8 @@ public class CategoriesViewModelTests
             new SaveAccountDetailUseCase(accountRepository),
             new ToggleAccountArchiveUseCase(accountRepository),
             new DeleteAccountUseCase(accountRepository, transactionRepository, templateRepository),
+            createCategoryViewModel,
+            categoryCreateSheetService,
             localizationService,
             navigationService,
             dialogService,

--- a/Finanzuebersicht.Tests/ViewModels/CategoryDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoryDetailViewModelTests.cs
@@ -1,0 +1,57 @@
+using Finanzuebersicht.Application.UseCases.Categories;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Tests.ViewModels;
+
+public class CategoryDetailViewModelTests
+{
+    [Fact]
+    public async Task TrySaveAsync_WhenBudgetSaveFails_SecondAttemptReusesSavedCategory()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        var savedCategories = new List<Category>();
+        categoryRepository.SaveCategoryAsync(Arg.Any<Category>())
+            .Returns(call =>
+            {
+                var category = call.Arg<Category>();
+                savedCategories.Add(category);
+                category.Id = "cat-new";
+                return Task.FromResult(category);
+            });
+
+        var budgetRepository = Substitute.For<IBudgetRepository>();
+        budgetRepository.GetBudgetsAsync().Returns(Task.FromResult(new List<CategoryBudget>()));
+        budgetRepository.SaveBudgetAsync(Arg.Any<CategoryBudget>())
+            .Returns(Task.FromException(new InvalidOperationException("budget failed")));
+
+        var dialogService = Substitute.For<IDialogService>();
+        dialogService.ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>())
+            .Returns(Task.CompletedTask);
+
+        var localizationService = Substitute.For<ILocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(call => call.Arg<string>());
+        localizationService.GetString(Arg.Any<string>(), Arg.Any<object[]>()).Returns(call => call.ArgAt<string>(0));
+
+        var sut = new CategoryDetailViewModel(
+            new SaveCategoryDetailUseCase(categoryRepository),
+            Substitute.For<INavigationService>(),
+            localizationService,
+            Substitute.For<IFeedbackService>(),
+            Substitute.For<IAppEvents>(),
+            dialogService,
+            new SaveCategoryBudgetUseCase(budgetRepository),
+            budgetRepository);
+
+        sut.Name = "Miete";
+        sut.MonthlyBudgetText = "100";
+
+        Assert.False(await sut.TrySaveAsync());
+        Assert.False(await sut.TrySaveAsync());
+
+        Assert.Equal(2, savedCategories.Count);
+        Assert.Same(savedCategories[0], savedCategories[1]);
+    }
+}

--- a/Finanzuebersicht.Tests/ViewModels/RecurringTransactionDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/RecurringTransactionDetailViewModelTests.cs
@@ -1,0 +1,68 @@
+using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Core.Services;
+using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.ViewModels;
+
+namespace Finanzuebersicht.Tests.ViewModels;
+
+public class RecurringTransactionDetailViewModelTests
+{
+    [Fact]
+    public async Task ResetForCreateAsync_ClearsCategoryAndAccountSelection()
+    {
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(Task.FromResult(new List<Category>
+        {
+            new() { Id = "cat-1", Name = "Miete" }
+        }));
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>
+        {
+            new() { Id = "acc-1", Name = "Giro", SystemKey = Finanzuebersicht.Constants.SystemAccountKeys.Default }
+        }));
+
+        var sut = CreateSut(categoryRepository, accountRepository);
+        sut.SelectedKategorie = new Category { Id = "cat-old", Name = "Alt" };
+        sut.SelectedAccount = new Account { Id = "acc-old", Name = "Alt" };
+
+        await sut.ResetForCreateAsync();
+
+        Assert.Null(sut.SelectedKategorie);
+        Assert.NotEqual("acc-old", sut.SelectedAccount?.Id);
+        Assert.Equal("acc-1", sut.SelectedAccount?.Id);
+        Assert.False(sut.IsEditing);
+    }
+
+    private static RecurringTransactionDetailViewModel CreateSut(
+        ICategoryRepository categoryRepository,
+        IAccountRepository accountRepository)
+    {
+        var localizationService = Substitute.For<ILocalizationService>();
+        localizationService.GetString(Arg.Any<string>()).Returns(call => call.Arg<string>());
+
+        return new RecurringTransactionDetailViewModel(
+            new SaveRecurringTransactionDetailUseCase(
+                Substitute.For<IRecurringTransactionRepository>(),
+                Substitute.For<IRecurringGenerationService>(),
+                accountRepository),
+            new LoadRecurringTransactionDetailDataUseCase(categoryRepository, accountRepository),
+            new AddRecurringExceptionUseCase(Substitute.For<IRecurringTransactionRepository>()),
+            new RemoveRecurringExceptionUseCase(Substitute.For<IRecurringTransactionRepository>()),
+            Substitute.For<ITransactionValidationService>(),
+            Substitute.For<INavigationService>(),
+            Substitute.For<IDialogService>(),
+            localizationService,
+            Substitute.For<IFeedbackService>(),
+            Substitute.For<IAppEvents>(),
+            clock: new FixedClock(new DateTime(2026, 7, 3)));
+    }
+
+    private sealed class FixedClock(DateTime today) : IClock
+    {
+        public DateTime Now => today;
+        public DateTime Today => today.Date;
+        public DateTime UtcNow => today.ToUniversalTime();
+    }
+}

--- a/Finanzuebersicht.Tests/ViewModels/RecurringTransactionsViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/RecurringTransactionsViewModelTests.cs
@@ -1,6 +1,8 @@
 using System.Collections.ObjectModel;
 using Finanzuebersicht.Application.UseCases.RecurringTransactions;
+using Finanzuebersicht.Core.Services;
 using Finanzuebersicht.Models;
+using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Presentation.Services;
 using Finanzuebersicht.ViewModels;
 
@@ -82,8 +84,59 @@ public class RecurringTransactionsViewModelTests
             Arg.Is<RecurringTransaction>(item => item.Id == "rec-1" && item.Aktiv == false));
     }
 
+    [Fact]
+    public async Task GoToDetail_WhenNoItem_ShowsCreateSheet()
+    {
+        var createSheet = Substitute.For<IRecurringTransactionCreateSheetService>();
+        createSheet.ShowAsync(Arg.Any<RecurringTransactionDetailViewModel>()).Returns(Task.FromResult(false));
+
+        var sut = CreateSut(
+            Substitute.For<IRecurringTransactionRepository>(),
+            createSheet,
+            out _,
+            out var navigationService);
+
+        await sut.GoToDetailCommand.ExecuteAsync(null);
+
+        await createSheet.Received(1).ShowAsync(Arg.Any<RecurringTransactionDetailViewModel>());
+        await navigationService.DidNotReceive().GoToAsync(Arg.Any<string>());
+        await navigationService.DidNotReceive().GoToAsync(Arg.Any<string>(), Arg.Any<IDictionary<string, object>>());
+    }
+
+    [Fact]
+    public async Task GoToDetail_WhenItemProvided_NavigatesToDetail()
+    {
+        var recurringTransaction = new RecurringTransaction { Id = "rec-1", Titel = "Miete" };
+        var sut = CreateSut(
+            Substitute.For<IRecurringTransactionRepository>(),
+            Substitute.For<IRecurringTransactionCreateSheetService>(),
+            out _,
+            out var navigationService);
+
+        await sut.GoToDetailCommand.ExecuteAsync(recurringTransaction);
+
+        await navigationService.Received(1).GoToAsync(
+            Routes.RecurringTransactionDetail,
+            Arg.Is<IDictionary<string, object>>(parameters =>
+                parameters.ContainsKey("RecurringTransaction") &&
+                object.ReferenceEquals(parameters["RecurringTransaction"], recurringTransaction)));
+    }
+
     private static RecurringTransactionsViewModel CreateSut(
         IRecurringTransactionRepository recurringTransactionRepository,
+        out IDialogService dialogService,
+        out INavigationService navigationService)
+    {
+        return CreateSut(
+            recurringTransactionRepository,
+            Substitute.For<IRecurringTransactionCreateSheetService>(),
+            out dialogService,
+            out navigationService);
+    }
+
+    private static RecurringTransactionsViewModel CreateSut(
+        IRecurringTransactionRepository recurringTransactionRepository,
+        IRecurringTransactionCreateSheetService createSheetService,
         out IDialogService dialogService,
         out INavigationService navigationService)
     {
@@ -99,10 +152,30 @@ public class RecurringTransactionsViewModelTests
 
         navigationService = Substitute.For<INavigationService>();
 
+        var categoryRepository = Substitute.For<ICategoryRepository>();
+        categoryRepository.GetCategoriesAsync().Returns(Task.FromResult(new List<Category>()));
+        var accountRepository = Substitute.For<IAccountRepository>();
+        accountRepository.GetAccountsAsync().Returns(Task.FromResult(new List<Account>()));
+        var recurringGenerationService = Substitute.For<IRecurringGenerationService>();
+
+        var createViewModel = new RecurringTransactionDetailViewModel(
+            new SaveRecurringTransactionDetailUseCase(recurringTransactionRepository, recurringGenerationService, accountRepository),
+            new LoadRecurringTransactionDetailDataUseCase(categoryRepository, accountRepository),
+            new AddRecurringExceptionUseCase(recurringTransactionRepository),
+            new RemoveRecurringExceptionUseCase(recurringTransactionRepository),
+            Substitute.For<ITransactionValidationService>(),
+            navigationService,
+            dialogService,
+            localizationService,
+            Substitute.For<IFeedbackService>(),
+            Substitute.For<IAppEvents>());
+
         return new RecurringTransactionsViewModel(
             new DeleteRecurringTransactionUseCase(recurringTransactionRepository),
             new LoadRecurringTransactionsUseCase(recurringTransactionRepository),
             new ToggleRecurringTransactionActiveUseCase(recurringTransactionRepository),
+            createViewModel,
+            createSheetService,
             localizationService,
             navigationService,
             dialogService,

--- a/Finanzuebersicht.Tests/ViewModels/SparZieleViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/SparZieleViewModelTests.cs
@@ -10,6 +10,18 @@ namespace Finanzuebersicht.Tests.ViewModels;
 public class SparZieleViewModelTests
 {
     [Fact]
+    public void ToggleAddForm_OpensFormAndHidesEmptyState()
+    {
+        var viewModel = CreateSut(Substitute.For<ISparZielRepository>(), out _, out _);
+        Assert.True(viewModel.IsEmptyStateVisible);
+
+        viewModel.ToggleAddFormCommand.Execute(null);
+
+        Assert.True(viewModel.ShowAddForm);
+        Assert.False(viewModel.IsEmptyStateVisible);
+    }
+
+    [Fact]
     public async Task SaveNewSparZiel_WithEmptyTitel_ShowsAlertAndDoesNotSave()
     {
         var repository = Substitute.For<ISparZielRepository>();

--- a/Finanzuebersicht/Controls/CategoryFormView.xaml
+++ b/Finanzuebersicht/Controls/CategoryFormView.xaml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
+             x:Class="Finanzuebersicht.Controls.CategoryFormView"
+             x:DataType="vm:CategoryDetailViewModel">
+
+    <VerticalStackLayout Spacing="20">
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Name}" FontSize="13" TextColor="Gray" />
+            <Entry Text="{Binding Name}" Placeholder="{loc:Translate Hint_Kategoriename}"
+                   FontSize="16" />
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Icon}" FontSize="13" TextColor="Gray" />
+            <CollectionView ItemsSource="{Binding VerfuegbareIcons}"
+                            SelectionMode="Single"
+                            SelectedItem="{Binding Icon}">
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Orientation="Vertical" Span="7"
+                                     HorizontalItemSpacing="8" VerticalItemSpacing="8" />
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <Border Padding="8" StrokeShape="RoundRectangle 10"
+                               Stroke="Transparent"
+                               BackgroundColor="#F2F2F7"
+                               HorizontalOptions="Center">
+                            <Label Text="{Binding .}" FontSize="22"
+                                   HorizontalOptions="Center" VerticalOptions="Center" />
+                        </Border>
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Farbe}" FontSize="13" TextColor="Gray" />
+            <CollectionView ItemsSource="{Binding VerfuegbareFarben}"
+                            SelectionMode="Single"
+                            SelectedItem="{Binding Color}">
+                <CollectionView.ItemsLayout>
+                    <GridItemsLayout Orientation="Vertical" Span="5"
+                                     HorizontalItemSpacing="10" VerticalItemSpacing="10" />
+                </CollectionView.ItemsLayout>
+                <CollectionView.ItemTemplate>
+                    <DataTemplate x:DataType="x:String">
+                        <Border WidthRequest="40" HeightRequest="40"
+                               StrokeShape="RoundRectangle 20"
+                               Stroke="Transparent" Padding="0"
+                               BackgroundColor="{Binding .}"
+                               HorizontalOptions="Center" />
+                    </DataTemplate>
+                </CollectionView.ItemTemplate>
+            </CollectionView>
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Typ}" FontSize="13" TextColor="Gray" />
+            <controls:SelectionField ItemsSource="{Binding VerfuegbareTypen}"
+                                     SelectedItem="{Binding SelectedTypeOption, Mode=TwoWay}"
+                                     DisplayMemberPath="DisplayName"
+                                     FieldLabel="{loc:Translate Lbl_Typ}" />
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_MonatlichesBudget}" FontSize="13" TextColor="Gray" />
+            <Entry Text="{Binding MonthlyBudgetText}" Keyboard="Numeric"
+                   Placeholder="{loc:Translate Hint_BudgetOptional}" FontSize="16"
+                   SemanticProperties.Hint="{loc:Translate A11y_HintBudget}" />
+            <Label Text="{loc:Translate Hint_BudgetNull}" FontSize="11" TextColor="Gray" />
+        </VerticalStackLayout>
+
+    </VerticalStackLayout>
+</ContentView>

--- a/Finanzuebersicht/Controls/CategoryFormView.xaml
+++ b/Finanzuebersicht/Controls/CategoryFormView.xaml
@@ -10,13 +10,14 @@
     <VerticalStackLayout Spacing="20">
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Name}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Name}" FontSize="13"
+                   TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <Entry Text="{Binding Name}" Placeholder="{loc:Translate Hint_Kategoriename}"
                    FontSize="16" />
         </VerticalStackLayout>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Icon}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Icon}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <CollectionView ItemsSource="{Binding VerfuegbareIcons}"
                             SelectionMode="Single"
                             SelectedItem="{Binding Icon}">
@@ -28,7 +29,7 @@
                     <DataTemplate x:DataType="x:String">
                         <Border Padding="8" StrokeShape="RoundRectangle 10"
                                Stroke="Transparent"
-                               BackgroundColor="#F2F2F7"
+                               BackgroundColor="{AppThemeBinding Light={StaticResource Gray100}, Dark={StaticResource Gray900}}"
                                HorizontalOptions="Center">
                             <Label Text="{Binding .}" FontSize="22"
                                    HorizontalOptions="Center" VerticalOptions="Center" />
@@ -39,7 +40,7 @@
         </VerticalStackLayout>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Farbe}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Farbe}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <CollectionView ItemsSource="{Binding VerfuegbareFarben}"
                             SelectionMode="Single"
                             SelectedItem="{Binding Color}">
@@ -60,7 +61,7 @@
         </VerticalStackLayout>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Typ}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Typ}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <controls:SelectionField ItemsSource="{Binding VerfuegbareTypen}"
                                      SelectedItem="{Binding SelectedTypeOption, Mode=TwoWay}"
                                      DisplayMemberPath="DisplayName"
@@ -68,11 +69,11 @@
         </VerticalStackLayout>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_MonatlichesBudget}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_MonatlichesBudget}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <Entry Text="{Binding MonthlyBudgetText}" Keyboard="Numeric"
                    Placeholder="{loc:Translate Hint_BudgetOptional}" FontSize="16"
                    SemanticProperties.Hint="{loc:Translate A11y_HintBudget}" />
-            <Label Text="{loc:Translate Hint_BudgetNull}" FontSize="11" TextColor="Gray" />
+            <Label Text="{loc:Translate Hint_BudgetNull}" FontSize="11" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
         </VerticalStackLayout>
 
     </VerticalStackLayout>

--- a/Finanzuebersicht/Controls/CategoryFormView.xaml.cs
+++ b/Finanzuebersicht/Controls/CategoryFormView.xaml.cs
@@ -1,0 +1,6 @@
+namespace Finanzuebersicht.Controls;
+
+public partial class CategoryFormView : ContentView
+{
+    public CategoryFormView() => InitializeComponent();
+}

--- a/Finanzuebersicht/Controls/CreateFormCard.xaml
+++ b/Finanzuebersicht/Controls/CreateFormCard.xaml
@@ -4,10 +4,12 @@
              x:Class="Finanzuebersicht.Controls.CreateFormCard"
              x:Name="Root">
 
-    <Border StrokeShape="RoundRectangle 12"
+    <Border x:Name="CardBorder"
+            StrokeShape="RoundRectangle 12"
             Stroke="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
             BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
-            Padding="16">
+            Padding="16"
+            SemanticProperties.Description="{Binding Source={x:Reference Root}, Path=AccessibilityDescription}">
         <VerticalStackLayout Spacing="14">
 
             <Label Text="{Binding Source={x:Reference Root}, Path=Title}"
@@ -27,6 +29,7 @@
                 <Button Grid.Column="0"
                         Text="{Binding Source={x:Reference Root}, Path=CancelText}"
                         Command="{Binding Source={x:Reference Root}, Path=CancelCommand}"
+                        SemanticProperties.Hint="{Binding Source={x:Reference Root}, Path=CancelText}"
                         BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
                         TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource TextPrimaryDark}}"
                         CornerRadius="10"
@@ -34,6 +37,7 @@
                 <Button Grid.Column="1"
                         Text="{Binding Source={x:Reference Root}, Path=SaveText}"
                         Command="{Binding Source={x:Reference Root}, Path=SaveCommand}"
+                        SemanticProperties.Hint="{Binding Source={x:Reference Root}, Path=SaveText}"
                         IsEnabled="{Binding Source={x:Reference Root}, Path=IsSaveEnabled}"
                         BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
                         TextColor="White"

--- a/Finanzuebersicht/Controls/CreateFormCard.xaml
+++ b/Finanzuebersicht/Controls/CreateFormCard.xaml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             x:Class="Finanzuebersicht.Controls.CreateFormCard"
+             x:Name="Root">
+
+    <Border StrokeShape="RoundRectangle 12"
+            Stroke="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
+            Padding="16">
+        <VerticalStackLayout Spacing="14">
+
+            <Label Text="{Binding Source={x:Reference Root}, Path=Title}"
+                   FontSize="16"
+                   FontAttributes="Bold"
+                   IsVisible="{Binding Source={x:Reference Root}, Path=HasTitle}" />
+
+            <ScrollView x:Name="FormScroll"
+                        VerticalScrollBarVisibility="Never">
+                <ContentPresenter x:Name="FormPresenter"
+                                  Content="{Binding Source={x:Reference Root}, Path=FormContent}" />
+            </ScrollView>
+
+            <Grid ColumnDefinitions="*, *"
+                  ColumnSpacing="10"
+                  IsVisible="{Binding Source={x:Reference Root}, Path=HasActions}">
+                <Button Grid.Column="0"
+                        Text="{Binding Source={x:Reference Root}, Path=CancelText}"
+                        Command="{Binding Source={x:Reference Root}, Path=CancelCommand}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
+                        TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource TextPrimaryDark}}"
+                        CornerRadius="10"
+                        HeightRequest="44" />
+                <Button Grid.Column="1"
+                        Text="{Binding Source={x:Reference Root}, Path=SaveText}"
+                        Command="{Binding Source={x:Reference Root}, Path=SaveCommand}"
+                        IsEnabled="{Binding Source={x:Reference Root}, Path=IsSaveEnabled}"
+                        BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
+                        TextColor="White"
+                        CornerRadius="10"
+                        HeightRequest="44" />
+            </Grid>
+
+        </VerticalStackLayout>
+    </Border>
+</ContentView>

--- a/Finanzuebersicht/Controls/CreateFormCard.xaml.cs
+++ b/Finanzuebersicht/Controls/CreateFormCard.xaml.cs
@@ -1,0 +1,136 @@
+using System.Windows.Input;
+
+namespace Finanzuebersicht.Controls;
+
+[ContentProperty(nameof(FormContent))]
+public partial class CreateFormCard : ContentView
+{
+    public static readonly BindableProperty TitleProperty =
+        BindableProperty.Create(nameof(Title), typeof(string), typeof(CreateFormCard), string.Empty,
+            propertyChanged: OnTitleChanged);
+
+    public static readonly BindableProperty FormContentProperty =
+        BindableProperty.Create(nameof(FormContent), typeof(View), typeof(CreateFormCard), null);
+
+    public static readonly BindableProperty CancelTextProperty =
+        BindableProperty.Create(nameof(CancelText), typeof(string), typeof(CreateFormCard), string.Empty);
+
+    public static readonly BindableProperty SaveTextProperty =
+        BindableProperty.Create(nameof(SaveText), typeof(string), typeof(CreateFormCard), string.Empty);
+
+    public static readonly BindableProperty CancelCommandProperty =
+        BindableProperty.Create(nameof(CancelCommand), typeof(ICommand), typeof(CreateFormCard));
+
+    public static readonly BindableProperty SaveCommandProperty =
+        BindableProperty.Create(nameof(SaveCommand), typeof(ICommand), typeof(CreateFormCard));
+
+    public static readonly BindableProperty IsSaveEnabledProperty =
+        BindableProperty.Create(nameof(IsSaveEnabled), typeof(bool), typeof(CreateFormCard), true);
+
+    public static readonly BindableProperty ScrollFormContentProperty =
+        BindableProperty.Create(nameof(ScrollFormContent), typeof(bool), typeof(CreateFormCard), false,
+            propertyChanged: OnScrollSettingsChanged);
+
+    public static readonly BindableProperty MaxFormHeightProperty =
+        BindableProperty.Create(nameof(MaxFormHeight), typeof(double), typeof(CreateFormCard), -1d,
+            propertyChanged: OnScrollSettingsChanged);
+
+    public CreateFormCard()
+    {
+        InitializeComponent();
+        UpdateScrollBehavior();
+    }
+
+    public string Title
+    {
+        get => (string)GetValue(TitleProperty);
+        set => SetValue(TitleProperty, value);
+    }
+
+    public View? FormContent
+    {
+        get => (View?)GetValue(FormContentProperty);
+        set => SetValue(FormContentProperty, value);
+    }
+
+    public string CancelText
+    {
+        get => (string)GetValue(CancelTextProperty);
+        set => SetValue(CancelTextProperty, value);
+    }
+
+    public string SaveText
+    {
+        get => (string)GetValue(SaveTextProperty);
+        set => SetValue(SaveTextProperty, value);
+    }
+
+    public ICommand? CancelCommand
+    {
+        get => (ICommand?)GetValue(CancelCommandProperty);
+        set => SetValue(CancelCommandProperty, value);
+    }
+
+    public ICommand? SaveCommand
+    {
+        get => (ICommand?)GetValue(SaveCommandProperty);
+        set => SetValue(SaveCommandProperty, value);
+    }
+
+    public bool IsSaveEnabled
+    {
+        get => (bool)GetValue(IsSaveEnabledProperty);
+        set => SetValue(IsSaveEnabledProperty, value);
+    }
+
+    public bool ScrollFormContent
+    {
+        get => (bool)GetValue(ScrollFormContentProperty);
+        set => SetValue(ScrollFormContentProperty, value);
+    }
+
+    public double MaxFormHeight
+    {
+        get => (double)GetValue(MaxFormHeightProperty);
+        set => SetValue(MaxFormHeightProperty, value);
+    }
+
+    public bool HasTitle => !string.IsNullOrWhiteSpace(Title);
+
+    public bool HasActions => CancelCommand is not null || SaveCommand is not null;
+
+    protected override void OnPropertyChanged(string? propertyName = null)
+    {
+        base.OnPropertyChanged(propertyName);
+
+        if (propertyName is nameof(CancelCommand) or nameof(SaveCommand))
+            OnPropertyChanged(nameof(HasActions));
+    }
+
+    private static void OnTitleChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is CreateFormCard card)
+            card.OnPropertyChanged(nameof(HasTitle));
+    }
+
+    private static void OnScrollSettingsChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is CreateFormCard card)
+            card.UpdateScrollBehavior();
+    }
+
+    private void UpdateScrollBehavior()
+    {
+        if (FormScroll is null)
+            return;
+
+        FormScroll.VerticalScrollBarVisibility = ScrollFormContent
+            ? ScrollBarVisibility.Always
+            : ScrollBarVisibility.Never;
+
+        if (ScrollFormContent && MaxFormHeight > 0)
+            FormScroll.HeightRequest = MaxFormHeight;
+        else
+            FormScroll.ClearValue(HeightRequestProperty);
+    }
+}

--- a/Finanzuebersicht/Controls/CreateFormCard.xaml.cs
+++ b/Finanzuebersicht/Controls/CreateFormCard.xaml.cs
@@ -35,6 +35,10 @@ public partial class CreateFormCard : ContentView
         BindableProperty.Create(nameof(MaxFormHeight), typeof(double), typeof(CreateFormCard), -1d,
             propertyChanged: OnScrollSettingsChanged);
 
+    public static readonly BindableProperty AccessibilityDescriptionProperty =
+        BindableProperty.Create(nameof(AccessibilityDescription), typeof(string), typeof(CreateFormCard), string.Empty,
+            propertyChanged: OnAccessibilityDescriptionChanged);
+
     public CreateFormCard()
     {
         InitializeComponent();
@@ -95,6 +99,12 @@ public partial class CreateFormCard : ContentView
         set => SetValue(MaxFormHeightProperty, value);
     }
 
+    public string AccessibilityDescription
+    {
+        get => (string)GetValue(AccessibilityDescriptionProperty);
+        set => SetValue(AccessibilityDescriptionProperty, value);
+    }
+
     public bool HasTitle => !string.IsNullOrWhiteSpace(Title);
 
     public bool HasActions => CancelCommand is not null || SaveCommand is not null;
@@ -117,6 +127,20 @@ public partial class CreateFormCard : ContentView
     {
         if (bindable is CreateFormCard card)
             card.UpdateScrollBehavior();
+    }
+
+    private static void OnAccessibilityDescriptionChanged(BindableObject bindable, object oldValue, object newValue)
+    {
+        if (bindable is CreateFormCard card)
+            SemanticProperties.SetDescription(card, (string)newValue);
+    }
+
+    public void FocusForm()
+    {
+        if (FormContent is Element formRoot)
+            FormFocusHelper.TryFocusFirstInput(formRoot);
+        else if (FormPresenter?.Content is Element presenterRoot)
+            FormFocusHelper.TryFocusFirstInput(presenterRoot);
     }
 
     private void UpdateScrollBehavior()

--- a/Finanzuebersicht/Controls/FormFocusHelper.cs
+++ b/Finanzuebersicht/Controls/FormFocusHelper.cs
@@ -1,0 +1,43 @@
+namespace Finanzuebersicht.Controls;
+
+internal static class FormFocusHelper
+{
+    public static void TryFocusFirstInput(Element? root)
+    {
+        if (FindFirstFocusable(root) is VisualElement target)
+            target.Focus();
+    }
+
+    private static VisualElement? FindFirstFocusable(Element? element)
+    {
+        if (element is null)
+            return null;
+
+        if (element is VisualElement visual &&
+            visual.IsEnabled &&
+            visual.IsVisible &&
+            visual is Entry or Editor or SearchBar)
+        {
+            return visual;
+        }
+
+        switch (element)
+        {
+            case Layout layout:
+                foreach (var child in layout.Children)
+                {
+                    if (child is Element childElement && FindFirstFocusable(childElement) is { } found)
+                        return found;
+                }
+                break;
+            case ContentView contentView when contentView.Content is Element content:
+                return FindFirstFocusable(content);
+            case ScrollView scrollView when scrollView.Content is Element scrollContent:
+                return FindFirstFocusable(scrollContent);
+            case Border border when border.Content is Element borderContent:
+                return FindFirstFocusable(borderContent);
+        }
+
+        return null;
+    }
+}

--- a/Finanzuebersicht/Controls/RecurringTransactionFormView.xaml
+++ b/Finanzuebersicht/Controls/RecurringTransactionFormView.xaml
@@ -26,7 +26,7 @@
         </Grid>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Betrag}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Betrag}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <Entry Text="{Binding BetragText}" Placeholder="{loc:Translate Hint_Betrag}"
                    Keyboard="Numeric" FontSize="28" FontAttributes="Bold"
                    HorizontalTextAlignment="Center"
@@ -34,13 +34,13 @@
         </VerticalStackLayout>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <Entry Text="{Binding Titel}" Placeholder="{loc:Translate Hint_Titelbeispiel}"
                    FontSize="16" />
         </VerticalStackLayout>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Kategorie}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Kategorie}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <controls:SelectionField ItemsSource="{Binding Kategorien}"
                                      SelectedItem="{Binding SelectedKategorie, Mode=TwoWay}"
                                      DisplayMemberPath="Name"
@@ -49,7 +49,7 @@
         </VerticalStackLayout>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Konto}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Konto}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <controls:SelectionField ItemsSource="{Binding Accounts}"
                                      SelectedItem="{Binding SelectedAccount, Mode=TwoWay}"
                                      DisplayMemberPath="Name"
@@ -58,7 +58,7 @@
         </VerticalStackLayout>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Startdatum}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Startdatum}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <DatePicker Date="{Binding Startdatum, Mode=TwoWay}" FontSize="16"
                         Format="dd. MMMM yyyy"
                         controls:DatePickerProperties.ImmediateUpdate="True" />
@@ -82,7 +82,7 @@
         </Grid>
 
         <VerticalStackLayout Spacing="4">
-            <Label Text="{loc:Translate Lbl_Intervall}" FontSize="13" TextColor="Gray" />
+            <Label Text="{loc:Translate Lbl_Intervall}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
             <controls:SelectionField ItemsSource="{Binding VerfuegbareIntervalle}"
                                      SelectedItem="{Binding SelectedIntervalOption, Mode=TwoWay}"
                                      DisplayMemberPath="DisplayName"
@@ -93,11 +93,11 @@
 
         <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8" Margin="0,8,0,0">
             <VerticalStackLayout Grid.Column="0" Spacing="4">
-                <Label Text="{loc:Translate Lbl_IntervallFaktor}" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_IntervallFaktor}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                 <Entry Text="{Binding IntervalFactorText}" Keyboard="Numeric" />
             </VerticalStackLayout>
             <VerticalStackLayout Grid.Column="1" Spacing="4" HorizontalOptions="End">
-                <Label Text="{loc:Translate Lbl_ErinnerungTage}" FontSize="13" TextColor="Gray" />
+                <Label Text="{loc:Translate Lbl_ErinnerungTage}" FontSize="13" TextColor="{AppThemeBinding Light={StaticResource TextTertiary}, Dark={StaticResource Gray600}}" />
                 <Entry Text="{Binding ReminderDaysBeforeText}" Keyboard="Numeric" WidthRequest="80" />
             </VerticalStackLayout>
         </Grid>

--- a/Finanzuebersicht/Controls/RecurringTransactionFormView.xaml
+++ b/Finanzuebersicht/Controls/RecurringTransactionFormView.xaml
@@ -1,0 +1,106 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ContentView xmlns="http://schemas.microsoft.com/dotnet/2021/maui"
+             xmlns:x="http://schemas.microsoft.com/winfx/2009/xaml"
+             xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
+             xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
+             xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
+             xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
+             x:Class="Finanzuebersicht.Controls.RecurringTransactionFormView"
+             x:DataType="vm:RecurringTransactionDetailViewModel">
+
+    <ContentView.Resources>
+        <conv:TypButtonColorConverter x:Key="TypButtonColor" />
+    </ContentView.Resources>
+
+    <VerticalStackLayout Spacing="20">
+
+        <Grid ColumnDefinitions="*, *" ColumnSpacing="8">
+            <Button Grid.Column="0" Text="{loc:Translate Lbl_Ausgabe}"
+                    BackgroundColor="{Binding Typ, Converter={StaticResource TypButtonColor}, ConverterParameter=Ausgabe}"
+                    TextColor="White" CornerRadius="10" HeightRequest="44"
+                    Command="{Binding SetTypCommand}" CommandParameter="Ausgabe" />
+            <Button Grid.Column="1" Text="{loc:Translate Lbl_Einnahme}"
+                    BackgroundColor="{Binding Typ, Converter={StaticResource TypButtonColor}, ConverterParameter=Einnahme}"
+                    TextColor="White" CornerRadius="10" HeightRequest="44"
+                    Command="{Binding SetTypCommand}" CommandParameter="Einnahme" />
+        </Grid>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Betrag}" FontSize="13" TextColor="Gray" />
+            <Entry Text="{Binding BetragText}" Placeholder="{loc:Translate Hint_Betrag}"
+                   Keyboard="Numeric" FontSize="28" FontAttributes="Bold"
+                   HorizontalTextAlignment="Center"
+                   SemanticProperties.Hint="{loc:Translate A11y_HintBetrag}" />
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="Gray" />
+            <Entry Text="{Binding Titel}" Placeholder="{loc:Translate Hint_Titelbeispiel}"
+                   FontSize="16" />
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Kategorie}" FontSize="13" TextColor="Gray" />
+            <controls:SelectionField ItemsSource="{Binding Kategorien}"
+                                     SelectedItem="{Binding SelectedKategorie, Mode=TwoWay}"
+                                     DisplayMemberPath="Name"
+                                     FieldLabel="{loc:Translate Lbl_Kategorie}"
+                                     Placeholder="{loc:Translate Hint_KategorieWaehlen}" />
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Konto}" FontSize="13" TextColor="Gray" />
+            <controls:SelectionField ItemsSource="{Binding Accounts}"
+                                     SelectedItem="{Binding SelectedAccount, Mode=TwoWay}"
+                                     DisplayMemberPath="Name"
+                                     FieldLabel="{loc:Translate Lbl_Konto}"
+                                     Placeholder="{loc:Translate Hint_KontoWaehlen}" />
+        </VerticalStackLayout>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Startdatum}" FontSize="13" TextColor="Gray" />
+            <DatePicker Date="{Binding Startdatum, Mode=TwoWay}" FontSize="16"
+                        Format="dd. MMMM yyyy"
+                        controls:DatePickerProperties.ImmediateUpdate="True" />
+        </VerticalStackLayout>
+
+        <Grid ColumnDefinitions="*, Auto" Padding="0">
+            <Label Text="{loc:Translate Lbl_EnddatumFestlegen}" FontSize="16"
+                   VerticalTextAlignment="Center" />
+            <Switch Grid.Column="1" IsToggled="{Binding HatEnddatum}" />
+        </Grid>
+
+        <DatePicker Date="{Binding EnddatumWert, Mode=TwoWay}" FontSize="16"
+                    Format="dd. MMMM yyyy"
+                    IsVisible="{Binding HatEnddatum}"
+                    controls:DatePickerProperties.ImmediateUpdate="True" />
+
+        <Grid ColumnDefinitions="*, Auto" Padding="0">
+            <Label Text="{loc:Translate Lbl_Aktiv}" FontSize="16"
+                   VerticalTextAlignment="Center" />
+            <Switch Grid.Column="1" IsToggled="{Binding Aktiv}" />
+        </Grid>
+
+        <VerticalStackLayout Spacing="4">
+            <Label Text="{loc:Translate Lbl_Intervall}" FontSize="13" TextColor="Gray" />
+            <controls:SelectionField ItemsSource="{Binding VerfuegbareIntervalle}"
+                                     SelectedItem="{Binding SelectedIntervalOption, Mode=TwoWay}"
+                                     DisplayMemberPath="DisplayName"
+                                     FieldLabel="{loc:Translate Lbl_Intervall}"
+                                     Placeholder="{loc:Translate Hint_IntervallWaehlen}"
+                                     Margin="0,0,0,8" />
+        </VerticalStackLayout>
+
+        <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8" Margin="0,8,0,0">
+            <VerticalStackLayout Grid.Column="0" Spacing="4">
+                <Label Text="{loc:Translate Lbl_IntervallFaktor}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding IntervalFactorText}" Keyboard="Numeric" />
+            </VerticalStackLayout>
+            <VerticalStackLayout Grid.Column="1" Spacing="4" HorizontalOptions="End">
+                <Label Text="{loc:Translate Lbl_ErinnerungTage}" FontSize="13" TextColor="Gray" />
+                <Entry Text="{Binding ReminderDaysBeforeText}" Keyboard="Numeric" WidthRequest="80" />
+            </VerticalStackLayout>
+        </Grid>
+
+    </VerticalStackLayout>
+</ContentView>

--- a/Finanzuebersicht/Controls/RecurringTransactionFormView.xaml.cs
+++ b/Finanzuebersicht/Controls/RecurringTransactionFormView.xaml.cs
@@ -1,0 +1,6 @@
+namespace Finanzuebersicht.Controls;
+
+public partial class RecurringTransactionFormView : ContentView
+{
+    public RecurringTransactionFormView() => InitializeComponent();
+}

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -88,6 +88,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<IMainThreadDispatcher, MauiMainThreadDispatcher>();
 		builder.Services.AddSingleton<Finanzuebersicht.Presentation.Services.IFilePicker, MauiFilePicker>();
 		builder.Services.AddSingleton<IAppEvents, MauiAppEvents>();
+		builder.Services.AddSingleton<ICategoryCreateSheetService, CategoryCreateSheetService>();
 		builder.Services.AddSingleton<IImportSessionStore, ImportSessionStore>();
 		builder.Services.AddSingleton<IFolderPicker, MauiFolderPicker>();
 		builder.Services.AddSingleton<IFileSaver, MauiFileSaver>();

--- a/Finanzuebersicht/MauiProgram.cs
+++ b/Finanzuebersicht/MauiProgram.cs
@@ -89,6 +89,7 @@ public static class MauiProgram
 		builder.Services.AddSingleton<Finanzuebersicht.Presentation.Services.IFilePicker, MauiFilePicker>();
 		builder.Services.AddSingleton<IAppEvents, MauiAppEvents>();
 		builder.Services.AddSingleton<ICategoryCreateSheetService, CategoryCreateSheetService>();
+		builder.Services.AddSingleton<IRecurringTransactionCreateSheetService, RecurringTransactionCreateSheetService>();
 		builder.Services.AddSingleton<IImportSessionStore, ImportSessionStore>();
 		builder.Services.AddSingleton<IFolderPicker, MauiFolderPicker>();
 		builder.Services.AddSingleton<IFileSaver, MauiFileSaver>();

--- a/Finanzuebersicht/Resources/Strings/AppResources.de.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.de.resx
@@ -372,6 +372,8 @@ Bitte starte die App neu.</value></data>
   <data name="A11y_SelectionField" xml:space="preserve"><value>{0}, {1}, tippen zum Ändern</value></data>
   <data name="A11y_SelectionFieldLeer" xml:space="preserve"><value>{0}, tippen zum Auswählen</value></data>
   <data name="A11y_SegmentUmschalten" xml:space="preserve"><value>Ansicht umschalten</value></data>
+  <data name="A11y_CreateFormPanel" xml:space="preserve"><value>Formular zum Anlegen eines neuen Eintrags</value></data>
+  <data name="A11y_FormSheetDialog" xml:space="preserve"><value>Dialog: {0}</value></data>
   <data name="RecurrenceInterval_Daily" xml:space="preserve"><value>Täglich</value></data>
   <data name="RecurrenceInterval_Weekly" xml:space="preserve"><value>Wöchentlich</value></data>
   <data name="RecurrenceInterval_Monthly" xml:space="preserve"><value>Monatlich</value></data>

--- a/Finanzuebersicht/Resources/Strings/AppResources.resx
+++ b/Finanzuebersicht/Resources/Strings/AppResources.resx
@@ -372,6 +372,8 @@ Please restart the app.</value></data>
   <data name="A11y_SelectionField" xml:space="preserve"><value>{0}, {1}, tap to change</value></data>
   <data name="A11y_SelectionFieldLeer" xml:space="preserve"><value>{0}, tap to select</value></data>
   <data name="A11y_SegmentUmschalten" xml:space="preserve"><value>Switch view</value></data>
+  <data name="A11y_CreateFormPanel" xml:space="preserve"><value>Form for creating a new entry</value></data>
+  <data name="A11y_FormSheetDialog" xml:space="preserve"><value>Dialog: {0}</value></data>
   <data name="RecurrenceInterval_Daily" xml:space="preserve"><value>Daily</value></data>
   <data name="RecurrenceInterval_Weekly" xml:space="preserve"><value>Weekly</value></data>
   <data name="RecurrenceInterval_Monthly" xml:space="preserve"><value>Monthly</value></data>

--- a/Finanzuebersicht/Services/CategoryCreateSheetService.cs
+++ b/Finanzuebersicht/Services/CategoryCreateSheetService.cs
@@ -17,18 +17,10 @@ public sealed class CategoryCreateSheetService : ICategoryCreateSheetService
 
         var form = new CategoryFormView { BindingContext = viewModel };
 
-        while (true)
-        {
-            var result = await page.ShowFormSheetAsync(
-                viewModel.PageTitle,
-                form,
-                saveText: LocalizationResourceManager.Current[ResourceKeys.Btn_Speichern]);
-
-            if (result == FormSheetResult.Cancelled)
-                return false;
-
-            if (await viewModel.TrySaveAsync())
-                return true;
-        }
+        return await page.ShowFormSheetAsync(
+            viewModel.PageTitle,
+            form,
+            viewModel.TrySaveAsync,
+            saveText: LocalizationResourceManager.Current[ResourceKeys.Btn_Speichern]);
     }
 }

--- a/Finanzuebersicht/Services/CategoryCreateSheetService.cs
+++ b/Finanzuebersicht/Services/CategoryCreateSheetService.cs
@@ -1,0 +1,34 @@
+using Finanzuebersicht.Controls;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.Resources.Strings;
+using Finanzuebersicht.Services;
+using Finanzuebersicht.ViewModels;
+using Finanzuebersicht.Views.Popups;
+
+namespace Finanzuebersicht.Services;
+
+public sealed class CategoryCreateSheetService : ICategoryCreateSheetService
+{
+    public async Task<bool> ShowAsync(CategoryDetailViewModel viewModel)
+    {
+        var page = Shell.Current?.CurrentPage;
+        if (page is null)
+            return false;
+
+        var form = new CategoryFormView { BindingContext = viewModel };
+
+        while (true)
+        {
+            var result = await page.ShowFormSheetAsync(
+                viewModel.PageTitle,
+                form,
+                saveText: LocalizationResourceManager.Current[ResourceKeys.Btn_Speichern]);
+
+            if (result == FormSheetResult.Cancelled)
+                return false;
+
+            if (await viewModel.TrySaveAsync())
+                return true;
+        }
+    }
+}

--- a/Finanzuebersicht/Services/RecurringTransactionCreateSheetService.cs
+++ b/Finanzuebersicht/Services/RecurringTransactionCreateSheetService.cs
@@ -17,18 +17,10 @@ public sealed class RecurringTransactionCreateSheetService : IRecurringTransacti
 
         var form = new RecurringTransactionFormView { BindingContext = viewModel };
 
-        while (true)
-        {
-            var result = await page.ShowFormSheetAsync(
-                viewModel.PageTitle,
-                form,
-                saveText: LocalizationResourceManager.Current[ResourceKeys.Btn_Speichern]);
-
-            if (result == FormSheetResult.Cancelled)
-                return false;
-
-            if (await viewModel.TrySaveAsync())
-                return true;
-        }
+        return await page.ShowFormSheetAsync(
+            viewModel.PageTitle,
+            form,
+            viewModel.TrySaveAsync,
+            saveText: LocalizationResourceManager.Current[ResourceKeys.Btn_Speichern]);
     }
 }

--- a/Finanzuebersicht/Services/RecurringTransactionCreateSheetService.cs
+++ b/Finanzuebersicht/Services/RecurringTransactionCreateSheetService.cs
@@ -1,0 +1,34 @@
+using Finanzuebersicht.Controls;
+using Finanzuebersicht.Presentation.Services;
+using Finanzuebersicht.Resources.Strings;
+using Finanzuebersicht.Services;
+using Finanzuebersicht.ViewModels;
+using Finanzuebersicht.Views.Popups;
+
+namespace Finanzuebersicht.Services;
+
+public sealed class RecurringTransactionCreateSheetService : IRecurringTransactionCreateSheetService
+{
+    public async Task<bool> ShowAsync(RecurringTransactionDetailViewModel viewModel)
+    {
+        var page = Shell.Current?.CurrentPage;
+        if (page is null)
+            return false;
+
+        var form = new RecurringTransactionFormView { BindingContext = viewModel };
+
+        while (true)
+        {
+            var result = await page.ShowFormSheetAsync(
+                viewModel.PageTitle,
+                form,
+                saveText: LocalizationResourceManager.Current[ResourceKeys.Btn_Speichern]);
+
+            if (result == FormSheetResult.Cancelled)
+                return false;
+
+            if (await viewModel.TrySaveAsync())
+                return true;
+        }
+    }
+}

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -125,8 +125,10 @@
                     <ScrollView x:Name="KontenScrollView">
                         <VerticalStackLayout Spacing="12" Padding="16">
 
-                            <controls:CreateFormCard Title="{Binding NeuesKontoFormTitle}"
+                            <controls:CreateFormCard x:Name="AddKontoForm"
+                                                     Title="{Binding NeuesKontoFormTitle}"
                                                      IsVisible="{Binding ShowAddKontoForm}"
+                                                     AccessibilityDescription="{loc:Translate A11y_CreateFormPanel}"
                                                      CancelText="{loc:Translate Btn_Abbrechen}"
                                                      SaveText="{loc:Translate Title_KontoHinzufuegen}"
                                                      CancelCommand="{Binding ToggleAddKontoFormCommand}"

--- a/Finanzuebersicht/Views/CategoriesPage.xaml
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml
@@ -122,8 +122,45 @@
                 <RefreshView Command="{Binding LoadKategorienCommand}"
                              IsRefreshing="{Binding IsLoading}"
                              IsVisible="{Binding IsKontenVisible}">
-                    <ScrollView>
+                    <ScrollView x:Name="KontenScrollView">
                         <VerticalStackLayout Spacing="12" Padding="16">
+
+                            <controls:CreateFormCard Title="{Binding NeuesKontoFormTitle}"
+                                                     IsVisible="{Binding ShowAddKontoForm}"
+                                                     CancelText="{loc:Translate Btn_Abbrechen}"
+                                                     SaveText="{loc:Translate Title_KontoHinzufuegen}"
+                                                     CancelCommand="{Binding ToggleAddKontoFormCommand}"
+                                                     SaveCommand="{Binding SaveNewKontoCommand}">
+                                <VerticalStackLayout Spacing="14">
+
+                                    <VerticalStackLayout Spacing="4">
+                                        <Label Text="{loc:Translate Lbl_Name}" FontSize="13"
+                                               TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                        <Entry Text="{Binding NeuerKontoName}"
+                                               Placeholder="{loc:Translate Lbl_Konto}"
+                                               FontSize="16" />
+                                    </VerticalStackLayout>
+
+                                    <VerticalStackLayout Spacing="4">
+                                        <Label Text="{loc:Translate Lbl_Typ}" FontSize="13"
+                                               TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                        <controls:SelectionField ItemsSource="{Binding VerfuegbareKontoTypen}"
+                                                                 SelectedItem="{Binding SelectedKontoTypeOption, Mode=TwoWay}"
+                                                                 DisplayMemberPath="DisplayName"
+                                                                 FieldLabel="{loc:Translate Lbl_Typ}" />
+                                    </VerticalStackLayout>
+
+                                    <VerticalStackLayout Spacing="4">
+                                        <Label Text="{loc:Translate Lbl_Anfangssaldo}" FontSize="13"
+                                               TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                        <Entry Text="{Binding NeuerAnfangssaldoText}"
+                                               Placeholder="{loc:Translate Hint_Betrag}"
+                                               Keyboard="Numeric"
+                                               FontSize="16" />
+                                    </VerticalStackLayout>
+
+                                </VerticalStackLayout>
+                            </controls:CreateFormCard>
 
                             <controls:EmptyStateView IconImage="categories.png"
                                                      IconAccessibilityDescription="{loc:Translate Lbl_Konten}"
@@ -131,7 +168,7 @@
                                                      Hint="{loc:Translate Empty_KontenHinweis}"
                                                      ActionText="{loc:Translate Btn_Hinzufuegen}"
                                                      ActionCommand="{Binding GoToDetailCommand}"
-                                                     IsVisible="{Binding IsKontenEmpty}" />
+                                                     IsVisible="{Binding IsKontenEmptyStateVisible}" />
 
                             <Border StrokeShape="RoundRectangle 12"
                                     Stroke="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"

--- a/Finanzuebersicht/Views/CategoriesPage.xaml.cs
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml.cs
@@ -37,5 +37,6 @@ public partial class CategoriesPage : BaseContentPage
             return;
 
         await KontenScrollView.ScrollToAsync(0, 0, false);
+        AddKontoForm.FocusForm();
     }
 }

--- a/Finanzuebersicht/Views/CategoriesPage.xaml.cs
+++ b/Finanzuebersicht/Views/CategoriesPage.xaml.cs
@@ -1,12 +1,41 @@
+using System.ComponentModel;
 using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
 public partial class CategoriesPage : BaseContentPage
 {
+    private CategoriesViewModel? _viewModel;
+
     public CategoriesPage(CategoriesViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
+    }
+
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+
+        if (_viewModel is not null)
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+
+        if (BindingContext is CategoriesViewModel viewModel)
+        {
+            _viewModel = viewModel;
+            viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        }
+        else
+        {
+            _viewModel = null;
+        }
+    }
+
+    private async void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(CategoriesViewModel.ShowAddKontoForm) || _viewModel?.ShowAddKontoForm != true)
+            return;
+
+        await KontenScrollView.ScrollToAsync(0, 0, false);
     }
 }

--- a/Finanzuebersicht/Views/CategoryDetailPage.xaml
+++ b/Finanzuebersicht/Views/CategoryDetailPage.xaml
@@ -12,78 +12,8 @@
     <ScrollView Grid.Row="0" Padding="16">
         <VerticalStackLayout Spacing="20">
 
-            <!-- Name -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Name}" FontSize="13" TextColor="Gray" />
-                <Entry Text="{Binding Name}" Placeholder="{loc:Translate Hint_Kategoriename}"
-                       FontSize="16" />
-            </VerticalStackLayout>
+            <controls:CategoryFormView BindingContext="{Binding .}" />
 
-            <!-- Icon-Auswahl -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Icon}" FontSize="13" TextColor="Gray" />
-                <CollectionView ItemsSource="{Binding VerfuegbareIcons}"
-                                SelectionMode="Single"
-                                SelectedItem="{Binding Icon}">
-                    <CollectionView.ItemsLayout>
-                        <GridItemsLayout Orientation="Vertical" Span="7"
-                                         HorizontalItemSpacing="8" VerticalItemSpacing="8" />
-                    </CollectionView.ItemsLayout>
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="x:String">
-                            <Border Padding="8" StrokeShape="RoundRectangle 10"
-                                   Stroke="Transparent"
-                                   BackgroundColor="#F2F2F7"
-                                   HorizontalOptions="Center">
-                                <Label Text="{Binding .}" FontSize="22"
-                                       HorizontalOptions="Center" VerticalOptions="Center" />
-                            </Border>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-            </VerticalStackLayout>
-
-            <!-- Farb-Auswahl -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Farbe}" FontSize="13" TextColor="Gray" />
-                <CollectionView ItemsSource="{Binding VerfuegbareFarben}"
-                                SelectionMode="Single"
-                                SelectedItem="{Binding Color}">
-                    <CollectionView.ItemsLayout>
-                        <GridItemsLayout Orientation="Vertical" Span="5"
-                                         HorizontalItemSpacing="10" VerticalItemSpacing="10" />
-                    </CollectionView.ItemsLayout>
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="x:String">
-                            <Border WidthRequest="40" HeightRequest="40"
-                                   StrokeShape="RoundRectangle 20"
-                                   Stroke="Transparent" Padding="0"
-                                   BackgroundColor="{Binding .}"
-                                   HorizontalOptions="Center" />
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-            </VerticalStackLayout>
-
-            <!-- Typ -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Typ}" FontSize="13" TextColor="Gray" />
-                <controls:SelectionField ItemsSource="{Binding VerfuegbareTypen}"
-                                         SelectedItem="{Binding SelectedTypeOption, Mode=TwoWay}"
-                                         DisplayMemberPath="DisplayName"
-                                         FieldLabel="{loc:Translate Lbl_Typ}" />
-            </VerticalStackLayout>
-
-            <!-- Monatliches Budget -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_MonatlichesBudget}" FontSize="13" TextColor="Gray" />
-                <Entry Text="{Binding MonthlyBudgetText}" Keyboard="Numeric"
-                       Placeholder="{loc:Translate Hint_BudgetOptional}" FontSize="16"
-                       SemanticProperties.Hint="{loc:Translate A11y_HintBudget}" />
-                <Label Text="{loc:Translate Hint_BudgetNull}" FontSize="11" TextColor="Gray" />
-            </VerticalStackLayout>
-
-            <!-- Speichern -->
             <Button Text="{loc:Translate Btn_Speichern}" Command="{Binding SaveCommand}"
                     BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}" TextColor="White"
                     CornerRadius="12" HeightRequest="50"

--- a/Finanzuebersicht/Views/Popups/FormSheetPopup.cs
+++ b/Finanzuebersicht/Views/Popups/FormSheetPopup.cs
@@ -31,6 +31,9 @@ public class FormSheetPopup : Popup<FormSheetResult>
         CanBeDismissedByTappingOutsideOfPopup = true;
 
         var maxFormHeight = ComputeMaxFormHeight();
+        var sheetDescription = string.Format(
+            LocalizationResourceManager.Current[ResourceKeys.A11y_FormSheetDialog],
+            title);
 
         var card = new CreateFormCard
         {
@@ -40,6 +43,7 @@ public class FormSheetPopup : Popup<FormSheetResult>
             SaveText = saveText,
             ScrollFormContent = true,
             MaxFormHeight = maxFormHeight,
+            AccessibilityDescription = sheetDescription,
             CancelCommand = new Command(() => _ = CloseWithResultAsync(FormSheetResult.Cancelled)),
             SaveCommand = new Command(() => _ = CloseWithResultAsync(FormSheetResult.Saved))
         };
@@ -68,6 +72,10 @@ public class FormSheetPopup : Popup<FormSheetResult>
                 Children = { card }
             }
         };
+
+        Microsoft.Maui.Controls.Application.Current?.Dispatcher.DispatchDelayed(
+            TimeSpan.FromMilliseconds(200),
+            () => FormFocusHelper.TryFocusFirstInput(formContent));
     }
 
     private async Task CloseWithResultAsync(FormSheetResult result)

--- a/Finanzuebersicht/Views/Popups/FormSheetPopup.cs
+++ b/Finanzuebersicht/Views/Popups/FormSheetPopup.cs
@@ -17,20 +17,29 @@ public enum FormSheetResult
 
 public class FormSheetPopup : Popup<FormSheetResult>
 {
-    private const double SheetWidth = 360;
+    private const double MaxSheetWidth = 360;
+    private const double MinSheetWidth = 280;
+    private const double HorizontalMargin = 40;
     private const double ChromeHeight = 120;
     private const double MaxHeightFraction = 0.7;
 
     private bool _isClosing;
+    private bool _isSaving;
 
-    public FormSheetPopup(string title, View formContent, string cancelText, string saveText)
+    public FormSheetPopup(
+        Page hostPage,
+        string title,
+        View formContent,
+        string cancelText,
+        string saveText,
+        Func<Task<bool>>? trySaveAsync = null)
     {
         BackgroundColor = Colors.Transparent;
         Padding = 0;
         Margin = new Thickness(20);
         CanBeDismissedByTappingOutsideOfPopup = true;
 
-        var maxFormHeight = ComputeMaxFormHeight();
+        var (sheetWidth, maxFormHeight) = ComputeSheetSize(hostPage);
         var sheetDescription = string.Format(
             LocalizationResourceManager.Current[ResourceKeys.A11y_FormSheetDialog],
             title);
@@ -45,7 +54,7 @@ public class FormSheetPopup : Popup<FormSheetResult>
             MaxFormHeight = maxFormHeight,
             AccessibilityDescription = sheetDescription,
             CancelCommand = new Command(() => _ = CloseWithResultAsync(FormSheetResult.Cancelled)),
-            SaveCommand = new Command(() => _ = CloseWithResultAsync(FormSheetResult.Saved))
+            SaveCommand = new Command(async () => await OnSaveAsync(trySaveAsync))
         };
 
         var cardBackground = ColorResourceHelper.GetThemeColor(
@@ -67,7 +76,7 @@ public class FormSheetPopup : Popup<FormSheetResult>
             },
             Content = new Grid
             {
-                WidthRequest = SheetWidth,
+                WidthRequest = sheetWidth,
                 MaximumHeightRequest = maxFormHeight + ChromeHeight,
                 Children = { card }
             }
@@ -76,6 +85,28 @@ public class FormSheetPopup : Popup<FormSheetResult>
         Microsoft.Maui.Controls.Application.Current?.Dispatcher.DispatchDelayed(
             TimeSpan.FromMilliseconds(200),
             () => FormFocusHelper.TryFocusFirstInput(formContent));
+    }
+
+    private async Task OnSaveAsync(Func<Task<bool>>? trySaveAsync)
+    {
+        if (_isClosing || _isSaving)
+            return;
+
+        if (trySaveAsync is not null)
+        {
+            _isSaving = true;
+            try
+            {
+                if (!await trySaveAsync())
+                    return;
+            }
+            finally
+            {
+                _isSaving = false;
+            }
+        }
+
+        await CloseWithResultAsync(FormSheetResult.Saved);
     }
 
     private async Task CloseWithResultAsync(FormSheetResult result)
@@ -87,32 +118,43 @@ public class FormSheetPopup : Popup<FormSheetResult>
         await CloseAsync(result);
     }
 
-    private static double ComputeMaxFormHeight()
+    private static (double SheetWidth, double MaxFormHeight) ComputeSheetSize(Page hostPage)
     {
-        var display = DeviceDisplay.MainDisplayInfo;
-        var heightDp = display.Height / display.Density;
-        return Math.Max(200, heightDp * MaxHeightFraction - ChromeHeight);
+        var windowWidth = hostPage.Window?.Width ?? 0;
+        var windowHeight = hostPage.Window?.Height ?? 0;
+
+        if (windowWidth <= 0 || windowHeight <= 0)
+        {
+            var display = DeviceDisplay.MainDisplayInfo;
+            windowWidth = display.Width / display.Density;
+            windowHeight = display.Height / display.Density;
+        }
+
+        var sheetWidth = Math.Min(MaxSheetWidth, Math.Max(MinSheetWidth, windowWidth - HorizontalMargin));
+        var maxFormHeight = Math.Max(200, windowHeight * MaxHeightFraction - ChromeHeight);
+        return (sheetWidth, maxFormHeight);
     }
 }
 
 public static class FormSheetPopupExtensions
 {
-    public static async Task<FormSheetResult> ShowFormSheetAsync(
+    public static async Task<bool> ShowFormSheetAsync(
         this Page page,
         string title,
         View formContent,
+        Func<Task<bool>> trySaveAsync,
         string? cancelText = null,
         string? saveText = null)
     {
         cancelText ??= LocalizationResourceManager.Current[ResourceKeys.Btn_Abbrechen];
         saveText ??= LocalizationResourceManager.Current[ResourceKeys.Btn_Speichern];
 
-        var popup = new FormSheetPopup(title, formContent, cancelText, saveText);
+        var popup = new FormSheetPopup(page, title, formContent, cancelText, saveText, trySaveAsync);
         var popupResult = await page.ShowPopupAsync<FormSheetResult>(popup);
 
         if (popupResult.WasDismissedByTappingOutsideOfPopup)
-            return FormSheetResult.Cancelled;
+            return false;
 
-        return popupResult.Result;
+        return popupResult.Result == FormSheetResult.Saved;
     }
 }

--- a/Finanzuebersicht/Views/Popups/FormSheetPopup.cs
+++ b/Finanzuebersicht/Views/Popups/FormSheetPopup.cs
@@ -1,0 +1,110 @@
+using System.Windows.Input;
+using CommunityToolkit.Maui.Extensions;
+using CommunityToolkit.Maui.Views;
+using Finanzuebersicht.Controls;
+using Finanzuebersicht.Converters;
+using Finanzuebersicht.Resources.Strings;
+using Finanzuebersicht.Services;
+using Microsoft.Maui.Controls.Shapes;
+
+namespace Finanzuebersicht.Views.Popups;
+
+public enum FormSheetResult
+{
+    Cancelled,
+    Saved
+}
+
+public class FormSheetPopup : Popup<FormSheetResult>
+{
+    private const double SheetWidth = 360;
+    private const double ChromeHeight = 120;
+    private const double MaxHeightFraction = 0.7;
+
+    private bool _isClosing;
+
+    public FormSheetPopup(string title, View formContent, string cancelText, string saveText)
+    {
+        BackgroundColor = Colors.Transparent;
+        Padding = 0;
+        Margin = new Thickness(20);
+        CanBeDismissedByTappingOutsideOfPopup = true;
+
+        var maxFormHeight = ComputeMaxFormHeight();
+
+        var card = new CreateFormCard
+        {
+            Title = title,
+            FormContent = formContent,
+            CancelText = cancelText,
+            SaveText = saveText,
+            ScrollFormContent = true,
+            MaxFormHeight = maxFormHeight,
+            CancelCommand = new Command(() => _ = CloseWithResultAsync(FormSheetResult.Cancelled)),
+            SaveCommand = new Command(() => _ = CloseWithResultAsync(FormSheetResult.Saved))
+        };
+
+        var cardBackground = ColorResourceHelper.GetThemeColor(
+            "CardBackground", "CardBackgroundDark",
+            Color.FromArgb("#FFFFFF"), Color.FromArgb("#1C1C1E"));
+
+        Content = new Border
+        {
+            Padding = 0,
+            BackgroundColor = cardBackground,
+            StrokeThickness = 0,
+            StrokeShape = new RoundRectangle { CornerRadius = 12 },
+            Shadow = new Shadow
+            {
+                Brush = Brush.Black,
+                Offset = new Point(0, 6),
+                Radius = 16,
+                Opacity = 0.28f
+            },
+            Content = new Grid
+            {
+                WidthRequest = SheetWidth,
+                MaximumHeightRequest = maxFormHeight + ChromeHeight,
+                Children = { card }
+            }
+        };
+    }
+
+    private async Task CloseWithResultAsync(FormSheetResult result)
+    {
+        if (_isClosing)
+            return;
+
+        _isClosing = true;
+        await CloseAsync(result);
+    }
+
+    private static double ComputeMaxFormHeight()
+    {
+        var display = DeviceDisplay.MainDisplayInfo;
+        var heightDp = display.Height / display.Density;
+        return Math.Max(200, heightDp * MaxHeightFraction - ChromeHeight);
+    }
+}
+
+public static class FormSheetPopupExtensions
+{
+    public static async Task<FormSheetResult> ShowFormSheetAsync(
+        this Page page,
+        string title,
+        View formContent,
+        string? cancelText = null,
+        string? saveText = null)
+    {
+        cancelText ??= LocalizationResourceManager.Current[ResourceKeys.Btn_Abbrechen];
+        saveText ??= LocalizationResourceManager.Current[ResourceKeys.Btn_Speichern];
+
+        var popup = new FormSheetPopup(title, formContent, cancelText, saveText);
+        var popupResult = await page.ShowPopupAsync<FormSheetResult>(popup);
+
+        if (popupResult.WasDismissedByTappingOutsideOfPopup)
+            return FormSheetResult.Cancelled;
+
+        return popupResult.Result;
+    }
+}

--- a/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
+++ b/Finanzuebersicht/Views/RecurringTransactionDetailPage.xaml
@@ -4,143 +4,41 @@
              xmlns:views="clr-namespace:Finanzuebersicht.Views"
              xmlns:vm="clr-namespace:Finanzuebersicht.ViewModels"
              xmlns:models="clr-namespace:Finanzuebersicht.Models"
-             xmlns:conv="clr-namespace:Finanzuebersicht.Converters"
              xmlns:controls="clr-namespace:Finanzuebersicht.Controls"
              xmlns:loc="clr-namespace:Finanzuebersicht.Extensions"
              x:Class="Finanzuebersicht.Views.RecurringTransactionDetailPage"
              x:DataType="vm:RecurringTransactionDetailViewModel"
-             Title="{loc:Translate Title_Dauerauftrag}">
-
-    <views:BaseContentPage.Resources>
-        <conv:TypButtonColorConverter x:Key="TypButtonColor" />
-    </views:BaseContentPage.Resources>
+             Title="{Binding PageTitle}">
 
     <Grid RowDefinitions="*, Auto">
         <ScrollView Grid.Row="0" Padding="16">
             <VerticalStackLayout Spacing="20" Padding="0,0,0,24">
 
-            <!-- Typ-Auswahl -->
-            <Grid ColumnDefinitions="*, *" ColumnSpacing="8">
-                <Button Grid.Column="0" Text="{loc:Translate Lbl_Ausgabe}"
-                        BackgroundColor="{Binding Typ, Converter={StaticResource TypButtonColor}, ConverterParameter=Ausgabe}"
-                        TextColor="White" CornerRadius="10" HeightRequest="44"
-                        Command="{Binding SetTypCommand}" CommandParameter="Ausgabe" />
-                <Button Grid.Column="1" Text="{loc:Translate Lbl_Einnahme}"
-                        BackgroundColor="{Binding Typ, Converter={StaticResource TypButtonColor}, ConverterParameter=Einnahme}"
-                        TextColor="White" CornerRadius="10" HeightRequest="44"
-                        Command="{Binding SetTypCommand}" CommandParameter="Einnahme" />
-            </Grid>
+                <controls:RecurringTransactionFormView BindingContext="{Binding .}" />
 
-            <!-- Betrag -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Betrag}" FontSize="13" TextColor="Gray" />
-                  <Entry Text="{Binding BetragText}" Placeholder="{loc:Translate Hint_Betrag}"
-                       Keyboard="Numeric" FontSize="28" FontAttributes="Bold"
-                       HorizontalTextAlignment="Center"
-                       SemanticProperties.Hint="{loc:Translate A11y_HintBetrag}" />
-            </VerticalStackLayout>
+                <VerticalStackLayout Spacing="4" IsVisible="{Binding IsEditing}">
+                    <Label Text="{loc:Translate Lbl_Ausnahmen}" FontSize="13" TextColor="Gray" />
+                    <CollectionView ItemsSource="{Binding Exceptions}" SelectionMode="None" HeightRequest="180" VerticalOptions="Start" Margin="0,6,0,0">
+                        <CollectionView.ItemTemplate>
+                            <DataTemplate x:DataType="models:RecurringException">
+                                <Grid ColumnDefinitions="*, Auto" Padding="8">
+                                    <Label Text="{Binding InstanceDate, StringFormat='{}{0:dd.MM.yyyy}'}" VerticalTextAlignment="Center" />
+                                    <Button Grid.Column="1" Text="{loc:Translate Btn_Loeschen}" BackgroundColor="{StaticResource Ausgabe}" TextColor="White" Command="{Binding Source={RelativeSource AncestorType={x:Type vm:RecurringTransactionDetailViewModel}}, Path=RemoveExceptionCommand}" CommandParameter="{Binding .}" />
+                                </Grid>
+                            </DataTemplate>
+                        </CollectionView.ItemTemplate>
+                    </CollectionView>
 
-            <!-- Titel -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Titel}" FontSize="13" TextColor="Gray" />
-                <Entry Text="{Binding Titel}" Placeholder="{loc:Translate Hint_Titelbeispiel}"
-                       FontSize="16" />
-            </VerticalStackLayout>
-
-            <!-- Kategorie -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Kategorie}" FontSize="13" TextColor="Gray" />
-                <controls:SelectionField ItemsSource="{Binding Kategorien}"
-                                         SelectedItem="{Binding SelectedKategorie, Mode=TwoWay}"
-                                         DisplayMemberPath="Name"
-                                         FieldLabel="{loc:Translate Lbl_Kategorie}"
-                                         Placeholder="{loc:Translate Hint_KategorieWaehlen}" />
-            </VerticalStackLayout>
-
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Konto}" FontSize="13" TextColor="Gray" />
-                <controls:SelectionField ItemsSource="{Binding Accounts}"
-                                         SelectedItem="{Binding SelectedAccount, Mode=TwoWay}"
-                                         DisplayMemberPath="Name"
-                                         FieldLabel="{loc:Translate Lbl_Konto}"
-                                         Placeholder="{loc:Translate Hint_KontoWaehlen}" />
-            </VerticalStackLayout>
-
-            <!-- Startdatum -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Startdatum}" FontSize="13" TextColor="Gray" />
-                <DatePicker Date="{Binding Startdatum, Mode=TwoWay}" FontSize="16"
-                            Format="dd. MMMM yyyy"
-                            controls:DatePickerProperties.ImmediateUpdate="True" />
-            </VerticalStackLayout>
-
-            <!-- Enddatum (optional) -->
-            <Grid ColumnDefinitions="*, Auto" Padding="0">
-                <Label Text="{loc:Translate Lbl_EnddatumFestlegen}" FontSize="16"
-                       VerticalTextAlignment="Center" />
-                <Switch Grid.Column="1" IsToggled="{Binding HatEnddatum}" />
-            </Grid>
-
-            <DatePicker Date="{Binding EnddatumWert, Mode=TwoWay}" FontSize="16"
-                        Format="dd. MMMM yyyy"
-                        IsVisible="{Binding HatEnddatum}"
-                        controls:DatePickerProperties.ImmediateUpdate="True" />
-
-            <!-- Aktiv -->
-            <Grid ColumnDefinitions="*, Auto" Padding="0">
-                <Label Text="{loc:Translate Lbl_Aktiv}" FontSize="16"
-                       VerticalTextAlignment="Center" />
-                <Switch Grid.Column="1" IsToggled="{Binding Aktiv}" />
-            </Grid>
-
-            <!-- Intervall (Täglich/Wöchentlich/Monatlich/Quartal/Jährlich) -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Intervall}" FontSize="13" TextColor="Gray" />
-                <controls:SelectionField ItemsSource="{Binding VerfuegbareIntervalle}"
-                                         SelectedItem="{Binding SelectedIntervalOption, Mode=TwoWay}"
-                                         DisplayMemberPath="DisplayName"
-                                         FieldLabel="{loc:Translate Lbl_Intervall}"
-                                         Placeholder="{loc:Translate Hint_IntervallWaehlen}"
-                                         Margin="0,0,0,8" />
-            </VerticalStackLayout>
-
-            <!-- Interval-Factor -->
-            <Grid ColumnDefinitions="*, Auto" ColumnSpacing="8" Margin="0,8,0,0">
-                <VerticalStackLayout Grid.Column="0" Spacing="4">
-                    <Label Text="{loc:Translate Lbl_IntervallFaktor}" FontSize="13" TextColor="Gray" />
-                    <Entry Text="{Binding IntervalFactorText}" Keyboard="Numeric" />
+                    <Button Text="{loc:Translate Btn_SkipNextInstance}" Command="{Binding AddSkipNextInstanceCommand}" BackgroundColor="{StaticResource Warning}" TextColor="White" />
                 </VerticalStackLayout>
-                <VerticalStackLayout Grid.Column="1" Spacing="4" HorizontalOptions="End">
-                    <Label Text="{loc:Translate Lbl_ErinnerungTage}" FontSize="13" TextColor="Gray" />
-                    <Entry Text="{Binding ReminderDaysBeforeText}" Keyboard="Numeric" WidthRequest="80" />
-                </VerticalStackLayout>
-            </Grid>
 
-            <!-- Exceptions -->
-            <VerticalStackLayout Spacing="4">
-                <Label Text="{loc:Translate Lbl_Ausnahmen}" FontSize="13" TextColor="Gray" />
-                <CollectionView ItemsSource="{Binding Exceptions}" SelectionMode="None" HeightRequest="180" VerticalOptions="Start" Margin="0,6,0,0">
-                    <CollectionView.ItemTemplate>
-                        <DataTemplate x:DataType="models:RecurringException">
-                            <Grid ColumnDefinitions="*, Auto" Padding="8">
-                                <Label Text="{Binding InstanceDate, StringFormat='{}{0:dd.MM.yyyy}'}" VerticalTextAlignment="Center" />
-                                <Button Grid.Column="1" Text="{loc:Translate Btn_Loeschen}" BackgroundColor="{StaticResource Ausgabe}" TextColor="White" Command="{Binding Source={RelativeSource AncestorType={x:Type vm:RecurringTransactionDetailViewModel}}, Path=RemoveExceptionCommand}" CommandParameter="{Binding .}" />
-                            </Grid>
-                        </DataTemplate>
-                    </CollectionView.ItemTemplate>
-                </CollectionView>
-
-                <Button Text="{loc:Translate Btn_SkipNextInstance}" Command="{Binding AddSkipNextInstanceCommand}" BackgroundColor="{StaticResource Warning}" TextColor="White" />
-            </VerticalStackLayout>
-
-                <!-- Speichern -->
                 <Button Text="{loc:Translate Btn_Speichern}" Command="{Binding SaveCommand}"
-                    BackgroundColor="{StaticResource Primary}" TextColor="White"
-                    CornerRadius="12" HeightRequest="50"
-                    FontSize="16" FontAttributes="Bold"
-                    Margin="0,20,0,0" />
+                        BackgroundColor="{StaticResource Primary}" TextColor="White"
+                        CornerRadius="12" HeightRequest="50"
+                        FontSize="16" FontAttributes="Bold"
+                        Margin="0,20,0,0" />
 
-                <HorizontalStackLayout Spacing="8" Margin="0,8,0,0">
+                <HorizontalStackLayout Spacing="8" Margin="0,8,0,0" IsVisible="{Binding IsEditing}">
                     <Button Text="{loc:Translate Btn_ShiftInstance}" Command="{Binding GoToShiftCommand}" BackgroundColor="{StaticResource Einnahme}" TextColor="White" />
                 </HorizontalStackLayout>
 

--- a/Finanzuebersicht/Views/SparZielePage.xaml
+++ b/Finanzuebersicht/Views/SparZielePage.xaml
@@ -110,15 +110,13 @@
                     </VerticalStackLayout>
 
                     <!-- Formular: Neues Ziel -->
-                    <Border StrokeShape="RoundRectangle 12"
-                            Stroke="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                            BackgroundColor="{AppThemeBinding Light={StaticResource CardBackground}, Dark={StaticResource CardBackgroundDark}}"
-                            Padding="16"
-                            IsVisible="{Binding ShowAddForm}">
+                    <controls:CreateFormCard Title="{loc:Translate Btn_NeuesZiel}"
+                                             IsVisible="{Binding ShowAddForm}"
+                                             CancelText="{loc:Translate Btn_Abbrechen}"
+                                             SaveText="{loc:Translate Btn_ZielHinzufuegen}"
+                                             CancelCommand="{Binding ToggleAddFormCommand}"
+                                             SaveCommand="{Binding SaveNewSparZielCommand}">
                         <VerticalStackLayout Spacing="14">
-
-                            <Label Text="{loc:Translate Btn_NeuesZiel}"
-                                   FontSize="16" FontAttributes="Bold" />
 
                             <!-- Titel -->
                             <VerticalStackLayout Spacing="4">
@@ -160,24 +158,8 @@
                                        Keyboard="Numeric" FontSize="16" />
                             </VerticalStackLayout>
 
-                            <!-- Buttons -->
-                            <Grid ColumnDefinitions="*, *" ColumnSpacing="10">
-                                <Button Grid.Column="0"
-                                        Text="{loc:Translate Btn_Abbrechen}"
-                                        BackgroundColor="{AppThemeBinding Light={StaticResource Gray200}, Dark={StaticResource Gray900}}"
-                                        TextColor="{AppThemeBinding Light={StaticResource TextPrimary}, Dark={StaticResource TextPrimaryDark}}"
-                                        CornerRadius="10" HeightRequest="44"
-                                        Command="{Binding ToggleAddFormCommand}" />
-                                <Button Grid.Column="1"
-                                        Text="{loc:Translate Btn_ZielHinzufuegen}"
-                                        BackgroundColor="{AppThemeBinding Light={StaticResource Primary}, Dark={StaticResource PrimaryDark}}"
-                                        TextColor="White"
-                                        CornerRadius="10" HeightRequest="44"
-                                        Command="{Binding SaveNewSparZielCommand}" />
-                            </Grid>
-
                         </VerticalStackLayout>
-                    </Border>
+                    </controls:CreateFormCard>
 
                 </VerticalStackLayout>
             </ScrollView>

--- a/Finanzuebersicht/Views/SparZielePage.xaml
+++ b/Finanzuebersicht/Views/SparZielePage.xaml
@@ -31,8 +31,10 @@
                                              IsVisible="{Binding IsEmptyStateVisible}" />
 
                     <!-- Formular: Neues Ziel -->
-                    <controls:CreateFormCard Title="{loc:Translate Btn_NeuesZiel}"
+                    <controls:CreateFormCard x:Name="AddSparZielForm"
+                                             Title="{loc:Translate Btn_NeuesZiel}"
                                              IsVisible="{Binding ShowAddForm}"
+                                             AccessibilityDescription="{loc:Translate A11y_CreateFormPanel}"
                                              CancelText="{loc:Translate Btn_Abbrechen}"
                                              SaveText="{loc:Translate Btn_ZielHinzufuegen}"
                                              CancelCommand="{Binding ToggleAddFormCommand}"

--- a/Finanzuebersicht/Views/SparZielePage.xaml
+++ b/Finanzuebersicht/Views/SparZielePage.xaml
@@ -19,7 +19,7 @@
     <Grid>
         <RefreshView Command="{Binding LoadSparZieleCommand}"
                      IsRefreshing="{Binding IsLoading}">
-            <ScrollView>
+            <ScrollView x:Name="SparZieleScrollView">
                 <VerticalStackLayout Spacing="16" Padding="16">
 
                     <controls:EmptyStateView IconImage="savings.png"
@@ -28,7 +28,59 @@
                                              Hint="{loc:Translate Empty_HintSparZiele}"
                                              ActionText="{loc:Translate Btn_NeuesZiel}"
                                              ActionCommand="{Binding ToggleAddFormCommand}"
-                                             IsVisible="{Binding IsEmpty}" />
+                                             IsVisible="{Binding IsEmptyStateVisible}" />
+
+                    <!-- Formular: Neues Ziel -->
+                    <controls:CreateFormCard Title="{loc:Translate Btn_NeuesZiel}"
+                                             IsVisible="{Binding ShowAddForm}"
+                                             CancelText="{loc:Translate Btn_Abbrechen}"
+                                             SaveText="{loc:Translate Btn_ZielHinzufuegen}"
+                                             CancelCommand="{Binding ToggleAddFormCommand}"
+                                             SaveCommand="{Binding SaveNewSparZielCommand}">
+                        <VerticalStackLayout Spacing="14">
+
+                            <!-- Titel -->
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="{loc:Translate Lbl_Titel}" FontSize="13"
+                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                <Entry Text="{Binding NeuerTitel}"
+                                       Placeholder="{loc:Translate Hint_ZielTitel}"
+                                       FontSize="16" />
+                            </VerticalStackLayout>
+
+                            <!-- Icon -->
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="{loc:Translate Lbl_Icon}" FontSize="13"
+                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                <Entry Text="{Binding NeuerIcon}" FontSize="24" MaxLength="2" />
+                            </VerticalStackLayout>
+
+                            <!-- Zielbetrag -->
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="{loc:Translate Lbl_ZielBetrag}" FontSize="13"
+                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                <Entry Text="{Binding NeuesZielBetrag}"
+                                       Keyboard="Numeric" FontSize="16" />
+                            </VerticalStackLayout>
+
+                            <!-- Aktueller Betrag -->
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="{loc:Translate Lbl_AktuellerBetrag}" FontSize="13"
+                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                <Entry Text="{Binding NeuerAktuellerBetrag}"
+                                       Keyboard="Numeric" FontSize="16" />
+                            </VerticalStackLayout>
+
+                            <!-- Monatliche Sparrate -->
+                            <VerticalStackLayout Spacing="4">
+                                <Label Text="{loc:Translate Lbl_MonatlicheSparrate}" FontSize="13"
+                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
+                                <Entry Text="{Binding NeueMonatlicheSparrate}"
+                                       Keyboard="Numeric" FontSize="16" />
+                            </VerticalStackLayout>
+
+                        </VerticalStackLayout>
+                    </controls:CreateFormCard>
 
                     <!-- Ziele-Liste -->
                     <VerticalStackLayout BindableLayout.ItemsSource="{Binding SparZiele}" Spacing="12">
@@ -108,58 +160,6 @@
                             </DataTemplate>
                         </BindableLayout.ItemTemplate>
                     </VerticalStackLayout>
-
-                    <!-- Formular: Neues Ziel -->
-                    <controls:CreateFormCard Title="{loc:Translate Btn_NeuesZiel}"
-                                             IsVisible="{Binding ShowAddForm}"
-                                             CancelText="{loc:Translate Btn_Abbrechen}"
-                                             SaveText="{loc:Translate Btn_ZielHinzufuegen}"
-                                             CancelCommand="{Binding ToggleAddFormCommand}"
-                                             SaveCommand="{Binding SaveNewSparZielCommand}">
-                        <VerticalStackLayout Spacing="14">
-
-                            <!-- Titel -->
-                            <VerticalStackLayout Spacing="4">
-                                <Label Text="{loc:Translate Lbl_Titel}" FontSize="13"
-                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
-                                <Entry Text="{Binding NeuerTitel}"
-                                       Placeholder="{loc:Translate Hint_ZielTitel}"
-                                       FontSize="16" />
-                            </VerticalStackLayout>
-
-                            <!-- Icon -->
-                            <VerticalStackLayout Spacing="4">
-                                <Label Text="{loc:Translate Lbl_Icon}" FontSize="13"
-                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
-                                <Entry Text="{Binding NeuerIcon}" FontSize="24" MaxLength="2" />
-                            </VerticalStackLayout>
-
-                            <!-- Zielbetrag -->
-                            <VerticalStackLayout Spacing="4">
-                                <Label Text="{loc:Translate Lbl_ZielBetrag}" FontSize="13"
-                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
-                                <Entry Text="{Binding NeuesZielBetrag}"
-                                       Keyboard="Numeric" FontSize="16" />
-                            </VerticalStackLayout>
-
-                            <!-- Aktueller Betrag -->
-                            <VerticalStackLayout Spacing="4">
-                                <Label Text="{loc:Translate Lbl_AktuellerBetrag}" FontSize="13"
-                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
-                                <Entry Text="{Binding NeuerAktuellerBetrag}"
-                                       Keyboard="Numeric" FontSize="16" />
-                            </VerticalStackLayout>
-
-                            <!-- Monatliche Sparrate -->
-                            <VerticalStackLayout Spacing="4">
-                                <Label Text="{loc:Translate Lbl_MonatlicheSparrate}" FontSize="13"
-                                       TextColor="{AppThemeBinding Light=#8E8E93, Dark=#636366}" />
-                                <Entry Text="{Binding NeueMonatlicheSparrate}"
-                                       Keyboard="Numeric" FontSize="16" />
-                            </VerticalStackLayout>
-
-                        </VerticalStackLayout>
-                    </controls:CreateFormCard>
 
                 </VerticalStackLayout>
             </ScrollView>

--- a/Finanzuebersicht/Views/SparZielePage.xaml.cs
+++ b/Finanzuebersicht/Views/SparZielePage.xaml.cs
@@ -1,12 +1,41 @@
+using System.ComponentModel;
 using Finanzuebersicht.ViewModels;
 
 namespace Finanzuebersicht.Views;
 
 public partial class SparZielePage : BaseContentPage
 {
+    private SparZieleViewModel? _viewModel;
+
     public SparZielePage(SparZieleViewModel viewModel)
     {
         InitializeComponent();
         BindingContext = viewModel;
+    }
+
+    protected override void OnBindingContextChanged()
+    {
+        base.OnBindingContextChanged();
+
+        if (_viewModel is not null)
+            _viewModel.PropertyChanged -= OnViewModelPropertyChanged;
+
+        if (BindingContext is SparZieleViewModel viewModel)
+        {
+            _viewModel = viewModel;
+            viewModel.PropertyChanged += OnViewModelPropertyChanged;
+        }
+        else
+        {
+            _viewModel = null;
+        }
+    }
+
+    private async void OnViewModelPropertyChanged(object? sender, PropertyChangedEventArgs e)
+    {
+        if (e.PropertyName != nameof(SparZieleViewModel.ShowAddForm) || _viewModel?.ShowAddForm != true)
+            return;
+
+        await SparZieleScrollView.ScrollToAsync(0, 0, false);
     }
 }

--- a/Finanzuebersicht/Views/SparZielePage.xaml.cs
+++ b/Finanzuebersicht/Views/SparZielePage.xaml.cs
@@ -37,5 +37,6 @@ public partial class SparZielePage : BaseContentPage
             return;
 
         await SparZieleScrollView.ScrollToAsync(0, 0, false);
+        AddSparZielForm.FocusForm();
     }
 }

--- a/docs/CREATE_UX.md
+++ b/docs/CREATE_UX.md
@@ -1,0 +1,82 @@
+# Einheitliches Anlegen (Create UX)
+
+Issue **#265** — Übersicht der Anlege-Patterns ab v1.19.
+
+## Stufen
+
+| Stufe | Pattern | Komponente | Entitäten |
+|-------|---------|------------|-----------|
+| A | Inline-Panel oben | `CreateFormCard` | Konten, Sparziele |
+| B | Scroll-Sheet (Modal) | `FormSheetPopup` + Form-View | Kategorien, Daueraufträge |
+| C | Detail-Seite | bestehende `*DetailPage` | Bearbeiten aller Entitäten |
+
+## Verhalten
+
+- **FAB / Empty State** auf Listen-Seiten → kein Navigation-Push zum Anlegen
+- Nach **Speichern** schließt Panel/Sheet; Liste aktualisiert sich über Use-Case + Reload
+- **Bearbeiten** per Tap auf Karte → Detail-Seite (inkl. erweiterter Felder, z. B. Ausnahmen bei Daueraufträgen)
+
+## UI-Bausteine
+
+```
+Finanzuebersicht/Controls/
+  CreateFormCard.xaml       — Stufe A (Primary-Rand, Abbrechen/Speichern)
+  CategoryFormView.xaml     — Kategorie-Felder (Sheet + Detail)
+  RecurringTransactionFormView.xaml
+
+Finanzuebersicht/Views/Popups/
+  FormSheetPopup.cs       — Stufe B (~70 % Fensterhöhe, scrollbar)
+
+Finanzuebersicht/Services/
+  CategoryCreateSheetService.cs
+  RecurringTransactionCreateSheetService.cs
+```
+
+## Layout (Stufe A — Konten)
+
+```
+┌─────────────────────────────────────┐
+│  Verwaltung › Konten                │
+├─────────────────────────────────────┤
+│ [ Kategorien ] [ Konten ]           │
+├─────────────────────────────────────┤
+│ ┌─ Neues Konto ─────────────────┐   │  ← CreateFormCard oben
+│ │ Name, Typ, Anfangssaldo        │   │
+│ │ [Abbrechen]  [Hinzufügen]      │   │
+│ └───────────────────────────────┘   │
+│ ┌─ Giro ─────────────── 1.234 € ┐   │
+│ └─ Sparkonto ────────── 5.600 € ┘   │
+│                            [＋] FAB │
+└─────────────────────────────────────┘
+```
+
+## Layout (Stufe B — Kategorien / Daueraufträge)
+
+```
+┌─────────────────────────────────────┐
+│ ░░░ Liste (gedimmt) ░░░░░░░░░░░░░░░ │
+│ ░░░ ┌─ Neuer Eintrag ───────────┐ ░ │
+│ ░░░ │ Formular (scrollbar)      │ ░ │
+│ ░░░ │ [Abbrechen] [Speichern]   │ ░ │
+│ ░░░ └───────────────────────────┘ ░ │
+│                            [＋] FAB │
+└─────────────────────────────────────┘
+```
+
+## A11y & Fokus (Phase 5)
+
+- `A11y_CreateFormPanel` — Screenreader-Beschreibung für Inline-`CreateFormCard`
+- `A11y_FormSheetDialog` — Sheet-Dialog mit Titel (`Dialog: {0}`)
+- `FormFocusHelper` — setzt Fokus auf erstes Textfeld beim Öffnen (Panel + Sheet)
+- Abbrechen/Speichern-Buttons: `SemanticProperties.Hint` = Button-Text
+
+## Screenshots
+
+Manuelle Screenshots für Release-Notizen (Mac Catalyst, kleines Fenster empfohlen):
+
+1. Verwaltung → Konten → Inline-Panel geöffnet
+2. Verwaltung → Kategorien → Sheet geöffnet
+3. Daueraufträge → Sheet geöffnet
+4. Sparziele → Panel oben
+
+Speicherort-Vorschlag: `docs/images/create-ux/` (optional, nicht versioniert)


### PR DESCRIPTION
## Summary

- Einheitliches Anlege-Erlebnis für Verwaltung, Daueraufträge und Sparziele: **kein Navigation-Push** mehr beim Anlegen über FAB/Empty State
- **Stufe A (Inline):** `CreateFormCard` für Konten (oben) und Sparziele (oben, mit Scroll-to-top)
- **Stufe B (Sheet):** `FormSheetPopup` für Kategorien und Daueraufträge; Formulare als `CategoryFormView` / `RecurringTransactionFormView` extrahiert
- **Bearbeiten** weiter auf bestehenden Detail-Seiten; Phase 5: A11y-Strings, `FormFocusHelper`, Doku in `docs/CREATE_UX.md`

Closes #265

## Test plan

- [ ] Verwaltung → Konten: FAB öffnet Inline-Panel oben; Speichern schließt Panel und zeigt neues Konto; Tap auf Karte → `AccountDetailPage`
- [ ] Verwaltung → Kategorien: FAB öffnet Sheet; Validierung bei leerem Namen; Speichern aktualisiert Liste; Tap → `CategoryDetailPage`
- [ ] Daueraufträge: FAB öffnet Sheet; Speichern ohne Navigation; Tap → Detail inkl. Ausnahmen/Shift
- [ ] Sparziele: FAB öffnet Panel oben (auch bei langer Liste); Scroll-to-top; Speichern wie bisher
- [ ] Mac Catalyst, kleines Fenster: Sheets scrollbar, SelectionField nutzbar
- [ ] `dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj` (337 Tests)


Made with [Cursor](https://cursor.com)