### PR TITLE
Code-Qualität: Magic Strings zentralisieren

### DIFF
--- a/Finanzuebersicht.Core/Constants/BackupEntityKeys.cs
+++ b/Finanzuebersicht.Core/Constants/BackupEntityKeys.cs
@@ -1,0 +1,15 @@
+namespace Finanzuebersicht.Core.Constants;
+
+/// <summary>
+/// Stable entity keys stored in backup metadata.
+/// </summary>
+public static class BackupEntityKeys
+{
+    public const string Categories = "categories";
+    public const string Accounts = "accounts";
+    public const string Transactions = "transactions";
+    public const string Recurring = "recurring";
+    public const string Budgets = "budgets";
+    public const string Sparziele = "sparziele";
+    public const string TransactionTemplates = "transactionTemplates";
+}

--- a/Finanzuebersicht.Core/Services/SettingsKeys.cs
+++ b/Finanzuebersicht.Core/Services/SettingsKeys.cs
@@ -5,6 +5,23 @@ namespace Finanzuebersicht.Core.Services
     /// </summary>
     public static class SettingsKeys
     {
+        // Darstellung und Lokalisierung
+        /// <summary>
+        /// Ausgewähltes App-Theme (System, Light oder Dark).
+        /// </summary>
+        public const string Theme = "Theme";
+
+        /// <summary>
+        /// Ausgewählter Sprachcode; leer bedeutet Systemsprache.
+        /// </summary>
+        public const string LanguageCode = "LanguageCode";
+
+        /// <summary>
+        /// Legacy-Key für den Anzeige-Währungscode.
+        /// Neue Werte werden unter <see cref="DisplayCurrency"/> gespeichert.
+        /// </summary>
+        public const string Currency = "Currency";
+
         // Daten und Pfade
         /// <summary>
         /// Benutzerdefinierter Pfad für Datenspeicher.

--- a/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
+++ b/Finanzuebersicht.Infrastructure/DependencyInjection/InfrastructureServiceCollectionExtensions.cs
@@ -22,7 +22,7 @@ public static class InfrastructureServiceCollectionExtensions
         string GetDataDir(IServiceProvider sp)
         {
             var settings = sp.GetRequiredService<ISettingsService>();
-            var customPath = settings.Get("DataPath", "");
+            var customPath = settings.Get(SettingsKeys.DataPath, "");
             return string.IsNullOrWhiteSpace(customPath) ? AppPaths.GetDefaultDataDir() : customPath;
         }
 

--- a/Finanzuebersicht.Infrastructure/Services/BackupService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/BackupService.cs
@@ -5,6 +5,7 @@ using System.IO.Compression;
 using System.Linq;
 using System.Text.Json;
 using System.Threading.Tasks;
+using Finanzuebersicht.Core.Constants;
 using Microsoft.Extensions.Logging;
 using Finanzuebersicht.Models;
 
@@ -97,13 +98,13 @@ namespace Finanzuebersicht.Infrastructure.Services
                     FileName = fileName,
                     EntityCounts = new Dictionary<string, int>
                     {
-                        { "categories", categories.Count() },
-                        { "accounts", accounts.Count() },
-                        { "transactions", transactions.Count() },
-                        { "recurring", recurring.Count() },
-                        { "budgets", budgets.Count },
-                        { "sparziele", sparziele.Count },
-                        { "transactionTemplates", transactionTemplates.Count }
+                        { BackupEntityKeys.Categories, categories.Count() },
+                        { BackupEntityKeys.Accounts, accounts.Count() },
+                        { BackupEntityKeys.Transactions, transactions.Count() },
+                        { BackupEntityKeys.Recurring, recurring.Count() },
+                        { BackupEntityKeys.Budgets, budgets.Count },
+                        { BackupEntityKeys.Sparziele, sparziele.Count },
+                        { BackupEntityKeys.TransactionTemplates, transactionTemplates.Count }
                     }
                 };
 
@@ -122,7 +123,13 @@ namespace Finanzuebersicht.Infrastructure.Services
                 }
 
                 _logger?.LogInformation("Backup erstellt: {FileName} mit {CatCount} Kategorien, {TxnCount} Transaktionen, {RecCount} Daueraufträgen, {BudCount} Budgets, {SparCount} Sparzielen, {TemplateCount} Vorlagen",
-                    fileName, metadata.EntityCounts["categories"], metadata.EntityCounts["transactions"], metadata.EntityCounts["recurring"], metadata.EntityCounts["budgets"], metadata.EntityCounts["sparziele"], metadata.EntityCounts["transactionTemplates"]);
+                    fileName,
+                    metadata.EntityCounts[BackupEntityKeys.Categories],
+                    metadata.EntityCounts[BackupEntityKeys.Transactions],
+                    metadata.EntityCounts[BackupEntityKeys.Recurring],
+                    metadata.EntityCounts[BackupEntityKeys.Budgets],
+                    metadata.EntityCounts[BackupEntityKeys.Sparziele],
+                    metadata.EntityCounts[BackupEntityKeys.TransactionTemplates]);
 
                 // Speichere Zeitstempel in Settings
                 _settingsService.SetLastBackupTime(_clock.UtcNow);
