### PR TITLE
Release v1.19 — Einheitliches Anlegen

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -10,7 +10,7 @@ Personal finance app built with **.NET 10** and **.NET MAUI**, targeting **macOS
 Data is persisted locally as JSON. Architecture: **Clean Architecture + MVVM**.
 Languages: **German and English** (`AppResources.resx` / `AppResources.de.resx`).
 
-Current version baseline: `version.json` → `1.18` (patch = git height via Nerdbank.GitVersioning).
+Current version baseline: `version.json` → `1.19` (patch = git height via Nerdbank.GitVersioning).
 
 ## Build & Run
 
@@ -163,7 +163,7 @@ Components: `CreateFormCard`, `FormSheetPopup`, `CategoryCreateSheetService`, `R
 
 Automatic **SemVer** via **Nerdbank.GitVersioning** (`version.json`):
 
-- Version = `<major>.<minor>.<git-height>` (e.g. `1.18.5`)
+- Version = `<major>.<minor>.<git-height>` (e.g. `1.19.5`)
 - Bump: edit `version.json` or `nbgv set-version <version>`
 - Current: `nbgv get-version`
 - Stable releases: `main` and `release/v*` branches

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Änderungsverlauf
 
+## [1.19] - 2026-07-17
+
+### Hinzugefügt
+
+- Einheitliches Anlegen (#265): Inline-Panel (`CreateFormCard`) für Konten und Sparziele
+- Sheet-Anlegen (`FormSheetPopup`) für Kategorien und Daueraufträge
+- Doku: `docs/CREATE_UX.md`
+
+### Geändert
+
+- Recurring-Schedule-Logik konsolidiert; Repository-Zugriffe in Use Cases (#275)
+- Microsoft.Maui.Controls 10.0.80, Nerdbank.GitVersioning, Test-SDK
+
+### Behoben
+
+- Systemkonten: Löschen-Aktion ausgeblendet, Zeilen weiter bearbeitbar (#277)
+- Dauerauftrag-`OccursOnDate` berücksichtigt Shift-Ausnahmen korrekt
+- NSubstitute-6-kompatible Test-Matcher (#282)
+
 ## [1.18] - 2026-06-29
 
 ### Hinzugefügt

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Hinweis: Die Benutzeroberfläche unterstützt Deutsch und Englisch; weitere Spra
 
 ## Screenshots
 
-*Dark Mode auf macOS (Mac Catalyst), v1.18*
+*Dark Mode auf macOS (Mac Catalyst), v1.19*
 
 ### Dashboard
 
@@ -208,7 +208,7 @@ Finanzuebersicht.Tests/            ← xUnit Tests (net10.0)
 
 ## Versionierung & CI
 
-- Nerdbank.GitVersioning (`version.json`) steuert Versionsnummern (aktuell Basis `1.18`)
+- Nerdbank.GitVersioning (`version.json`) steuert Versionsnummern (aktuell Basis `1.19`)
 - CI / Pre-Release / Release Workflows in `.github/workflows/`
 
 ### Full MAUI build (macCatalyst)

--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -198,8 +198,8 @@ Neue Migratoren als `IDataMigrator`-Implementierungen in DI registrieren.
 
 ## 11. Versionierung
 
-- **System:** Nerdbank.GitVersioning (`version.json`, aktuell Basis `1.18`)
-- **Format:** `<major>.<minor>.<git-height>` (z.B. `1.18.3`)
+- **System:** Nerdbank.GitVersioning (`version.json`, aktuell Basis `1.19`)
+- **Format:** `<major>.<minor>.<git-height>` (z.B. `1.19.3`)
 - **MAUI-Version:** Automatisch gesetzt via `ApplicationDisplayVersion` und `ApplicationVersion` zur Buildzeit
 
 ```bash

--- a/docs/QUICK_START.md
+++ b/docs/QUICK_START.md
@@ -100,7 +100,7 @@ dotnet test Finanzuebersicht.Tests
 
 ## Versioning
 