@@ -245,10 +252,10 @@ namespace Finanzuebersicht.Infrastructure.Services
                 return new RestoreResult
                 {
                     Success = true,
-                    Details = $"Wiederhergestellt: {counts.GetValueOrDefault("categories")} Kategorien, " +
-                              $"{counts.GetValueOrDefault("transactions")} Transaktionen, " +
-                              $"{counts.GetValueOrDefault("recurring")} Daueraufträge, " +
-                              $"{counts.GetValueOrDefault("transactionTemplates")} Vorlagen",
+                    Details = $"Wiederhergestellt: {counts.GetValueOrDefault(BackupEntityKeys.Categories)} Kategorien, " +
+                              $"{counts.GetValueOrDefault(BackupEntityKeys.Transactions)} Transaktionen, " +
+                              $"{counts.GetValueOrDefault(BackupEntityKeys.Recurring)} Daueraufträge, " +
+                              $"{counts.GetValueOrDefault(BackupEntityKeys.TransactionTemplates)} Vorlagen",
                     RestoredMetadata = archiveData.Metadata
                 };
             }

--- a/Finanzuebersicht.Infrastructure/Services/DisplayCurrencyService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/DisplayCurrencyService.cs
@@ -65,7 +65,7 @@ public sealed class DisplayCurrencyService : IDisplayCurrencyService
     {
         var code = _settings.Get(SettingsKeys.DisplayCurrency, "");
         if (string.IsNullOrEmpty(code))
-            code = _settings.Get("Currency", "EUR");
+            code = _settings.Get(SettingsKeys.Currency, "EUR");
 
         code = code.Trim().ToUpperInvariant();
         return CultureByCode.ContainsKey(code) ? code : "EUR";

--- a/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
+++ b/Finanzuebersicht.Infrastructure/Services/LocalDataService.cs
@@ -56,7 +56,7 @@ public class LocalDataService : IDataService, IAccountRepository, ITransactionTe
     public LocalDataService(ISettingsService? settings, IClock clock)
     {
         var defaultDataDir = AppPaths.GetDefaultDataDir();
-        var customPath = settings?.Get("DataPath", "");
+        var customPath = settings?.Get(SettingsKeys.DataPath, "");
         var dataDir = string.IsNullOrWhiteSpace(customPath) ? defaultDataDir : customPath;
 
         _categoryStore = new CategoryStore(dataDir);

--- a/Finanzuebersicht.Presentation/Navigation/NavigationQueryKeys.cs
+++ b/Finanzuebersicht.Presentation/Navigation/NavigationQueryKeys.cs
@@ -1,0 +1,18 @@
+namespace Finanzuebersicht.Navigation;
+
+/// <summary>
+/// Query parameter keys shared by Shell navigation senders and receivers.
+/// </summary>
+public static class NavigationQueryKeys
+{
+    public const string Transaction = "Transaction";
+    public const string DuplicateTransaction = "DuplicateTransaction";
+    public const string TransactionTemplate = "TransactionTemplate";
+    public const string SparZielContribution = "SparZielContribution";
+    public const string SparZiel = "SparZiel";
+    public const string RecurringTransaction = "RecurringTransaction";
+    public const string RecurringId = "RecurringId";
+    public const string InstanceDate = "InstanceDate";
+    public const string Account = "Account";
+    public const string Category = "Category";
+}

--- a/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/AccountDetailViewModel.cs
@@ -126,7 +126,7 @@ public partial class AccountDetailViewModel(
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
-        if (query.TryGetValue("Account", out var val) && val is Account a)
+        if (query.TryGetValue(NavigationQueryKeys.Account, out var val) && val is Account a)
             Account = a;
     }
 

--- a/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoriesViewModel.cs
@@ -340,7 +340,7 @@ public partial class CategoriesViewModel(
         {
             var kontoParameter = new Dictionary<string, object>
             {
-                ["Account"] = kontoItem.Account
+                [NavigationQueryKeys.Account] = kontoItem.Account
             };
             await _navigationService.GoToAsync(Routes.AccountDetail, kontoParameter);
             return;
@@ -362,7 +362,7 @@ public partial class CategoriesViewModel(
 
         if (item is Category kategorie)
         {
-            var parameter = new Dictionary<string, object> { ["Category"] = kategorie };
+            var parameter = new Dictionary<string, object> { [NavigationQueryKeys.Category] = kategorie };
             await _navigationService.GoToAsync(Routes.CategoryDetail, parameter);
             return;
         }

--- a/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/CategoryDetailViewModel.cs
@@ -118,7 +118,7 @@ public partial class CategoryDetailViewModel(
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
-        if (query.TryGetValue("Category", out var val) && val is Category c)
+        if (query.TryGetValue(NavigationQueryKeys.Category, out var val) && val is Category c)
             Category = c;
     }
 

--- a/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/DashboardViewModel.cs
@@ -903,8 +903,8 @@ public partial class DashboardViewModel : MonthNavigationViewModel, ILocalizable
 
         await _navigationService.GoToAsync(Routes.RecurringInstanceShift, new Dictionary<string, object>
         {
-            ["RecurringId"] = item.Recurring.Id,
-            ["InstanceDate"] = item.InstanceDate
+            [NavigationQueryKeys.RecurringId] = item.Recurring.Id,
+            [NavigationQueryKeys.InstanceDate] = item.InstanceDate
         });
     }
 

--- a/Finanzuebersicht.Presentation/ViewModels/OnboardingViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/OnboardingViewModel.cs
@@ -118,7 +118,7 @@ public partial class OnboardingViewModel(
 
         await _navigationService.GoToAsync(Routes.AccountDetail, new Dictionary<string, object>
         {
-            ["Account"] = account
+            [NavigationQueryKeys.Account] = account
         });
     }
 

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringInstanceShiftViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringInstanceShiftViewModel.cs
@@ -43,9 +43,9 @@ public partial class RecurringInstanceShiftViewModel(
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
-        if (query.TryGetValue("RecurringId", out var id) && id is string recurringId)
+        if (query.TryGetValue(NavigationQueryKeys.RecurringId, out var id) && id is string recurringId)
             RecurringId = recurringId;
-        if (query.TryGetValue("InstanceDate", out var date) && date is DateTime instanceDate)
+        if (query.TryGetValue(NavigationQueryKeys.InstanceDate, out var date) && date is DateTime instanceDate)
             InstanceDate = instanceDate;
     }
 

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionDetailViewModel.cs
@@ -155,7 +155,7 @@ public partial class RecurringTransactionDetailViewModel(
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
-        if (query.TryGetValue("RecurringTransaction", out var val) && val is RecurringTransaction rt)
+        if (query.TryGetValue(NavigationQueryKeys.RecurringTransaction, out var val) && val is RecurringTransaction rt)
             RecurringTransaction = rt;
     }
 
@@ -317,8 +317,8 @@ public partial class RecurringTransactionDetailViewModel(
 
         var parameters = new Dictionary<string, object>
         {
-            ["RecurringId"] = _existing.Id,
-            ["InstanceDate"] = next.Date
+            [NavigationQueryKeys.RecurringId] = _existing.Id,
+            [NavigationQueryKeys.InstanceDate] = next.Date
         };
 
         await _navigationService.GoToAsync(Routes.RecurringInstanceShift, parameters);

--- a/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/RecurringTransactionsViewModel.cs
@@ -117,7 +117,7 @@ public partial class RecurringTransactionsViewModel(
 
         var parameter = new Dictionary<string, object>
         {
-            ["RecurringTransaction"] = dauerauftrag
+            [NavigationQueryKeys.RecurringTransaction] = dauerauftrag
         };
 
         await _navigationService.GoToAsync(Routes.RecurringTransactionDetail, parameter);

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/AppearanceViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/AppearanceViewModel.cs
@@ -30,7 +30,7 @@ public partial class AppearanceViewModel : ObservableObject
         _loc = localizationService;
         _displayCurrency = displayCurrency;
 
-        var theme = _settings.Get("Theme", "System");
+        var theme = _settings.Get(SettingsKeys.Theme, "System");
         selectedThemeIndex = theme switch
         {
             "Light" => 1,
@@ -58,7 +58,7 @@ public partial class AppearanceViewModel : ObservableObject
             _ => "System"
         };
 
-        _settings.Set("Theme", themeKey);
+        _settings.Set(SettingsKeys.Theme, themeKey);
         _themeService.Apply(themeKey);
     }
 

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/BackupViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/BackupViewModel.cs
@@ -1,5 +1,6 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
+using Finanzuebersicht.Core.Constants;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Resources.Strings;
 using Microsoft.Extensions.Logging;
@@ -59,9 +60,9 @@ public partial class BackupViewModel : ObservableObject
                 _loc.GetString(ResourceKeys.Msg_BackupSuccessTitle),
                 string.Format(
                     _loc.GetString(ResourceKeys.Msg_BackupCreatedBody),
-                    metadata.EntityCounts["categories"],
-                    metadata.EntityCounts["transactions"],
-                    metadata.EntityCounts["recurring"]),
+                    metadata.EntityCounts[BackupEntityKeys.Categories],
+                    metadata.EntityCounts[BackupEntityKeys.Transactions],
+                    metadata.EntityCounts[BackupEntityKeys.Recurring]),
                 _loc.GetString(ResourceKeys.Btn_OK));
         }
         catch (Exception ex)
@@ -179,7 +180,7 @@ public partial class BackupViewModel : ObservableObject
 
     private void UpdateLastBackupInfo()
     {
-        var lastBackupStr = _settings.Get("LastBackupTime", string.Empty);
+        var lastBackupStr = _settings.Get(SettingsKeys.LastBackupTime, string.Empty);
         if (string.IsNullOrEmpty(lastBackupStr))
         {
             LastBackupInfo = _loc.GetString(ResourceKeys.Stn_NoBackupYet);

--- a/Finanzuebersicht.Presentation/ViewModels/Settings/StorageViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/Settings/StorageViewModel.cs
@@ -25,7 +25,7 @@ public partial class StorageViewModel : ObservableObject
         _loc = localizationService;
         _folderPicker = folderPicker;
 
-        DataPath = _settings.Get("DataPath", "");
+        DataPath = _settings.Get(SettingsKeys.DataPath, "");
         if (string.IsNullOrWhiteSpace(DataPath))
         {
             DataPath = GetDefaultDataDir();
@@ -63,7 +63,7 @@ public partial class StorageViewModel : ObservableObject
                 return;
             }
 
-            _settings.Set("DataPath", newPath);
+            _settings.Set(SettingsKeys.DataPath, newPath);
             DataPath = newPath;
 
             await _dialogService.ShowAlertAsync(
@@ -83,7 +83,7 @@ public partial class StorageViewModel : ObservableObject
     [RelayCommand]
     private async Task ResetDataPath()
     {
-        _settings.Set("DataPath", string.Empty);
+        _settings.Set(SettingsKeys.DataPath, string.Empty);
         DataPath = GetDefaultDataDir();
 
         await _dialogService.ShowAlertAsync(

--- a/Finanzuebersicht.Presentation/ViewModels/SparZielDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SparZielDetailViewModel.cs
@@ -93,7 +93,7 @@ public partial class SparZielDetailViewModel(
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
-        if (query.TryGetValue("SparZiel", out var val) && val is SparZiel sz)
+        if (query.TryGetValue(NavigationQueryKeys.SparZiel, out var val) && val is SparZiel sz)
             SparZiel = sz;
     }
 
@@ -223,7 +223,7 @@ public partial class SparZielDetailViewModel(
 
         await _navigationService.GoToAsync(Routes.TransactionDetail, new Dictionary<string, object>
         {
-            ["SparZielContribution"] = _sparZiel
+            [NavigationQueryKeys.SparZielContribution] = _sparZiel
         });
     }
 

--- a/Finanzuebersicht.Presentation/ViewModels/SparZieleViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/SparZieleViewModel.cs
@@ -193,7 +193,7 @@ public partial class SparZieleViewModel : ObservableObject, IAutoLoadViewModel, 
     {
         await _navigationService.GoToAsync(Routes.SparZielDetail, new Dictionary<string, object>
         {
-            ["SparZiel"] = summary.SparZiel
+            [NavigationQueryKeys.SparZiel] = summary.SparZiel
         });
     }
 

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionDetailViewModel.cs
@@ -103,19 +103,19 @@ public partial class TransactionDetailViewModel(
 
     public void ApplyQueryAttributes(IDictionary<string, object> query)
     {
-        if (query.TryGetValue("Transaction", out var val) && val is Transaction t)
+        if (query.TryGetValue(NavigationQueryKeys.Transaction, out var val) && val is Transaction t)
         {
             Transaction = t;
         }
-        else if (query.TryGetValue("DuplicateTransaction", out var duplicateVal) && duplicateVal is Transaction duplicate)
+        else if (query.TryGetValue(NavigationQueryKeys.DuplicateTransaction, out var duplicateVal) && duplicateVal is Transaction duplicate)
         {
             ApplyTransactionDraft(duplicate, _clock.Today);
         }
-        else if (query.TryGetValue("TransactionTemplate", out var templateVal) && templateVal is TransactionTemplate template)
+        else if (query.TryGetValue(NavigationQueryKeys.TransactionTemplate, out var templateVal) && templateVal is TransactionTemplate template)
         {
             ApplyTemplateDraft(template);
         }
-        else if (query.TryGetValue("SparZielContribution", out var contributionVal) && contributionVal is SparZiel sparZiel)
+        else if (query.TryGetValue(NavigationQueryKeys.SparZielContribution, out var contributionVal) && contributionVal is SparZiel sparZiel)
         {
             ApplySparZielContribution(sparZiel);
         }

--- a/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
+++ b/Finanzuebersicht.Presentation/ViewModels/TransactionsViewModel.cs
@@ -500,7 +500,7 @@ public partial class TransactionsViewModel(
             var parameter = new Dictionary<string, object>();
             if (transaktion != null)
             {
-                parameter["Transaction"] = transaktion;
+                parameter[NavigationQueryKeys.Transaction] = transaktion;
             }
 
             if (_navigationService == null)
@@ -524,7 +524,7 @@ public partial class TransactionsViewModel(
 
         await _navigationService.GoToAsync(Routes.TransactionDetail, new Dictionary<string, object>
         {
-            ["DuplicateTransaction"] = transaktion
+            [NavigationQueryKeys.DuplicateTransaction] = transaktion
         });
     }
 
@@ -541,7 +541,7 @@ public partial class TransactionsViewModel(
 
         await _navigationService.GoToAsync(Routes.TransactionDetail, new Dictionary<string, object>
         {
-            ["TransactionTemplate"] = template
+            [NavigationQueryKeys.TransactionTemplate] = template
         });
     }
 

--- a/Finanzuebersicht.Tests/Core/Services/DisplayCurrencyServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/DisplayCurrencyServiceTests.cs
@@ -10,7 +10,7 @@ public class DisplayCurrencyServiceTests
     {
         var settings = Substitute.For<ISettingsService>();
         settings.Get(SettingsKeys.DisplayCurrency, "").Returns("");
-        settings.Get("Currency", "EUR").Returns("EUR");
+        settings.Get(SettingsKeys.Currency, "EUR").Returns("EUR");
 
         var service = new DisplayCurrencyService(settings);
 
@@ -24,7 +24,7 @@ public class DisplayCurrencyServiceTests
     {
         var settings = Substitute.For<ISettingsService>();
         settings.Get(SettingsKeys.DisplayCurrency, "").Returns("");
-        settings.Get("Currency", "EUR").Returns("USD");
+        settings.Get(SettingsKeys.Currency, "EUR").Returns("USD");
 
         var service = new DisplayCurrencyService(settings);
 
@@ -37,7 +37,7 @@ public class DisplayCurrencyServiceTests
     {
         var settings = Substitute.For<ISettingsService>();
         settings.Get(SettingsKeys.DisplayCurrency, "").Returns("");
-        settings.Get("Currency", "EUR").Returns("EUR");
+        settings.Get(SettingsKeys.Currency, "EUR").Returns("EUR");
 
         var service = new DisplayCurrencyService(settings);
         var changed = false;
@@ -75,7 +75,7 @@ public class DisplayCurrencyServiceTests
     {
         var settings = Substitute.For<ISettingsService>();
         settings.Get(SettingsKeys.DisplayCurrency, "").Returns("");
-        settings.Get("Currency", "EUR").Returns("EUR");
+        settings.Get(SettingsKeys.Currency, "EUR").Returns("EUR");
 
         var service = new DisplayCurrencyService(settings);
         service.SelectedIndex = index;

--- a/Finanzuebersicht.Tests/Core/Services/SettingsServiceTests.cs
+++ b/Finanzuebersicht.Tests/Core/Services/SettingsServiceTests.cs
@@ -50,8 +50,8 @@ public class SettingsServiceTests : IDisposable
 
         var settings = new SettingsService(path);
 
-        Assert.Equal("Dark", settings.Get("Theme"));
-        Assert.Equal("EUR", settings.Get("Currency"));
+        Assert.Equal("Dark", settings.Get(SettingsKeys.Theme));
+        Assert.Equal("EUR", settings.Get(SettingsKeys.Currency));
     }
 
     [Fact]
@@ -65,7 +65,7 @@ public class SettingsServiceTests : IDisposable
         Assert.Null(exception);
 
         var settings = new SettingsService(path);
-        Assert.Equal("fallback", settings.Get("Theme", "fallback"));
+        Assert.Equal("fallback", settings.Get(SettingsKeys.Theme, "fallback"));
     }
 
     [Fact]

--- a/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceEdgeCaseTests.cs
+++ b/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceEdgeCaseTests.cs
@@ -14,7 +14,7 @@ public class LocalDataServiceEdgeCaseTests : IDisposable
         Directory.CreateDirectory(_tempDir);
 
         var settings = new SettingsService(Path.Combine(_tempDir, "settings.json"));
-        settings.Set("DataPath", _tempDir);
+        settings.Set(SettingsKeys.DataPath, _tempDir);
         _service = new LocalDataService(settings, new Finanzuebersicht.Core.Services.SystemClock());
     }
 

--- a/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceTests.cs
+++ b/Finanzuebersicht.Tests/Infrastructure/Services/LocalDataServiceTests.cs
@@ -14,7 +14,7 @@ public class LocalDataServiceTests : IDisposable
         Directory.CreateDirectory(_testDir);
 
         var settings = new SettingsService(Path.Combine(_testDir, "settings.json"));
-        settings.Set("DataPath", _testDir);
+        settings.Set(SettingsKeys.DataPath, _testDir);
         _service = new LocalDataService(settings, new Finanzuebersicht.Core.Services.SystemClock());
     }
 

--- a/Finanzuebersicht.Tests/Infrastructure/Services/YearAggregationTests.cs
+++ b/Finanzuebersicht.Tests/Infrastructure/Services/YearAggregationTests.cs
@@ -40,7 +40,7 @@ namespace Finanzuebersicht.Tests.Services
 
             // Use SettingsService to point LocalDataService to temp dir
             var settings = new SettingsService(Path.Combine(_tempDir, "settings.json"));
-            settings.Set("DataPath", _tempDir);
+            settings.Set(SettingsKeys.DataPath, _tempDir);
             var ds = new LocalDataService(settings, new Finanzuebersicht.Core.Services.SystemClock());
 
             // Act

--- a/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupRestoreIntegrationTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Finanzuebersicht.Core.Constants;
 using Finanzuebersicht.Models;
 using System.IO.Compression;
 using System.Text.Json;
@@ -97,13 +98,13 @@ namespace Finanzuebersicht.Tests.Services
 
             // Assert 1: Backup created with correct data
             Assert.NotNull(backup);
-            Assert.Equal(2, backup.EntityCounts["categories"]);
-            Assert.Equal(1, backup.EntityCounts["accounts"]);
-            Assert.Equal(2, backup.EntityCounts["transactions"]);
-            Assert.Equal(1, backup.EntityCounts["recurring"]);
-            Assert.Equal(1, backup.EntityCounts["budgets"]);
-            Assert.Equal(1, backup.EntityCounts["sparziele"]);
-            Assert.Equal(1, backup.EntityCounts["transactionTemplates"]);
+            Assert.Equal(2, backup.EntityCounts[BackupEntityKeys.Categories]);
+            Assert.Equal(1, backup.EntityCounts[BackupEntityKeys.Accounts]);
+            Assert.Equal(2, backup.EntityCounts[BackupEntityKeys.Transactions]);
+            Assert.Equal(1, backup.EntityCounts[BackupEntityKeys.Recurring]);
+            Assert.Equal(1, backup.EntityCounts[BackupEntityKeys.Budgets]);
+            Assert.Equal(1, backup.EntityCounts[BackupEntityKeys.Sparziele]);
+            Assert.Equal(1, backup.EntityCounts[BackupEntityKeys.TransactionTemplates]);
             Assert.True(File.Exists(Path.Combine(backupPath, backup.FileName)));
 
             // Act 2: Restore backup — clear state first to verify data is re-saved
@@ -182,9 +183,9 @@ namespace Finanzuebersicht.Tests.Services
 
             // Assert
             Assert.NotNull(backup);
-            Assert.Equal(0, backup.EntityCounts["categories"]);
-            Assert.Equal(0, backup.EntityCounts["transactions"]);
-            Assert.Equal(0, backup.EntityCounts["recurring"]);
+            Assert.Equal(0, backup.EntityCounts[BackupEntityKeys.Categories]);
+            Assert.Equal(0, backup.EntityCounts[BackupEntityKeys.Transactions]);
+            Assert.Equal(0, backup.EntityCounts[BackupEntityKeys.Recurring]);
         }
 
         [Fact]
@@ -257,12 +258,12 @@ namespace Finanzuebersicht.Tests.Services
 
             // Act
             var backup1 = await service.CreateBackupAsync(backupPath);
-            var lastBackupTime1 = _mockSettingsService.Get("LastBackupTime");
+            var lastBackupTime1 = _mockSettingsService.Get(SettingsKeys.LastBackupTime);
 
             await Task.Delay(100);
 
             var backup2 = await service.CreateBackupAsync(backupPath);
-            var lastBackupTime2 = _mockSettingsService.Get("LastBackupTime");
+            var lastBackupTime2 = _mockSettingsService.Get(SettingsKeys.LastBackupTime);
 
             // Assert
             Assert.NotNull(lastBackupTime1);

--- a/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
+++ b/Finanzuebersicht.Tests/Services/BackupServiceTests.cs
@@ -1,4 +1,5 @@
 using Xunit;
+using Finanzuebersicht.Core.Constants;
 using Finanzuebersicht.Models;
 using System.IO.Compression;
 using System.Text.Json;
@@ -116,10 +117,10 @@ namespace Finanzuebersicht.Tests.Services
             var metadata = await service.CreateBackupAsync(_testBackupDir);
 
             // Assert
-            Assert.Equal(2, metadata.EntityCounts["categories"]);
-            Assert.Equal(1, metadata.EntityCounts["accounts"]);
-            Assert.Equal(3, metadata.EntityCounts["transactions"]);
-            Assert.Equal(1, metadata.EntityCounts["recurring"]);
+            Assert.Equal(2, metadata.EntityCounts[BackupEntityKeys.Categories]);
+            Assert.Equal(1, metadata.EntityCounts[BackupEntityKeys.Accounts]);
+            Assert.Equal(3, metadata.EntityCounts[BackupEntityKeys.Transactions]);
+            Assert.Equal(1, metadata.EntityCounts[BackupEntityKeys.Recurring]);
         }
 
         [Fact]
@@ -149,8 +150,8 @@ namespace Finanzuebersicht.Tests.Services
             }
 
             // Assert: EntityCounts enthält budgets und sparziele
-            Assert.Equal(2, metadata.EntityCounts["budgets"]);
-            Assert.Equal(1, metadata.EntityCounts["sparziele"]);
+            Assert.Equal(2, metadata.EntityCounts[BackupEntityKeys.Budgets]);
+            Assert.Equal(1, metadata.EntityCounts[BackupEntityKeys.Sparziele]);
         }
 
         [Fact]
@@ -264,7 +265,12 @@ namespace Finanzuebersicht.Tests.Services
                 Id = "test",
                 CreatedAt = DateTime.UtcNow,
                 SchemaVersion = 999, // Wrong version!
-                EntityCounts = new Dictionary<string, int> { { "categories", 0 }, { "transactions", 0 }, { "recurring", 0 } },
+                EntityCounts = new Dictionary<string, int>
+                {
+                    { BackupEntityKeys.Categories, 0 },
+                    { BackupEntityKeys.Transactions, 0 },
+                    { BackupEntityKeys.Recurring, 0 }
+                },
                 FileName = "backup_wrongversion.zip"
             };
 

--- a/Finanzuebersicht.Tests/ViewModels/AccountDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/AccountDetailViewModelTests.cs
@@ -22,7 +22,7 @@ public class AccountDetailViewModelTests
             OpeningBalanceDate = new DateTime(2026, 1, 1)
         };
 
-        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { ["Account"] = account });
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { [NavigationQueryKeys.Account] = account });
 
         Assert.Equal("Giro", viewModel.Name);
         Assert.Equal(AccountType.Girokonto, viewModel.Type);
@@ -64,7 +64,7 @@ public class AccountDetailViewModelTests
         var viewModel = CreateSut(out _, out var dialogService);
         viewModel.ApplyQueryAttributes(new Dictionary<string, object>
         {
-            ["Account"] = new Account { Id = "acc-1", Name = "Giro", OpeningBalance = 1000m }
+            [NavigationQueryKeys.Account] = new Account { Id = "acc-1", Name = "Giro", OpeningBalance = 1000m }
         });
         viewModel.ActualBalanceText = "abc";
 

--- a/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/CategoriesViewModelTests.cs
@@ -263,8 +263,8 @@ public class CategoriesViewModelTests
             Routes.CategoryDetail,
             Arg.Is<IDictionary<string, object>?>(parameters =>
                 parameters != null &&
-                parameters.ContainsKey("Category") &&
-                object.ReferenceEquals(parameters["Category"], category)));
+                parameters.ContainsKey(NavigationQueryKeys.Category) &&
+                object.ReferenceEquals(parameters[NavigationQueryKeys.Category], category)));
     }
 
     [Fact]

--- a/Finanzuebersicht.Tests/ViewModels/RecurringTransactionsViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/RecurringTransactionsViewModelTests.cs
@@ -118,8 +118,8 @@ public class RecurringTransactionsViewModelTests
         await navigationService.Received(1).GoToAsync(
             Routes.RecurringTransactionDetail,
             NonNullArg.Is<IDictionary<string, object>>(parameters =>
-                parameters.ContainsKey("RecurringTransaction") &&
-                object.ReferenceEquals(parameters["RecurringTransaction"], recurringTransaction)));
+                parameters.ContainsKey(NavigationQueryKeys.RecurringTransaction) &&
+                object.ReferenceEquals(parameters[NavigationQueryKeys.RecurringTransaction], recurringTransaction)));
     }
 
     private static RecurringTransactionsViewModel CreateSut(

--- a/Finanzuebersicht.Tests/ViewModels/Settings/AppearanceViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/Settings/AppearanceViewModelTests.cs
@@ -8,7 +8,7 @@ public class AppearanceViewModelTests
     [Fact]
     public void Constructor_LoadsThemeFromSettings()
     {
-        using var settingsScope = new SettingsScope(nameof(AppearanceViewModelTests), ("Theme", "Dark"));
+        using var settingsScope = new SettingsScope(nameof(AppearanceViewModelTests), (SettingsKeys.Theme, "Dark"));
         var themeService = Substitute.For<IThemeService>();
         var localizationService = CreateLocalizationService();
 
@@ -40,7 +40,7 @@ public class AppearanceViewModelTests
         sut.SetThemeCommand.Execute("1");
 
         Assert.Equal(1, sut.SelectedThemeIndex);
-        Assert.Equal("Light", settingsScope.Settings.Get("Theme"));
+        Assert.Equal("Light", settingsScope.Settings.Get(SettingsKeys.Theme));
         themeService.Received(1).Apply("Light");
     }
 
@@ -54,7 +54,7 @@ public class AppearanceViewModelTests
 
         sut.SelectedThemeIndex = 2;
 
-        Assert.Equal("Dark", settingsScope.Settings.Get("Theme"));
+        Assert.Equal("Dark", settingsScope.Settings.Get(SettingsKeys.Theme));
         themeService.Received(1).Apply("Dark");
     }
 