-Automatic SemVer via **Nerdbank.GitVersioning** (`version.json`, base `1.18`):
+Automatic SemVer via **Nerdbank.GitVersioning** (`version.json`, base `1.19`):
 
 ```bash
 nbgv get-version

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -4,7 +4,7 @@
 
 > **Hinweis:** Die Milestone-Bezeichnungen (v1.14, v1.2, v2.0) sind thematische GitHub-Planungslabels, keine sequenziellen Release-Versionen. Tatsächliche Releases (v1.0, v1.6, v1.12 …) werden durch Git-Commit-Höhe via Nerdbank.GitVersioning bestimmt.
 
-**Aktueller Stand:** Release **v1.18** (Latest). Nächster thematischer Backlog: **Milestone 22** (vor v2.0).
+**Aktueller Stand:** Release **v1.19** (Latest). Nächster thematischer Backlog: **Milestone 22** (vor v2.0).
 
 ---
 
@@ -131,9 +131,19 @@ Weitere Umsetzungen in v1.17: Live-Währungsrefresh (`CurrencyRefreshRegistry`),
 
 ---
 
+## ✅ v1.19 — Einheitliches Anlegen *(abgeschlossen)*
+
+- Inline-Anlegen für Konten und Sparziele (`CreateFormCard`, Scroll-to-top)
+- Sheet-Anlegen für Kategorien und Daueraufträge (`FormSheetPopup`)
+- Bearbeiten bleibt auf den jeweiligen Detailseiten
+- Architektur: Recurring-Schedule konsolidiert, Repository-Reads in Use Cases (#275)
+- Fixes: Systemkonto-Löschen (#277), Shift-Ausnahmen, Test-Stabilität (#282)
+
+---
+
 ## 💡 Weiterer Backlog — Milestone 22 *(vor v2)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/22)
 
-Größere Features — Priorisierung nach v1.18.
+Größere Features — Priorisierung nach v1.19.
 
 | Issue | Thema | Aufwand |
 |-------|-------|---------|
@@ -161,7 +171,7 @@ Technische Schulden — parallel zu UX-Releases möglich.
 
 ## 🔐 v2.0 — Sicherheit & erweiterte Finanzen *(geplant)* · [Milestone](https://github.com/tom4711/finanzuebersicht/milestone/17)
 
-Größere Architekturänderungen — nach v1.14–v1.18.
+Größere Architekturänderungen — nach v1.14–v1.19.
 
 | Issue | Thema | Aufwand |
 |-------|-------|---------|

--- a/version.json
+++ b/version.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://raw.githubusercontent.com/dotnet/Nerdbank.GitVersioning/main/src/NerdBank.GitVersioning/version.schema.json",
-  "version": "1.18",
+  "version": "1.19",
   "publicReleaseRefSpec": [
     "^refs/heads/main$",
     "^refs/heads/release/v\\d+(?:\\.\\d+)?$"


### PR DESCRIPTION
## Summary
- **Create UX (#265):** Inline-Anlegen für Konten/Sparziele (`CreateFormCard`), Sheet für Kategorien/Daueraufträge (`FormSheetPopup`)
- **Architektur:** Recurring-Schedule konsolidiert, Repository-Reads in Use Cases (#275)
- **Fixes:** Systemkonto-Löschen (#277), Shift-Ausnahmen, NSubstitute-6-Tests (#282)
- **Docs:** Version **1.19** (`version.json`, CHANGELOG, Roadmap)

> Hinweis: Feature-Code ist bereits über vorherige Merges auf `main`; dieser PR formalisiert den Release-Bump auf 1.19 und synchronisiert `develop`.

Closes #265

## Test plan
- [ ] Konten und Sparziele inline anlegen (Panel oben, Scroll-to-top)
- [ ] Kategorien und Daueraufträge per Sheet anlegen; Bearbeiten weiter über Detailseite
- [ ] Systemkonto: kein Löschen-Swipe, Zeile weiterhin editierbar
- [ ] `dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj -c Release`
- [ ] Release-Build Mac Catalyst starten