--- a/Finanzuebersicht.Tests/ViewModels/Settings/BackupViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/Settings/BackupViewModelTests.cs
@@ -1,3 +1,4 @@
+using Finanzuebersicht.Core.Constants;
 using Finanzuebersicht.Navigation;
 using Finanzuebersicht.Resources.Strings;
 using Finanzuebersicht.Tests.TestHelpers;
@@ -37,9 +38,9 @@ public class BackupViewModelTests
             {
                 EntityCounts = new Dictionary<string, int>
                 {
-                    ["categories"] = 2,
-                    ["transactions"] = 3,
-                    ["recurring"] = 4
+                    [BackupEntityKeys.Categories] = 2,
+                    [BackupEntityKeys.Transactions] = 3,
+                    [BackupEntityKeys.Recurring] = 4
                 }
             }));
 

--- a/Finanzuebersicht.Tests/ViewModels/Settings/StorageViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/Settings/StorageViewModelTests.cs
@@ -9,7 +9,7 @@ public class StorageViewModelTests
     [Fact]
     public void Constructor_LoadsDataPathFromSettings()
     {
-        using var settingsScope = new SettingsScope(nameof(StorageViewModelTests), ("DataPath", "/Users/test/custom-data"));
+        using var settingsScope = new SettingsScope(nameof(StorageViewModelTests), (SettingsKeys.DataPath, "/Users/test/custom-data"));
 
         var sut = new StorageViewModel(
             settingsScope.Settings,
@@ -22,7 +22,7 @@ public class StorageViewModelTests
     [Fact]
     public void Constructor_UsesDefaultPath_WhenSettingsEmpty()
     {
-        using var settingsScope = new SettingsScope(nameof(StorageViewModelTests), ("DataPath", string.Empty));
+        using var settingsScope = new SettingsScope(nameof(StorageViewModelTests), (SettingsKeys.DataPath, string.Empty));
 
         var sut = new StorageViewModel(
             settingsScope.Settings,
@@ -36,7 +36,7 @@ public class StorageViewModelTests
     [Fact]
     public async Task ResetDataPath_ClearsSettingsAndRestoresDefault()
     {
-        using var settingsScope = new SettingsScope(nameof(StorageViewModelTests), ("DataPath", "/Users/test/custom-data"));
+        using var settingsScope = new SettingsScope(nameof(StorageViewModelTests), (SettingsKeys.DataPath, "/Users/test/custom-data"));
         var dialogService = CreateDialogService();
         var sut = new StorageViewModel(
             settingsScope.Settings,
@@ -45,7 +45,7 @@ public class StorageViewModelTests
 
         await sut.ResetDataPathCommand.ExecuteAsync(null);
 
-        Assert.Equal(string.Empty, settingsScope.Settings.Get("DataPath"));
+        Assert.Equal(string.Empty, settingsScope.Settings.Get(SettingsKeys.DataPath));
         Assert.Equal(AppPaths.GetDefaultDataDir(), sut.DataPath);
         await dialogService.Received(1).ShowAlertAsync(
             ResourceKeys.Stn_SpeicherortZurueckgesetzt,
@@ -68,7 +68,7 @@ public class StorageViewModelTests
 
         await sut.ChooseDataPathCommand.ExecuteAsync(null);
 
-        Assert.Equal("__missing__", settingsScope.Settings.Get("DataPath", "__missing__"));
+        Assert.Equal("__missing__", settingsScope.Settings.Get(SettingsKeys.DataPath, "__missing__"));
         await dialogService.DidNotReceive().ShowAlertAsync(Arg.Any<string>(), Arg.Any<string>(), Arg.Any<string>());
     }
 
@@ -106,7 +106,7 @@ public class StorageViewModelTests
 
         await sut.ChooseDataPathCommand.ExecuteAsync(null);
 
-        Assert.Equal("__missing__", settingsScope.Settings.Get("DataPath", "__missing__"));
+        Assert.Equal("__missing__", settingsScope.Settings.Get(SettingsKeys.DataPath, "__missing__"));
         await dialogService.Received(1).ShowAlertAsync(
             ResourceKeys.Stn_UngueltigerOrdner,
             ResourceKeys.Stn_UngueltigerOrdnerDesc,

--- a/Finanzuebersicht.Tests/ViewModels/SparZielDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/SparZielDetailViewModelTests.cs
@@ -24,7 +24,7 @@ public class SparZielDetailViewModelTests
             Faelligkeitsdatum = new DateTime(2027, 6, 1)
         };
 
-        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { ["SparZiel"] = sparZiel });
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { [NavigationQueryKeys.SparZiel] = sparZiel });
 
         Assert.Equal("Urlaub", viewModel.Titel);
         Assert.Equal("🏖️", viewModel.Icon);
@@ -44,7 +44,7 @@ public class SparZielDetailViewModelTests
         var viewModel = CreateSut(repository, out var navigationService);
         viewModel.ApplyQueryAttributes(new Dictionary<string, object>
         {
-            ["SparZiel"] = new SparZiel { Id = "goal-1", Titel = "Alt", ZielBetrag = 1000m }
+            [NavigationQueryKeys.SparZiel] = new SparZiel { Id = "goal-1", Titel = "Alt", ZielBetrag = 1000m }
         });
         viewModel.Titel = "Neu";
         viewModel.ZielBetragText = "1500";
@@ -60,7 +60,7 @@ public class SparZielDetailViewModelTests
     {
         var viewModel = CreateSut(out var navigationService);
         var sparZiel = new SparZiel { Id = "goal-1", Titel = "Urlaub", MonatlicheSparrate = 100m };
-        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { ["SparZiel"] = sparZiel });
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { [NavigationQueryKeys.SparZiel] = sparZiel });
 
         await viewModel.BookContributionCommand.ExecuteAsync(null);
 
@@ -70,7 +70,7 @@ public class SparZielDetailViewModelTests
         var call = navigationService.ReceivedCalls()
             .Last(c => c.GetMethodInfo().Name == nameof(INavigationService.GoToAsync));
         var args = (IDictionary<string, object>)call.GetArguments()[1]!;
-        Assert.True(args.TryGetValue("SparZielContribution", out var value));
+        Assert.True(args.TryGetValue(NavigationQueryKeys.SparZielContribution, out var value));
         Assert.IsType<SparZiel>(value);
         Assert.Equal("goal-1", ((SparZiel)value).Id);
     }

--- a/Finanzuebersicht.Tests/ViewModels/TransactionDetailViewModelTests.cs
+++ b/Finanzuebersicht.Tests/ViewModels/TransactionDetailViewModelTests.cs
@@ -28,7 +28,7 @@ public class TransactionDetailViewModelTests
             Verwendungszweck = "Wocheneinkauf"
         };
 
-        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { ["Transaction"] = transaction });
+        viewModel.ApplyQueryAttributes(new Dictionary<string, object> { [NavigationQueryKeys.Transaction] = transaction });
 
         Assert.Equal("Supermarkt", viewModel.Titel);
         Assert.Equal(42.50m.ToString("F2", CultureInfo.CurrentCulture), viewModel.BetragText);

--- a/Finanzuebersicht/App.xaml.cs
+++ b/Finanzuebersicht/App.xaml.cs
@@ -45,7 +45,7 @@ public partial class App : global::Microsoft.Maui.Controls.Application
 		_logger = logger;
 
 		// Gespeichertes Theme anwenden (MAUI-Ebene)
-		_savedTheme = settings.Get("Theme", "System");
+		_savedTheme = settings.Get(SettingsKeys.Theme, "System");
 		_themeService.Apply(_savedTheme);
 	}
 

--- a/Finanzuebersicht/Services/LocalizationService.cs
+++ b/Finanzuebersicht/Services/LocalizationService.cs
@@ -10,8 +10,6 @@ namespace Finanzuebersicht.Services;
 /// </summary>
 public class LocalizationService(ISettingsService settings) : ILocalizationService
 {
-    private const string LanguageKey = "LanguageCode";
-
     private readonly ISettingsService _settings = settings;
     private string _currentLanguageCode = string.Empty;
 
@@ -23,7 +21,7 @@ public class LocalizationService(ISettingsService settings) : ILocalizationServi
     {
         LocalizationResourceManager.Current.Init(AppResources.ResourceManager);
 
-        var saved = _settings.Get(LanguageKey);
+        var saved = _settings.Get(SettingsKeys.LanguageCode);
         var culture = string.IsNullOrEmpty(saved)
             ? CultureInfo.CurrentUICulture
             : new CultureInfo(saved);
@@ -33,7 +31,7 @@ public class LocalizationService(ISettingsService settings) : ILocalizationServi
 
     public void SetLanguage(string? cultureCode)
     {
-        _settings.Set(LanguageKey, cultureCode ?? string.Empty);
+        _settings.Set(SettingsKeys.LanguageCode, cultureCode ?? string.Empty);
 
         var culture = string.IsNullOrEmpty(cultureCode)
             ? CultureInfo.InstalledUICulture


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Beschreibung

Zentralisiert Settings-, Shell-Navigations- und Backup-Metadaten-Keys in `SettingsKeys`, `NavigationQueryKeys` und `BackupEntityKeys`. Alle bestehenden Stringwerte bleiben unverändert, damit gespeicherte Einstellungen und vorhandene Backups kompatibel bleiben.

## Validierung

- `dotnet test Finanzuebersicht.Tests/Finanzuebersicht.Tests.csproj -c Release`: 346/346 Tests bestanden
- Source-Audit: keine Raw-Settings-Strings in Presentation-ViewModels oder Infrastructure
- Source-Audit: Navigation-Query- und Backup-Metadaten-Keys werden nur noch in ihren Konstantenklassen definiert

## Art der Änderung

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [x] ♻️ Refactoring
- [ ] 💄 UI/Style
- [ ] 🔧 Build/Config
- [ ] 📝 Dokumentation
- [ ] 🧪 Tests

## Checkliste

- [x] Tests laufen durch (`dotnet test Finanzuebersicht.Tests`)
- [ ] Build erfolgreich (`dotnet build -f net10.0-maccatalyst`)
- [x] Kein hardcoded Farben (AppThemeBinding verwendet)
- [x] Commit-Nachrichten folgen dem Gitmoji + Conventional Commits Format
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6ced0677-38f6-4e6c-bf49-d2100c0589af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6ced0677-38f6-4e6c-bf49-d2100c0589af"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

